### PR TITLE
Fix /usr/bin/time output formatting

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -209,7 +209,7 @@ endif
 
 #-------------------------------------------------------------------------------
 # setup all commands used within this flow
-TIME_CMD = /usr/bin/time -f "Elapsed time: %E[h:]min:sec, Average CPU: %P, Peak memory: %MKB"
+TIME_CMD = /usr/bin/time -f "Elapsed time: %E[h:]min:sec, average CPU: %P, peak memory: %MKB"
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
 ifeq (, $(strip $(TIME_TEST)))
   TIME_CMD = /usr/bin/time

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -209,7 +209,7 @@ endif
 
 #-------------------------------------------------------------------------------
 # setup all commands used within this flow
-TIME_CMD = /usr/bin/time -f "Elapsed time: %E[h:]min:sec, average CPU: %P, peak memory: %MKB"
+TIME_CMD = /usr/bin/time -f "Elapsed time: %E[h:]min:sec. Average CPU: %P. Peak memory: %MKB."
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
 ifeq (, $(strip $(TIME_TEST)))
   TIME_CMD = /usr/bin/time

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -209,7 +209,7 @@ endif
 
 #-------------------------------------------------------------------------------
 # setup all commands used within this flow
-TIME_CMD = /usr/bin/time -f "%Eelapsed %PCPU %MmemKB"
+TIME_CMD = /usr/bin/time -f "Elapsed time: %E[h:]min:sec, Average CPU: %P, Peak memory: %MKB"
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
 ifeq (, $(strip $(TIME_TEST)))
   TIME_CMD = /usr/bin/time

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -127,15 +127,15 @@ def extractGnuTime(prefix, jsonFile, file): #'^(\S+)elapsed \S+CPU \S+memKB',
     
     extractTagFromFile(prefix + '__runtime__total',
                        jsonFile,
-                       '^Elapsed time: (\S+)\[h:\]min:sec, Average CPU: \S+, Peak memory: \S+KB',
+                       '^Elapsed time: (\S+)\[h:\]min:sec, average CPU: \S+, peak memory: \S+KB',
                        file)
     extractTagFromFile(prefix + '__cpu__total',
                        jsonFile,
-                       '^Elapsed time: \S+\[h:\]min:sec, Average CPU: (\S+), Peak memory: \S+KB',
+                       '^Elapsed time: \S+\[h:\]min:sec, average CPU: (\S+), peak memory: \S+KB',
                        file)
     extractTagFromFile(prefix + '__mem__peak',
                        jsonFile,
-                       '^Elapsed time: \S+\[h:\]min:sec, Average CPU: \S+, Peak memory: (\S+)KB',
+                       '^Elapsed time: \S+\[h:\]min:sec, average CPU: \S+, peak memory: (\S+)KB',
                        file)
 
 

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -123,7 +123,7 @@ def extractTagFromFile(jsonTag, jsonFile, pattern, file, count=False,
         jsonFile[jsonTag] = 'ERR'
 
 
-def extractGnuTime(prefix, jsonFile, file): #'^(\S+)elapsed \S+CPU \S+memKB',
+def extractGnuTime(prefix, jsonFile, file):
     
     extractTagFromFile(prefix + '__runtime__total',
                        jsonFile,

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -123,18 +123,19 @@ def extractTagFromFile(jsonTag, jsonFile, pattern, file, count=False,
         jsonFile[jsonTag] = 'ERR'
 
 
-def extractGnuTime(prefix, jsonFile, file):
+def extractGnuTime(prefix, jsonFile, file): #'^(\S+)elapsed \S+CPU \S+memKB',
+    
     extractTagFromFile(prefix + '__runtime__total',
                        jsonFile,
-                       '^(\S+)elapsed \S+CPU \S+memKB',
+                       '^Elapsed time: (\S+)\[h:\]min:sec, Average CPU: \S+, Peak memory: \S+KB',
                        file)
     extractTagFromFile(prefix + '__cpu__total',
                        jsonFile,
-                       '^\S+elapsed (\S+)CPU \S+memKB',
+                       '^Elapsed time: \S+\[h:\]min:sec, Average CPU: (\S+), Peak memory: \S+KB',
                        file)
     extractTagFromFile(prefix + '__mem__peak',
                        jsonFile,
-                       '^\S+elapsed \S+CPU (\S+)memKB',
+                       '^Elapsed time: \S+\[h:\]min:sec, Average CPU: \S+, Peak memory: (\S+)KB',
                        file)
 
 

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -127,15 +127,15 @@ def extractGnuTime(prefix, jsonFile, file): #'^(\S+)elapsed \S+CPU \S+memKB',
     
     extractTagFromFile(prefix + '__runtime__total',
                        jsonFile,
-                       '^Elapsed time: (\S+)\[h:\]min:sec, average CPU: \S+, peak memory: \S+KB',
+                       '^Elapsed time: (\S+)\[h:\]min:sec. Average CPU: \S+. Peak memory: \S+KB.',
                        file)
     extractTagFromFile(prefix + '__cpu__total',
                        jsonFile,
-                       '^Elapsed time: \S+\[h:\]min:sec, average CPU: (\S+), peak memory: \S+KB',
+                       '^Elapsed time: \S+\[h:\]min:sec. Average CPU: (\S+). Peak memory: \S+KB.',
                        file)
     extractTagFromFile(prefix + '__mem__peak',
                        jsonFile,
-                       '^Elapsed time: \S+\[h:\]min:sec, average CPU: \S+, peak memory: (\S+)KB',
+                       '^Elapsed time: \S+\[h:\]min:sec. Average CPU: \S+. Peak memory: (\S+)KB.',
                        file)
 
 


### PR DESCRIPTION
There is a format mismatch in terms of spaces and the order of words, which this PR fixes.

Example output:

old:
```
...
[INFO] No orphan cells
[INFO] Writing out GDS/OAS 'results/nangate45/gcd/base/6_1_merged.gds'
0:01.21elapsed 94%CPU 320996memKB
cp results/nangate45/gcd/base/6_1_merged.gds results/nangate45/gcd/base/6_final.gds
```

new:
```
...
[INFO] No orphan cells
[INFO] Writing out GDS/OAS 'results/nangate45/gcd/base/6_1_merged.gds'
Elapsed time: 0:02.10[h:]min:sec, Average CPU: 69%, Peak memory: 319948KB
cp results/nangate45/gcd/base/6_1_merged.gds results/nangate45/gcd/base/6_final.gds
```
