### PR TITLE
asap7: fix `DFF_LIB_FILE` path for typical and worst corner

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -26,7 +26,7 @@ export WC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_SS_nldm_2
 				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_SS_nldm_201020.lib \
 				$(ADDITIONAL_LIBS)
 
-export WC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib \
+export WC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_SS_nldm_201020.lib
 
 export TC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_TT_nldm_201020.lib \
 				$(PLATFORM_DIR)/lib/asap7sc7p5t_INVBUF_RVT_TT_nldm_201020.lib \
@@ -35,7 +35,7 @@ export TC_LIB_FILES           = $(PLATFORM_DIR)/lib/asap7sc7p5t_AO_RVT_TT_nldm_2
 				$(PLATFORM_DIR)/lib/asap7sc7p5t_SIMPLE_RVT_TT_nldm_201020.lib \
 				$(ADDITIONAL_LIBS)
 
-export TC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib \
+export TC_DFF_LIB_FILE        = $(PLATFORM_DIR)/lib/asap7sc7p5t_SEQ_RVT_TT_nldm_201020.lib
 
 export BC_TEMPERATURE          = 25C
 export TC_TEMPERATURE          = 0C


### PR DESCRIPTION
The PR removes just an innocent \ that breaks the path resolution for the typical and worst corners for the ASAP7 technology.

It works for the best corner (BC):

https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/ec3b96c1eeb355dad74183e233f880ff8696aa65/flow/platforms/asap7/config.mk#L20

Thanks for having such an awesome open source flow :-)