### PR TITLE
Further upgrde ABC version after fix to delay calculation

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -145,7 +145,7 @@ if [ "$build_method" == "DOCKER" ]; then
 
 # Local build
 elif [ "$build_method" == "LOCAL" ]; then
-  $NICE make install -C tools/yosys -j${PROC} PREFIX=$(pwd)/tools/install/yosys CONFIG=gcc ABCREV=62180f3 ABCURL=https://github.com/berkeley-abc/abc
+  $NICE make install -C tools/yosys -j${PROC} PREFIX=$(pwd)/tools/install/yosys CONFIG=gcc ABCREV=bafd2a7 ABCURL=https://github.com/berkeley-abc/abc
 
   cmake -B tools/OpenROAD/build tools/OpenROAD -DCMAKE_INSTALL_PREFIX=tools/install/OpenROAD
   $NICE cmake --build tools/OpenROAD/build --target install -j${PROC}

--- a/tools/yosys_util/Dockerfile
+++ b/tools/yosys_util/Dockerfile
@@ -1,4 +1,4 @@
 FROM openroad/yosys-dev AS builder
 COPY . /yosys
 WORKDIR /yosys
-RUN make PREFIX=/install CONFIG=gcc ABCREV=62180f3 ABCURL=https://github.com/berkeley-abc/abc install -j$(nproc)
+RUN make PREFIX=/install CONFIG=gcc ABCREV=bafd2a7 ABCURL=https://github.com/berkeley-abc/abc install -j$(nproc)


### PR DESCRIPTION
Secure CI should be under "secure-abc_version"
Signed-off-by: Sanjiv Mathur <mathur.sanjiv@gmail.com>