### PR TITLE
blocks: changed environment variables leaked through to sub-make invocation

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -295,7 +295,15 @@ export WRAPPED_GDSOAS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/$(le
 define GENERATE_ABSTRACT_RULE
 # Single rule, two targets, hence the "&:", syntax
 $(1) $(2) &: $(3)
-	$(MAKE) "DESIGN_CONFIG=$(3)" generate_abstract
+	# Make sure environment variables modified in this Makefile do not leak into the sub-build
+	bash -c " \
+	unset BLOCKS && \
+	unset ADDITIONAL_LEFS && \
+	unset ADDITIONAL_GDS && \
+	unset ADDITIONAL_LIBS && \
+	unset DONT_USE_SC_LIB && \
+	unset LIB_FILES && \
+	$(MAKE) \"DESIGN_CONFIG=$(3)\" generate_abstract"
 endef
 
 # Targets to harden Blocks in case of hierarchical flow is triggered


### PR DESCRIPTION
@maliberty This fixes a problem where the top-level build fails when BLOCKS is used, but where the macros build fine when invoked separately.

This can fail before this fix:

```
make DESIGN=designs/sky130hd/foo/config.mk
```

Whereas, this works before the fix:

```
make DESIGN=designs/sky130hd/foo/bar/config.mk generate_abstract
make DESIGN=designs/sky130hd/foo/config.mk
```

This fix is tested as part of #709, however #709 won't be ready to be merged for some time and it is useful to have this in master before then to assist other testing.