### PR TITLE
Add Makefile shell test and fallback to bash

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -99,8 +99,8 @@ endif
 
 #-------------------------------------------------------------------------------
 # Proper way to initiate SHELL for make
-SHELL          ?= /usr/bin/env bash
-.SHELLFLAGS    = -o pipefail -c
+SHELL          := /usr/bin/env bash
+.SHELLFLAGS    := -o pipefail -c
 
 #-------------------------------------------------------------------------------
 # Setup variables to point to root / head of the OpenROAD directory

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -102,6 +102,24 @@ endif
 SHELL          ?= /bin/bash
 .SHELLFLAGS    = -o pipefail -c
 
+# Test that the shell works. Otherwise, warn user and fall back to bash. Note
+# that Make does not inherit $SHELL from the parent environment (See 5.3.2 of
+# GNU Make documentation).
+$(shell echo "" &> /dev/null)
+ifneq ($(.SHELLSTATUS),0)
+  define shell_warn_msg
+[WARNING][FLOW] Shell '$(SHELL)' returned an error on a simple test. Attempting\
+to fall back to '/bin/bash'.
+To fix this warning, try:
+  1) Ubuntu/WSL users: run 'sudo dpkg-reconfigure dash' and select 'No'
+  2) Run 'chsh' and change your shell path to '/bin/bash' or another shell
+  3) Invoke make with 'make SHELL=/bin/bash'
+
+endef
+  $(warning $(shell_warn_msg))
+  SHELL := /bin/bash
+endif
+
 #-------------------------------------------------------------------------------
 # Setup variables to point to root / head of the OpenROAD directory
 # - the following settings allowed user to point OpenROAD binaries to different

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -99,26 +99,8 @@ endif
 
 #-------------------------------------------------------------------------------
 # Proper way to initiate SHELL for make
-SHELL          ?= /bin/bash
+SHELL          ?= /usr/bin/env bash
 .SHELLFLAGS    = -o pipefail -c
-
-# Test that the shell works. Otherwise, warn user and fall back to bash. Note
-# that Make does not inherit $SHELL from the parent environment (See 5.3.2 of
-# GNU Make documentation).
-$(shell echo "" &> /dev/null)
-ifneq ($(.SHELLSTATUS),0)
-  define shell_warn_msg
-[WARNING][FLOW] Shell '$(SHELL)' returned an error on a simple test. Attempting\
-to fall back to '/bin/bash'.
-To fix this warning, try:
-  1) Ubuntu/WSL users: run 'sudo dpkg-reconfigure dash' and select 'No'
-  2) Run 'chsh' and change your shell path to '/bin/bash' or another shell
-  3) Invoke make with 'make SHELL=/bin/bash'
-
-endef
-  $(warning $(shell_warn_msg))
-  SHELL := /bin/bash
-endif
 
 #-------------------------------------------------------------------------------
 # Setup variables to point to root / head of the OpenROAD directory


### PR DESCRIPTION
This should help fix the longstanding issue as mentioned in https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/discussions/330.

The root of the issue is:

1. Ubuntu uses `dash` as its system default shell rather than `bash` which does not support `-o pipefail -c`
2. GNU Make [does not inherit `SHELL` from the environment](https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html). It chooses the non-interactive system default shell (`dash`), which is different from the interactive system default shell (`bash`).
3. The system default non-interactive shell counts as setting the `SHELL` variable so it will not be set here: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/55469ea7dc713be75fa5caf2007d82aa3dc7c300/flow/Makefile#L102

This results in Make silently choosing `dash` and failing. This PR fixes that by first testing the inherited shell (using `echo`) and then testing the shell return status. On failure, the Makefile forces the shell to bash and tries again, leaving a warning.

The proper solution for Ubuntu and WSL users is to use `sudo dpkg-reconfigure dash` and select `No`, but this works around the issue for a smoother user experience.

This PR does have the limitation that `.SHELLSTATUS` was only added in Make 4.2 (circa 2016). If a user uses Make < 4.2, `.SHELLSTATUS` will be empty and the fallback condition will be falsely triggered. 1) The only harm is the user is forced to use bash instead of their default shell; 2) All our supported OSs use Make >= 4.2; 3) It seems an unlikely scenario this is a real problem.