### PR TITLE
Avoid duplicate files in tar command

### DIFF
--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -111,6 +111,14 @@ endif
 VARS_BASENAME = vars-$(DESIGN_NICKNAME)-$(PLATFORM)-$(FLOW_VARIANT)
 RUN_ME_SCRIPT = run-me-$(DESIGN_NICKNAME)-$(PLATFORM)-$(FLOW_VARIANT).sh
 
+ISSUE_CP_FILES = $(foreach var,$(ISSUE_CP_FILE_VARS),$($(var))) \
+                 $(ISSUE_CP_FILES_PLATFORM) \
+                 $(UTILS_DIR)/def2stream.py \
+                 $(RUN_ME_SCRIPT) \
+                 $(VARS_BASENAME).sh \
+                 $(VARS_BASENAME).tcl \
+                 $(VARS_BASENAME).gdb
+
 $(foreach script,$(ISSUE_SCRIPTS),$(script)_issue): %_issue : versions.txt
 	# Creating $(RUN_ME_SCRIPT) script
 	@echo "#!/usr/bin/env bash"                     >  $(RUN_ME_SCRIPT)
@@ -157,13 +165,7 @@ $(foreach script,$(ISSUE_SCRIPTS),$(script)_issue): %_issue : versions.txt
 	    $(REPORTS_DIR) \
 	    $(RESULTS_DIR) \
 	    $(SCRIPTS_DIR) \
-	    $(UTILS_DIR)/def2stream.py \
-	    $(foreach var,$(ISSUE_CP_FILE_VARS),$($(var))) \
-	    $(ISSUE_CP_FILES_PLATFORM) \
-	    $(RUN_ME_SCRIPT) \
-	    $(VARS_BASENAME).sh \
-	    $(VARS_BASENAME).tcl \
-	    $(VARS_BASENAME).gdb \
+	    $(shell for f in $(ISSUE_CP_FILES); do echo $$f; done | sort | uniq) \
 	    $^
 
 ifdef EXCLUDE_PLATFORM


### PR DESCRIPTION
Fixes #365

Before this PR tar would store some files twice, leading to errors while unpacking depending on OS/tar version.

Before PR (tar source [here](https://jenkins.openroad.tools/job/OpenROAD-flow-scripts-Nightly-Public/lastSuccessfulBuild/artifact/flow/final_report_gcd_nangate45_base_2022-03-07_08-59.tar.gz)):
%  tar --list -f final_report_gcd_nangate45_base_2022-03-07_08-59.tar.gz | grep fastroute.tcl
final_report_gcd_nangate45_base_2022-03-07_08-59/./platforms/nangate45/fastroute.tcl
final_report_gcd_nangate45_base_2022-03-07_08-59/./platforms/nangate45/fastroute.tcl

After PR (tar source [here](https://jenkins.openroad.tools/job/OpenROAD-flow-script-Public/job/public_tests_all-pr/job/PR-391-head/1/artifact/flow/final_report_gcd_nangate45_base_2022-03-14_14-01.tar.gz)):
%  tar --list -f final_report_gcd_nangate45_base_2022-03-14_14-01.tar.gz | grep fastroute.tcl
final_report_gcd_nangate45_base_2022-03-14_14-01/./platforms/nangate45/fastroute.tcl

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>