### PR TITLE
sky130hd: ABC_CLOCK_PERIOD_IN_PS is automatically extracted in platforms/sky130hd/config.mk

### DIFF
--- a/flow/designs/sky130hd/chameleon_hier/DFFRAM_4K/config.mk
+++ b/flow/designs/sky130hd/chameleon_hier/DFFRAM_4K/config.mk
@@ -15,7 +15,6 @@ export SDC_FILE          = ${TOP_DIR}/${DESIGN_NAME}/constraint.sdc
 
 export PDN_CFG = ${TOP_DIR}/${DESIGN_NAME}/pdn.cfg
 
-export ABC_CLOCK_PERIOD_IN_PS = 10000
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 3
 

--- a/flow/designs/sky130hd/chameleon_hier/DMC_32x16HC/config.mk
+++ b/flow/designs/sky130hd/chameleon_hier/DMC_32x16HC/config.mk
@@ -15,7 +15,6 @@ export SDC_FILE = ${TOP_DIR}/${DESIGN_NAME}/constraint.sdc
 
 export PDN_CFG = ${TOP_DIR}/${DESIGN_NAME}/pdn.cfg
 
-export ABC_CLOCK_PERIOD_IN_PS = 10000
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 3
 

--- a/flow/designs/sky130hd/chameleon_hier/apb_sys_0/config.mk
+++ b/flow/designs/sky130hd/chameleon_hier/apb_sys_0/config.mk
@@ -15,7 +15,6 @@ export SDC_FILE = ${TOP_DIR}/${DESIGN_NAME}/constraint.sdc
 
 export PDN_CFG = ${TOP_DIR}/${DESIGN_NAME}/pdn.cfg
 
-export ABC_CLOCK_PERIOD_IN_PS = 10000
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 3
 

--- a/flow/designs/sky130hd/chameleon_hier/ibex_wrapper/config.mk
+++ b/flow/designs/sky130hd/chameleon_hier/ibex_wrapper/config.mk
@@ -37,7 +37,6 @@ export SDC_FILE          = ${TOP_DIR}/${DESIGN_NAME}/constraint.sdc
 
 export PDN_CFG = ${TOP_DIR}/${DESIGN_NAME}/pdn.cfg
 
-export ABC_CLOCK_PERIOD_IN_PS = 10000
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 3
 

--- a/flow/designs/sky130hd/coyote_tc/config.mk
+++ b/flow/designs/sky130hd/coyote_tc/config.mk
@@ -60,7 +60,6 @@ export ADDITIONAL_LEFS = $(IO_DIR)/lef/sky130_ef_io__gpiov2_pad_wrapped.lef \
 export DIE_AREA    = 0.0 0.0 5200 4609.14
 export CORE_AREA   = 210 210 4990 4389.14
 
-export ABC_CLOCK_PERIOD_IN_PS = 10000
 export ABC_DRIVER_CELL = sky130_fd_sc_hd__buf_1
 export ABC_LOAD_IN_FF = 3
 

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -13,8 +13,6 @@ export CORE_AREA  = 10 10 2910 3510
 
 export PLACE_DENSITY ?= 0.20
 
-export ABC_CLOCK_PERIOD_IN_PS = 25000
-
 export microwatt_DIR = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)
 
 export ADDITIONAL_GDS  = $(wildcard $(microwatt_DIR)/gds/*.gds.gz)


### PR DESCRIPTION

Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>