### PR TITLE
Obsolete variables removed/Autotuner variable =to?= updated

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -3,22 +3,48 @@ $(info [INFO-FLOW] ASU ASAP7 - version 2)
 export PLATFORM                = asap7
 export PROCESS                 = 7
 
-# Placement site for core cells
-# This can be found in the technology lef
-export PLACE_SITE              = asap7sc7p5t
+#Library Setup variable
+export TECH_LEF                = $(PLATFORM_DIR)/lef/asap7_tech_1x_201209.lef
+export SC_LEF                  = $(PLATFORM_DIR)/lef/asap7sc7p5t_27_R_1x_201211.lef
 
-# Set the TIEHI/TIELO cells
-# These are used in yosys synthesis to avoid logical 1/0's in the netlist
-export TIEHI_CELL_AND_PORT     = TIEHIx1_ASAP7_75t_R H
-export TIELO_CELL_AND_PORT     = TIELOx1_ASAP7_75t_R L
+export GDS_FILES               = $(PLATFORM_DIR)/gds/asap7sc7p5t_27_R_1x_201211.gds \
+                                 $(ADDITIONAL_GDS)
 
-# Used in synthesis
-export MIN_BUF_CELL_AND_PORTS  = BUFx2_ASAP7_75t_R A Y
+export BC_LIB_FILES            = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_FF_nldm_201020.lib \
+				 $(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_FF_nldm_201020.lib \
+				 $(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_FF_nldm_201020.lib \
+				 $(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_FF_nldm_201020.lib \
+				 $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_FF_nldm_201020.lib \
+         			 $(ADDITIONAL_LIBS)
 
-# Used in synthesis
-export MAX_FANOUT              = 40
+export BC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_FF_nldm_201020.lib
 
-export MAKE_TRACKS             = $(PLATFORM_DIR)/openRoad/make_tracks.tcl
+export WC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_SS_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_SS_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_SS_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_SS_nldm_201020.lib \
+       				$(ADDITIONAL_LIBS)
+
+export WC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib \
+
+export TC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_TT_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_TT_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_TT_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib \
+				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_TT_nldm_201020.lib \
+        			$(ADDITIONAL_LIBS)
+
+export TC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib \
+
+export BC_TEMPERATURE          = 25C
+export TC_TEMPERATURE          = 0C
+export WC_TEMPERATURE          = 100C
+
+# Dont use cells to ease congestion
+# Specify at least one filler cell if none
+export DONT_USE_CELLS          = *x1_ASAP7* *x1p*_ASAP7* *xp*_ASAP7*
+export DONT_USE_CELLS          += SDF* ICG* DFFH*
 
 # Yosys mapping files
 # Blackbox - list all standard cells and cells yosys should treat as blackboxes
@@ -28,83 +54,29 @@ export CLKGATE_MAP_FILE        = $(PLATFORM_DIR)/yoSys/cells_clkgate.v
 export ADDER_MAP_FILE         ?= $(PLATFORM_DIR)/yoSys/cells_adders.v
 export BLACKBOX_MAP_TCL        = $(PLATFORM_DIR)/yoSys/blackbox_map.tcl
 
-export BC_LIB_FILES            = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_FF_nldm_201020.lib \
-				 $(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_FF_nldm_201020.lib \
-				 $(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_FF_nldm_201020.lib \
-				 $(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_FF_nldm_201020.lib \
-				 $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_FF_nldm_201020.lib
+# Set yosys-abc clock period to first "-period" found in sdc file
+export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
+export ABC_DRIVER_CELL         = BUFx2_ASAP7_75t_R
 
-export BC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_FF_nldm_201020.lib
+# BUF_X1, pin (A) = 0.974659. Arbitrarily multiply by 4
+export ABC_LOAD_IN_FF          = 3.898
 
-export WC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_SS_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_SS_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_SS_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_SS_nldm_201020.lib
+# Set the TIEHI/TIELO cells
+# These are used in yosys synthesis to avoid logical 1/0's in the netlist
+export TIEHI_CELL_AND_PORT     = TIEHIx1_ASAP7_75t_R H
+export TIELO_CELL_AND_PORT     = TIELOx1_ASAP7_75t_R L
 
-export WC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib \
+# Used in synthesis
+export MIN_BUF_CELL_AND_PORTS  = BUFx2_ASAP7_75t_R A Y
 
-export TC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_TT_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_TT_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_OA_RVT_TT_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib \
-				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_TT_nldm_201020.lib
-
-export TC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib \
-
-export BC_TEMPERATURE          = 25C
-export TC_TEMPERATURE          = 0C
-export WC_TEMPERATURE          = 100C
-
-export TECH_LEF                = $(PLATFORM_DIR)/lef/asap7_tech_1x_201209.lef
-export SC_LEF                  = $(PLATFORM_DIR)/lef/asap7sc7p5t_27_R_1x_201211.lef
-
-export GDS_FILES               = $(PLATFORM_DIR)/gds/asap7sc7p5t_27_R_1x_201211.gds
-
-# Cell padding in SITE widths to ease rout-ability.  Applied to both sides
-export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 2
-export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 1
-
-# Endcap and Welltie cells
-export TAPCELL_TCL             = $(PLATFORM_DIR)/openRoad/tapcell.tcl
-
-# TritonCTS options
-export CTS_BUF_CELL            = BUFx4_ASAP7_75t_R
-
-#export CTS_TECH_DIR           = $(PLATFORM_DIR)/tritonCTS
-export CTS_SQR_CAP             = 2.28541e-4
-export CTS_SQR_RES             = 1.832146e-0
-export CTS_SLEW_INTER          = 7.5e-13
-export CTS_CAP_INTER           = 65.0e-17
-export CTS_MAX_SLEW            = 1.77e-9
-export CTS_MAX_CAP             = 0.968693e-12
-
-export CTS_BUF_DISTANCE        = 60
-
-# Route options
-export MIN_ROUTING_LAYER       = M2
-export MAX_ROUTING_LAYER       = M7
+# Placement site for core cells
+# This can be found in the technology lef
+export PLACE_SITE              = asap7sc7p5t
 
 # IO Pin fix margin
-export IO_PIN_MARGIN           = 70
+export IO_PIN_MARGIN          ?= 70
 
-# Layer to use for parasitics estimations
-export WIRE_RC_LAYER           = M3
-
-# resizer repair_long_wires -max_length
-export MAX_WIRE_LENGTH         = 1000
-
-# KLayout technology file
-export KLAYOUT_TECH_FILE       = $(PLATFORM_DIR)/KLayout/asap7.lyt
-
-# Dont use cells to ease congestion
-# Specify at least one filler cell if none
-export DONT_USE_CELLS          = *x1_ASAP7* *x1p*_ASAP7* *xp*_ASAP7*
-export DONT_USE_CELLS          += SDF* ICG* DFFH*
-
-# Fill cells used in fill cell insertion
-export FILL_CELLS              = "FILLERxp5_ASAP7_75t_R"
-
+export MAKE_TRACKS             = $(PLATFORM_DIR)/openRoad/make_tracks.tcl
 
 # Define default PDN config
 export PDN_CFG ?= $(PLATFORM_DIR)/openRoad/pdn/grid_strategy-M2-M5-M7.cfg
@@ -113,14 +85,38 @@ export PDN_CFG ?= $(PLATFORM_DIR)/openRoad/pdn/grid_strategy-M2-M5-M7.cfg
 export IO_PLACER_H             = M4
 export IO_PLACER_V             = M5
 
-# Set yosys-abc clock period to first "-period" found in sdc file
-export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
-export ABC_DRIVER_CELL         = BUFx2_ASAP7_75t_R
+export MACRO_PLACE_HALO ?= 10 10
+export MACRO_PLACE_CHANNEL ?= 12 12
 
-# BUF_X1, pin (A) = 0.974659. Arbitrarily multiply by 4
-export ABC_LOAD_IN_FF          = 3.898
+# Cell padding in SITE widths to ease rout-ability.  Applied to both sides
+export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 2
+export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 1
+
+export PLACE_DENSITY ?= 0.60
+
+# Layer to use for parasitics estimations
+export WIRE_RC_LAYER           = M3
+
+# Endcap and Welltie cells
+export TAPCELL_TCL             = $(PLATFORM_DIR)/openRoad/tapcell.tcl
+
+# TritonCTS options
+export CTS_BUF_CELL            = BUFx4_ASAP7_75t_R
+
+export CTS_BUF_DISTANCE        = 60
+
+# Fill cells used in fill cell insertion
+export FILL_CELLS              = "FILLERxp5_ASAP7_75t_R"
+
 
 export SET_RC_TCL              = $(PLATFORM_DIR)/setRC.tcl
+
+# Route options
+export MIN_ROUTING_LAYER       = M2
+export MAX_ROUTING_LAYER       = M7
+
+# KLayout technology file
+export KLAYOUT_TECH_FILE       = $(PLATFORM_DIR)/KLayout/asap7.lyt
 
 # OpenRCX extRules
 export RCX_RULES               = $(PLATFORM_DIR)/rcx_patterns.rules

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -73,9 +73,6 @@ export MIN_BUF_CELL_AND_PORTS  = BUFx2_ASAP7_75t_R A Y
 # This can be found in the technology lef
 export PLACE_SITE              = asap7sc7p5t
 
-# IO Pin fix margin
-export IO_PIN_MARGIN          ?= 70
-
 export MAKE_TRACKS             = $(PLATFORM_DIR)/openRoad/make_tracks.tcl
 
 # Define default PDN config

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -29,8 +29,6 @@ export TIELO_CELL_AND_PORT = LOGIC0_X1 Z
 # Used in synthesis
 export MIN_BUF_CELL_AND_PORTS = BUF_X1 A Z
 
-# Used in synthesis
-export MAX_FANOUT = 100
 
 # Yosys mapping files
 export LATCH_MAP_FILE = $(PLATFORM_DIR)/cells_latch.v
@@ -52,7 +50,7 @@ export ABC_LOAD_IN_FF = 3.898
 export PLACE_SITE = FreePDK45_38x28_10R_NP_162NW_34O
 #
 # IO Pin fix margin
-export IO_PIN_MARGIN = 70
+export IO_PIN_MARGIN ?= 70
 #
 # IO Placer pin layers
 export IO_PLACER_H = metal3
@@ -77,8 +75,6 @@ export WIRE_RC_LAYER = metal3
 export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 0
 export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 0
 #
-# resizer repair_long_wires -max_length
-export MAX_WIRE_LENGTH = 1000
 
 export PLACE_DENSITY ?= 0.30
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -48,10 +48,7 @@ export ABC_LOAD_IN_FF = 3.898
 # Placement site for core cells
 # This can be found in the technology lef
 export PLACE_SITE = FreePDK45_38x28_10R_NP_162NW_34O
-#
-# IO Pin fix margin
-export IO_PIN_MARGIN ?= 70
-#
+
 # IO Placer pin layers
 export IO_PLACER_H = metal3
 export IO_PLACER_V = metal2

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -69,8 +69,6 @@ export TIELO_CELL_AND_PORT = sky130_fd_sc_hd__conb_1 LO
 # Used in synthesis
 export MIN_BUF_CELL_AND_PORTS = sky130_fd_sc_hd__buf_4 A X
 
-# Used in synthesis
-export MAX_FANOUT = 5
 
 # Yosys mapping files
 export LATCH_MAP_FILE = $(PLATFORM_DIR)/cells_latch_hd.v
@@ -80,7 +78,8 @@ export ADDER_MAP_FILE ?= $(PLATFORM_DIR)/cells_adders_hd.v
 # Define ABC driver and load
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 5
-#export ABC_CLOCK_PERIOD_IN_PS = 10
+# Set yosys-abc clock period to first "-period" found in sdc file
+export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
 
 #--------------------------------------------------------
 # Floorplan
@@ -91,7 +90,7 @@ export ABC_LOAD_IN_FF = 5
 export PLACE_SITE = unithd
 
 # IO Pin fix margin
-export IO_PIN_MARGIN = 70
+export IO_PIN_MARGIN ?= 70
 #
 # IO Placer pin layers
 export IO_PLACER_H = met3
@@ -116,21 +115,17 @@ export WIRE_RC_LAYER = met3
 export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 4
 export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 2
 #
-# resizer repair_long_wires -max_length
-export MAX_WIRE_LENGTH = 21000
 
 export PLACE_DENSITY ?= 0.60
 
 # Cell padding in SITE widths to ease rout-ability
-export CELL_PAD_IN_SITES = 4
+export CELL_PAD_IN_SITES ?= 4
 # 
 # --------------------------------------------------------
 #  CTS
 #  -------------------------------------------------------
 # TritonCTS options
 export CTS_BUF_CELL   = sky130_fd_sc_hd__buf_1
-export CTS_MAX_SLEW   = 1.5e-9
-export CTS_MAX_CAP    = .1532e-12
 
 # ---------------------------------------------------------
 #  Route

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -78,8 +78,6 @@ export ADDER_MAP_FILE ?= $(PLATFORM_DIR)/cells_adders_hd.v
 # Define ABC driver and load
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 5
-# Set yosys-abc clock period to first "-period" found in sdc file
-#export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
 
 #--------------------------------------------------------
 # Floorplan

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -79,7 +79,7 @@ export ADDER_MAP_FILE ?= $(PLATFORM_DIR)/cells_adders_hd.v
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 5
 # Set yosys-abc clock period to first "-period" found in sdc file
-export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
+#export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
 
 #--------------------------------------------------------
 # Floorplan
@@ -89,9 +89,6 @@ export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_
 # This can be found in the technology lef
 export PLACE_SITE = unithd
 
-# IO Pin fix margin
-export IO_PIN_MARGIN ?= 70
-#
 # IO Placer pin layers
 export IO_PLACER_H = met3
 export IO_PLACER_V = met2

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -30,8 +30,6 @@ export TIELO_CELL_AND_PORT = sky130_fd_sc_hs__conb_1 LO
 # Used in synthesis
 export MIN_BUF_CELL_AND_PORTS = sky130_fd_sc_hs__buf_4 A X
 
-# Used in synthesis
-export MAX_FANOUT ?= 100
 
 # Yosys mapping files
 export LATCH_MAP_FILE = $(PLATFORM_DIR)/cells_latch_hs.v
@@ -41,7 +39,8 @@ export ADDER_MAP_FILE ?= $(PLATFORM_DIR)/cells_adders_hs.v
 # Define ABC driver and load
 export ABC_DRIVER_CELL = sky130_fd_sc_hs__buf_1
 export ABC_LOAD_IN_FF = 5
-export ABC_CLOCK_PERIOD_IN_PS = 10
+# Set yosys-abc clock period to first "-period" found in sdc file
+export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_FILE) | awk '{print $$2}')
 
 #--------------------------------------------------------
 # Floorplan
@@ -52,7 +51,7 @@ export ABC_CLOCK_PERIOD_IN_PS = 10
 export PLACE_SITE = unit
 
 # IO Pin fix margin
-export IO_PIN_MARGIN = 70
+export IO_PIN_MARGIN ?= 70
 #
 # IO Placer pin layers
 export IO_PLACER_H = met3
@@ -78,8 +77,6 @@ export WIRE_RC_LAYER = met3
 export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 4
 export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 2
 #
-# resizer repair_long_wires -max_length
-export MAX_WIRE_LENGTH = 21000
 
 export PLACE_DENSITY ?= 0.50
 #

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -50,9 +50,6 @@ export ABC_CLOCK_PERIOD_IN_PS ?= $(shell grep -E -o -m 1 "\-period\s+\S+" $(SDC_
 # This can be found in the technology lef
 export PLACE_SITE = unit
 
-# IO Pin fix margin
-export IO_PIN_MARGIN ?= 70
-#
 # IO Placer pin layers
 export IO_PLACER_H = met3
 export IO_PLACER_V = met2


### PR DESCRIPTION
Signed-off-by: vijayank88 <paruthi143@gmail.com>

Part of https://github.com/The-OpenROAD-Project/OpenROAD/pull/1479 this PR, @maliberty @vvbandeira  reviewed and wants clean-up for OpenROAD-flow-scripts platform config.mk.
Some of variables values changed to ?= from = (Re-assignable variables.)

modified:   flow/platforms/asap7/config.mk
Changes: Obsolete variables Removed
```
MAX_FANOUT
MAX_WIRE_LENGTH
CTS_MAX_SLEW
CTS_MAX_CAP
CTS_SQR_CAP
 CTS_SQR_RES   
 CTS_SLEW_INTER
 CTS_CAP_INTER 
Variables re-aligned with functional usage order
```
modified:   flow/platforms/nangate45/config.mk
Obsolete variable removed
```
MAX_FANOUT
MAX_WIRE_LENGTH
CTS_MAX_SLEW
CTS_MAX_CAP
```
modified:   flow/platforms/sky130hd/config.mk
Obsolete variable removed
```
MAX_FANOUT
MAX_WIRE_LENGTH
CTS_MAX_SLEW
CTS_MAX_CAP
```
modified:   flow/platforms/sky130hs/config.mk
Obsolete variable removed
```
MAX_FANOUT
MAX_WIRE_LENGTH
```
