### PR TITLE
Add USEMINSPACING OBS OFF to generated LEF files

### DIFF
--- a/flow/scripts/generate_lef.tcl
+++ b/flow/scripts/generate_lef.tcl
@@ -11,8 +11,8 @@ set llx [expr [$BBOX  xMin] / $defUnits]
 set width [expr [$BBOX getDX] / $defUnits]
 set height [expr [$BBOX getDY] / $defUnits]
 
-set data "VERSION 5.7 ;\n  NOWIREEXTENSIONATPIN ON ;\n  DIVIDERCHAR \"/\" ;\n  BUSBITCHARS \"\[\]\" ;\nMACRO $BName \
-\n  CLASS BLOCK ; \n  FOREIGN $BName ; \n  ORIGIN $llx $lly ; \n  SIZE  $width BY $height ; "
+set data "VERSION 5.7 ;\n  NOWIREEXTENSIONATPIN ON ;\n  DIVIDERCHAR \"/\" ;\n  BUSBITCHARS \"\[\]\" ;\n  USEMINSPACING OBS OFF ;\
+\nMACRO $BName \n  CLASS BLOCK ; \n  FOREIGN $BName ; \n  ORIGIN $llx $lly ; \n  SIZE  $width BY $height ; "
 
 foreach PIN [$block getBTerms] {
   set data "$data \n  PIN [$PIN getName] "


### PR DESCRIPTION
USEMINSPACING OBS defaults to ON, which means we always use minimum wire
spacing rules.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>