### PR TITLE
ci: remove extra check

### DIFF
--- a/.github/workflows/github-actions-on-push.yml
+++ b/.github/workflows/github-actions-on-push.yml
@@ -1,8 +1,7 @@
 name: Scan Code with pre commit trigger
 on:
-  # Triggers the workflow on push or pull request events
+  # Triggers the workflow on push
   push:
-  pull_request:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -14,6 +13,3 @@ jobs:
         uses: actions/checkout@v2
       - name: run security_scan_on_push
         uses: The-OpenROAD-Project/actions/security_scan_on_push@main
-
-
-        


### PR DESCRIPTION
Checking on push already guarantees that all code checked-in is scanned. Doing for PRs as well, just add an additional scan without need.

Signed-off-by: Vitor Bandeira <vitor.vbandeira@gmail.com>