### PR TITLE
Improve support for MacOS

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -9,7 +9,17 @@ cd "$(dirname $(readlink -f $0))"
 
 # Defaults variable values
 NICE=""
-PROC=$(nproc --all)
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  PROC=$(nproc --all)
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  PROC=$(sysctl -n hw.ncpu)
+else
+  cat << EOF
+[WARNING FLW-0025] Unsupported OSTYPE: cannot determine number of host CPUs"
+  Defaulting to 2 threads. Use --threads N to use N threads"
+EOF
+  PROC=2
+fi
 DOCKER_TAG="openroad/flow-scripts"
 OPENROAD_APP_REMOTE="origin"
 OPENROAD_APP_BRANCH="master"
@@ -277,6 +287,9 @@ __docker_build()
 
 __local_build()
 {
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+          export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk)/bin:$PATH"
+        fi
         echo "[INFO FLW-0017] Compiling Yosys."
         ${NICE} make install -C tools/yosys -j "${PROC}" ${YOSYS_ARGS}
 

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -260,6 +260,10 @@ KLAYOUT_CMD             ?= $(shell command -v klayout)
 
 KLAYOUT_FOUND            = $(if $(KLAYOUT_CMD),,$(error KLayout not found in PATH))
 
+ifneq ($(shell command -v stdbuf),)
+  STDBUF_CMD = stdbuf -o L
+endif
+
 #-------------------------------------------------------------------------------
 WRAPPED_LEFS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/lef/$(lef:.lef=_mod.lef))
 WRAPPED_LIBS = $(foreach lib,$(notdir $(WRAP_LIBS)),$(OBJECTS_DIR)/$(lib:.lib=_mod.lib))
@@ -656,7 +660,7 @@ $(WRAPPED_GDSOAS): $(OBJECTS_DIR)/klayout_wrap.lyt $(WRAPPED_LEFS)
 GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 $(GDS_MERGED_FILE): $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klayout.lyt $(GDSOAS_FILES) $(WRAPPED_GDSOAS) $(SEAL_GDSOAS)
 	$(call KLAYOUT_FOUND)
-	($(TIME_CMD) stdbuf -o L $(KLAYOUT_CMD) -zz -rd design_name=$(DESIGN_NAME) \
+	($(TIME_CMD) $(STDBUF_CMD) $(KLAYOUT_CMD) -zz -rd design_name=$(DESIGN_NAME) \
 	        -rd in_def=$< \
 	        -rd in_files="$(GDSOAS_FILES) $(WRAPPED_GDSOAS)" \
 	        -rd config_file=$(FILL_CONFIG) \

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -9,3 +9,8 @@ export OPENROAD=${modroot}/OpenROAD
 echo "OPENROAD: ${OPENROAD}"
 
 export PATH=${modroot}/install/OpenROAD/bin:${modroot}/install/yosys/bin:${modroot}/install/LSOracle/bin:$PATH
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  export PATH="/Applications/KLayout/klayout.app/Contents/MacOS:$PATH"
+  export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk)/bin:$PATH"
+fi


### PR DESCRIPTION
- build_openroad.sh
  - Use OS-specific mechanism to get # CPUs
  - Export Mac-specific paths
- setup_env.sh
  - Export Mac-specific paths
- Makefile
  - Use stdbuf only if it exists

Signed-off-by: Austin Rovinski <rovinski@umich.edu>