### PR TITLE
Allow CTS_BUF_CELL to be overridden

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -95,7 +95,7 @@ export PLACE_DENSITY ?= 0.60
 export TAPCELL_TCL             = $(PLATFORM_DIR)/openRoad/tapcell.tcl
 
 # TritonCTS options
-export CTS_BUF_CELL            = BUFx4_ASAP7_75t_R
+export CTS_BUF_CELL            ?= BUFx4_ASAP7_75t_R
 
 export CTS_BUF_DISTANCE        = 60
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -76,7 +76,7 @@ export PLACE_DENSITY ?= 0.30
 #  CTS
 #  -------------------------------------------------------
 # TritonCTS options
-export CTS_BUF_CELL   = BUF_X4
+export CTS_BUF_CELL   ?= BUF_X4
 
 # ---------------------------------------------------------
 #  Route


### PR DESCRIPTION
A different clock buffer might be optimal for different designs, so
allow it to be overridden.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>