### PR TITLE
gpl: split GLOBAL_PLACEMENT_ARGS

### DIFF
--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -40,7 +40,7 @@ global_placement -density $place_density \
     -pad_left $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \
     -pad_right $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \
     {*}$global_placement_args \
-    $::env(GLOBAL_PLACEMENT_ARGS)
+    {*}$::env(GLOBAL_PLACEMENT_ARGS)
 } else {
 global_placement -density $place_density \
     -pad_left $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \

--- a/flow/scripts/global_place_skip_io.tcl
+++ b/flow/scripts/global_place_skip_io.tcl
@@ -21,7 +21,7 @@ if {[info exists ::env(FLOORPLAN_DEF)] || ([info exists ::env(HAS_IO_CONSTRAINTS
   global_placement -skip_io -density $place_density \
       -pad_left $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \
       -pad_right $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \
-      $::env(GLOBAL_PLACEMENT_ARGS)
+      {*}$::env(GLOBAL_PLACEMENT_ARGS)
   } else {
   global_placement -skip_io -density $place_density \
       -pad_left $::env(CELL_PAD_IN_SITES_GLOBAL_PLACEMENT) \


### PR DESCRIPTION
This allows us to pass multiple arguments to global_placement via the GLOBAL_PLACEMENT_ARGS environment variable.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>