### PR TITLE
Update SiliconCompiler Makefile.py wrapper to account for changes as of v0.9.4

### DIFF
--- a/flow/Makefile.py
+++ b/flow/Makefile.py
@@ -59,6 +59,7 @@ def main():
     # Create a Chip object.
     chip = siliconcompiler.Chip(design)
     chip.set('option', 'scpath', scdir)
+    chip.set('option', 'jobname', f'{design}_{platform}')
 
     # Load PDK, flow, and libs.
     if platform == 'nangate45':
@@ -81,14 +82,14 @@ def main():
         seal_gds = chip.get('tool', tool, 'env', step, '0', 'SEAL_GDS')
     else:
         seal_gds = ''
-    gdsoas_in = ' '.join([chip.get('tool', tool, 'env', step, '0', 'GDS_FILES')])
+    gdsoas_in = ' '.join([os.path.abspath(gdsf) for gdsf in chip.get('tool', tool, 'env', step, '0', 'GDS_FILES').split()])
     out_file = os.path.join('outputs', f'{chip.get("design")}.{chip.get("tool", tool, "env", step, "0", "STREAM_SYSTEM_EXT")}')
     techf = '../../klayout.lyt' # TODO: objects_dir is currently top-level build root dir.
     layermap = chip.get('tool', tool, 'env', step, '0', 'GDS_LAYER_MAP')
     klayout_options = ['-zz',
                        '-rd', f'design_name={chip.get("design")}',
                        '-rd', 'in_def=inputs/6_final.def',
-                       '-rd', f'in_files={gdsoas_in}',
+                       '-rd', f'in_files="{gdsoas_in}"',
                        '-rd', f'config_file={fill_cfg}',
                        '-rd', f'seal_file={seal_gds}',
                        '-rd', f'out_file={out_file}',

--- a/flow/scripts/sc/tools/openroad/sc_apr.tcl
+++ b/flow/scripts/sc/tools/openroad/sc_apr.tcl
@@ -96,11 +96,7 @@ if {$sc_step == "or_synth_hier_report"} {
 } elseif {$sc_step == "or_synth"} {
     # Synthesis: Copy/rename RTL/SDC files
     file copy -force outputs/1_1_yosys.v outputs/1_synth.v
-    foreach f $inputs {
-        if {[string last ".sdc" $f] == [expr [string length $f] - 4]} {
-            file copy -force "inputs/$f" outputs/1_synth.sdc
-        }
-    }
+    file copy -force [lindex [dict get $sc_cfg input sdc] 0] outputs/1_synth.sdc
 } elseif {$sc_step == "or_tdms_place" && [info exists ::env(MACRO_PLACEMENT)]} {
     # TDMS Placement: copy .odb input if this step was skipped.
     file copy -force inputs/2_2_floorplan_io.odb outputs/2_3_floorplan_tdms.odb
@@ -123,7 +119,7 @@ if {$sc_step == "or_synth_hier_report"} {
     file copy -force outputs/4_2_cts_fillcell.odb outputs/4_cts.odb
 } elseif {$sc_step == "or_detail_route"} {
     # Last routing step: copy .odb and .sdc files.
-    file copy -force outputs/5_route.odb outputs/6_1_fill.odb
+    file copy -force outputs/5_2_route.odb outputs/6_1_fill.odb
     foreach f $inputs {
         if {[string last ".sdc" $f] == [expr [string length $f] - 4]} {
             file copy -force "inputs/$f" outputs/5_route.sdc

--- a/flow/scripts/sc/util/parse_target_config.py
+++ b/flow/scripts/sc/util/parse_target_config.py
@@ -25,7 +25,7 @@ def parse(chip, platform):
         repls['DESIGN_NICKNAME'] = config['DESIGN_NAME']
     # Set PLATFORM_DIR if not already set.
     if not 'PLATFORM_DIR' in config:
-        repls['PLATFORM_DIR'] = os.path.abspath(os.path.join(mydir, 'platforms', config['PLATFORM']))
+        repls['PLATFORM_DIR'] = os.path.join(platforms_root, config['PLATFORM'])
     if not 'CORNER' in config:
         if config['PLATFORM'] == 'asap7':
             repls['CORNER'] = 'BC'


### PR DESCRIPTION
We've started using the OpenROAD-flow-scripts examples internally as benchmarks - thank you for providing these sets of test designs.

In setting up our testing infrastructure, I discovered a few small changes that need to be made to the SiliconCompiler `Makefile.py` wrapper for compatibility with some recent changes to how the build system locates and reads source files. I also set the 'jobname' parameter to include the design and platform names, so that common examples such as gcd and ibex can be built for multiple platforms in parallel.

Thanks!