### PR TITLE
make: finish target prints time spent summary

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -627,6 +627,9 @@ finish: $(LOG_DIR)/6_report.log \
         $(RESULTS_DIR)/6_final.v \
         $(RESULTS_DIR)/6_final.sdc \
         $(GDS_FINAL_FILE)
+	@printf "%-25s %10s\n" Log "Elapsed seconds"
+	@grep Elapsed $(abspath $(LOG_DIR))/*.log | awk -F'[:. ]' '{sub(".*+/","",$$1); sub(".log:","",$$1); sub("\\:","",$$1); printf "%-25s %10s\n", $$1, $$6 * 60 +$$7}'
+
 # ==============================================================================
 
 ifneq ($(USE_FILL),)


### PR DESCRIPTION
The goal with this commit is to increase awareness of what flow performance improvements would make a dent.

Surprisingly to me the reporting stage was the slowest part of a design I'm working on, whereas I thought it was the detailed routing stage.

From build server:

![image](https://user-images.githubusercontent.com/2798822/209349137-179a8de6-3b6d-4269-aa31-0eaecdcfb864.png)


Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>