### PR TITLE
asap7: Add MIN_CLOCK_ROUTING_LAYER

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -111,7 +111,11 @@ export SET_RC_TCL              = $(PLATFORM_DIR)/setRC.tcl
 
 # Route options
 export MIN_ROUTING_LAYER       = M2
+export MIN_CLOCK_ROUTING_LAYER = M4
 export MAX_ROUTING_LAYER       = M7
+
+# Define fastRoute tcl
+export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 
 # KLayout technology file
 export KLAYOUT_TECH_FILE       = $(PLATFORM_DIR)/KLayout/asap7.lyt

--- a/flow/platforms/asap7/fastroute.tcl
+++ b/flow/platforms/asap7/fastroute.tcl
@@ -1,0 +1,3 @@
+set_global_routing_layer_adjustment $env(MIN_ROUTING_LAYER)-$env(MAX_ROUTING_LAYER) 0.5
+set_routing_layers -signal $env(MIN_ROUTING_LAYER)-$env(MAX_ROUTING_LAYER) -clock $env(MIN_CLOCK_ROUTING_LAYER)-$env(MAX_ROUTING_LAYER)
+set_macro_extension 2


### PR DESCRIPTION
Use higher metal layers for clock routing.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>