### PR TITLE
Add explicit script and configuration variables for LSOracle in synth script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY --from=openroad/yosys /build ./tools/build/yosys
 COPY --from=openroad/centos7-builder-gcc /OpenROAD/build ./tools/build/OpenROAD
 COPY --from=openroad/centos7-builder-gcc /OpenROAD/etc/DependencyInstaller.sh /etc/DependencyInstaller.sh
 RUN /etc/DependencyInstaller.sh -runtime
-COPY --from=openroad/lsoracle /LSOracle ./tools/build/LSOracle
-COPY --from=openroad/lsoracle /LSOracle/core/test.ini /usr/local/share/lsoracle/
+COPY --from=openroad/lsoracle /LSOracle/build ./tools/build/LSOracle
+COPY --from=openroad/lsoracle /LSOracle/core/test.ini ./tools/build/LSOracle/core/test.ini
 COPY --from=openroad/lsoracle /LSOracle/build/yosys-plugin/oracle.so /OpenROAD-flow/tools/build/yosys/share/yosys/plugins/
 COPY ./setup_env.sh .
 COPY ./flow ./flow

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY --from=openroad/yosys /build ./tools/build/yosys
 COPY --from=openroad/centos7-builder-gcc /OpenROAD/build ./tools/build/OpenROAD
 COPY --from=openroad/centos7-builder-gcc /OpenROAD/etc/DependencyInstaller.sh /etc/DependencyInstaller.sh
 RUN /etc/DependencyInstaller.sh -runtime
-COPY --from=openroad/lsoracle /LSOracle/build ./tools/build/LSOracle
-COPY --from=openroad/lsoracle /LSOracle/core/test.ini ./tools/build/LSOracle/core/test.ini
+COPY --from=openroad/lsoracle /LSOracle/build/core/lsoracle ./tools/build/LSOracle/bin/lsoracle
+COPY --from=openroad/lsoracle /LSOracle/core/test.ini ./tools/build/LSOracle/share/lsoracle/test.ini
 COPY --from=openroad/lsoracle /LSOracle/build/yosys-plugin/oracle.so /OpenROAD-flow/tools/build/yosys/share/yosys/plugins/
 COPY ./setup_env.sh .
 COPY ./flow ./flow

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -164,12 +164,13 @@ elif [ "$build_method" == "LOCAL" ]; then
   mkdir -p tools/build/OpenROAD
   (cd tools/build/OpenROAD && cmake ../../OpenROAD && $NICE make -j$PROC)
 
-  mkdir -p tools/build/LSOracle
-  cmake -B tools/build/LSOracle tools/LSOracle -D CMAKE_BUILD_TYPE=RELEASE -D YOSYS_INCLUDE_DIR=$(pwd)/tools/yosys -D YOSYS_PLUGIN=ON
-  $NICE cmake --build tools/build/LSOracle -j$PROC
-  mkdir -p tools/build/yosys/share/yosys/plugins
-  cp tools/LSOracle/core/test.ini tools/build/LSOracle/core/test.ini
-  cp tools/build/LSOracle/yosys-plugin/oracle.so tools/build/yosys/share/yosys/plugins/
+  cmake -B tools/LSOracle/build tools/LSOracle \
+        -D CMAKE_BUILD_TYPE=RELEASE \
+        -D YOSYS_INCLUDE_DIR=$(pwd)/tools/yosys \
+        -D YOSYS_PLUGIN=ON \
+        -D YOSYS_SHARE_DIR=$(pwd)/tools/build/yosys/share \
+        -D CMAKE_INSTALL_PREFIX=$(pwd)/tools/build/LSOracle
+  $NICE cmake --build tools/LSOracle/build -j$PROC -t install
 else
   echo "ERROR: No valid build method found"
   exit 1

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -168,7 +168,7 @@ elif [ "$build_method" == "LOCAL" ]; then
         -D CMAKE_BUILD_TYPE=RELEASE \
         -D YOSYS_INCLUDE_DIR=$(pwd)/tools/yosys \
         -D YOSYS_PLUGIN=ON \
-        -D YOSYS_SHARE_DIR=$(pwd)/tools/build/yosys/share \
+        -D YOSYS_SHARE_DIR=$(pwd)/tools/build/yosys/share/yosys \
         -D CMAKE_INSTALL_PREFIX=$(pwd)/tools/build/LSOracle
   $NICE cmake --build tools/LSOracle/build -j$PROC --target install
 else

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -168,6 +168,7 @@ elif [ "$build_method" == "LOCAL" ]; then
   cmake -B tools/build/LSOracle tools/LSOracle -D CMAKE_BUILD_TYPE=RELEASE -D YOSYS_INCLUDE_DIR=$(pwd)/tools/yosys -D YOSYS_PLUGIN=ON
   $NICE cmake --build tools/build/LSOracle -j$PROC
   mkdir -p tools/build/yosys/share/yosys/plugins
+  cp tools/LSOracle/core/test.ini tools/build/LSOracle/core/test.ini
   cp tools/build/LSOracle/yosys-plugin/oracle.so tools/build/yosys/share/yosys/plugins/
 else
   echo "ERROR: No valid build method found"

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -170,7 +170,7 @@ elif [ "$build_method" == "LOCAL" ]; then
         -D YOSYS_PLUGIN=ON \
         -D YOSYS_SHARE_DIR=$(pwd)/tools/build/yosys/share \
         -D CMAKE_INSTALL_PREFIX=$(pwd)/tools/build/LSOracle
-  $NICE cmake --build tools/LSOracle/build -j$PROC -t install
+  $NICE cmake --build tools/LSOracle/build -j$PROC --target install
 else
   echo "ERROR: No valid build method found"
   exit 1

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -198,9 +198,15 @@ ifeq (, $(strip $(NPROC)))
 endif
 export NUM_CORES := $(NPROC)
 
-LSORACLE_PLUGIN ?= oracle
+export LSORACLE_CMD ?= $(shell command -v lsoracle)
+ifeq ($(LSORACLE_CMD),)
+  LSORACLE_CMD = $(abspath $(FLOW_HOME)/../tools/build/LSOracle/core/lsoracle)
+endif
+
+LSORACLE_PLUGIN ?= $(abspath $(FLOW_HOME)/../tools/build/LSOracle/yosys-plugin/oracle.so)
+export LSORACLE_KAHYPAR_CONFIG ?= $(abspath $(FLOW_HOME)/../tools/build/LSOracle/core/test.ini)
 ifneq ($(USE_LSORACLE),)
-	YOSYS_FLAGS ?= -m $(LSORACLE_PLUGIN)
+  YOSYS_FLAGS ?= -m $(LSORACLE_PLUGIN)
 endif
 
 #-------------------------------------------------------------------------------

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -200,11 +200,11 @@ export NUM_CORES := $(NPROC)
 
 export LSORACLE_CMD ?= $(shell command -v lsoracle)
 ifeq ($(LSORACLE_CMD),)
-  LSORACLE_CMD = $(abspath $(FLOW_HOME)/../tools/build/LSOracle/core/lsoracle)
+  LSORACLE_CMD = $(abspath $(FLOW_HOME)/../tools/build/LSOracle/bin/lsoracle)
 endif
 
-LSORACLE_PLUGIN ?= $(abspath $(FLOW_HOME)/../tools/build/LSOracle/yosys-plugin/oracle.so)
-export LSORACLE_KAHYPAR_CONFIG ?= $(abspath $(FLOW_HOME)/../tools/build/LSOracle/core/test.ini)
+LSORACLE_PLUGIN ?= $(abspath $(FLOW_HOME)/../tools/build/yosys/share/yosys/plugin/oracle.so)
+export LSORACLE_KAHYPAR_CONFIG ?= $(abspath $(FLOW_HOME)/../tools/build/LSOracle/share/lsoracle/test.ini)
 ifneq ($(USE_LSORACLE),)
   YOSYS_FLAGS ?= -m $(LSORACLE_PLUGIN)
 endif

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -67,8 +67,16 @@ if {[info exist ::env(BLOCKS)]} {
 synth  -top $::env(DESIGN_NAME) {*}$::env(SYNTH_ARGS)
 
 if { [info exists ::env(USE_LSORACLE)] } {
+    set lso_script [open $::env(OBJECTS_DIR)/lso.script w]
+    puts $lso_script "ps -a"
+    puts $lso_script "oracle --config $::env(LSORACLE_KAHYPAR_CONFIG)"
+    puts $lso_script "ps -m"
+    puts $lso_script "crit_path_stats"
+    puts $lso_script "ntk_stats"
+    close $lso_script
+
     # LSOracle synthesis
-    lsoracle
+    lsoracle -script $::env(OBJECTS_DIR)/lso.script -lso_exe $::env(LSORACLE_CMD)
 }
 
 # Optimize the design

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -77,6 +77,7 @@ if { [info exists ::env(USE_LSORACLE)] } {
 
     # LSOracle synthesis
     lsoracle -script $::env(OBJECTS_DIR)/lso.script -lso_exe $::env(LSORACLE_CMD)
+    techmap
 }
 
 # Optimize the design

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -8,4 +8,4 @@ fi
 export OPENROAD=${modroot}/OpenROAD
 echo "OPENROAD: ${OPENROAD}"
 
-export PATH=${modroot}/build/OpenROAD/src:${modroot}/build/yosys/bin:${modroot}/build/LSOracle/core:$PATH
+export PATH=${modroot}/build/OpenROAD/src:${modroot}/build/yosys/bin:${modroot}/build/LSOracle/bin:$PATH


### PR DESCRIPTION
Fixes #66 
Added additional variables to the makefile to specify the lsoracle binary and config file locations, defaulting to relative on the filesystem. Additionally I made the lsoracle recipe explicit in the synth script, like how abc is invoked.