### PR TITLE
Remove ASAP7 4x library

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -119,8 +119,6 @@ export KLAYOUT_TECH_FILE       = $(PLATFORM_DIR)/KLayout/asap7.lyt
 # OpenRCX extRules
 export RCX_RULES               = $(PLATFORM_DIR)/rcx_patterns.rules
 
-# XS - defining function for selecting different timing library set
-
 # XS - defining function for using LVT
 ifeq ($(ASAP7_USELVT), 1)
    export TIEHI_CELL_AND_PORT     = TIEHIx1_ASAP7_75t_L H

--- a/flow/platforms/asap7/openRoad/make_tracks.tcl
+++ b/flow/platforms/asap7/openRoad/make_tracks.tcl
@@ -1,8 +1,5 @@
 
 set multiplier 1
-if { [info exists ::env(4X)] } {
-  set multiplier 4
-}
 
 make_tracks Pad -x_offset [expr 0.116 * $multiplier] -x_pitch [expr 0.08  * $multiplier] -y_offset [expr 0.116 * $multiplier] -y_pitch [expr 0.08 * $multiplier]
 make_tracks M9  -x_offset [expr 0.116 * $multiplier] -x_pitch [expr 0.08  * $multiplier] -y_offset [expr 0.116 * $multiplier] -y_pitch [expr 0.08 * $multiplier]

--- a/flow/platforms/asap7/openRoad/tapcell.tcl
+++ b/flow/platforms/asap7/openRoad/tapcell.tcl
@@ -1,7 +1,5 @@
 set multiplier 1
-if { [info exists ::env(4X)] } {
-  set multiplier 4
-}
+
 puts "\[INFO-FLOW\] Tap and End Cap cell insertion"
 puts "\[INFO-FLOW\]   TAP Cell          : $::env(TAP_CELL_NAME)"
 puts "\[INFO-FLOW\]   ENDCAP Cell       : $::env(TAP_CELL_NAME)"


### PR DESCRIPTION
The 4x sized ASAP7 library is unused and appears to have been created to
work around issues with proprietary tools. Remove it.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>