### PR TITLE
sky130hd: Update PDN

### DIFF
--- a/flow/platforms/sky130hd/pdn.tcl
+++ b/flow/platforms/sky130hd/pdn.tcl
@@ -20,8 +20,31 @@ set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
 ####################################
 define_pdn_grid -name {grid} -voltage_domains {CORE}
 add_pdn_stripe -grid {grid} -layer {met1} -width {0.48} -pitch {5.44} -offset {0} -followpins
-add_pdn_stripe -grid {grid} -layer {met4} -width {1.600} -pitch {27.140} -offset {13.570}
-add_pdn_stripe -grid {grid} -layer {met5} -width {1.600} -pitch {27.200} -offset {13.600}
+
+set db [::ord::get_db]
+set dbu_per_uu [[$db getTech] getDbUnitsPerMicron]
+set block [[$db getChip] getBlock]
+set core_bbox [$block getCoreArea]
+set core_width [$core_bbox dx]
+set core_height [$core_bbox dy]
+
+set core_width [expr $core_width / $dbu_per_uu ]
+set core_height [expr $core_height / $dbu_per_uu ]
+
+# Use multiples of the met4 pitch (0.92um)
+if [ expr $core_height < 100 ] {
+    add_pdn_stripe -grid {grid} -layer {met4} -width {1.600} -pitch {27.600} -offset {13.800} -snap_to_grid
+} else {
+    add_pdn_stripe -grid {grid} -layer {met4} -width {3.200} -pitch {74.520} -offset {37.260} -snap_to_grid
+}
+
+# Use multiples of the met5 pitch (3.4um)
+if [ expr $core_width < 100 ] {
+    add_pdn_stripe -grid {grid} -layer {met5} -width {1.600} -pitch {27.200} -offset {13.600} -snap_to_grid
+} else {
+    add_pdn_stripe -grid {grid} -layer {met5} -width {3.200} -pitch {74.800} -offset {37.400} -snap_to_grid
+}
+
 add_pdn_connect -grid {grid} -layers {met1 met4}
 add_pdn_connect -grid {grid} -layers {met4 met5}
 ####################################


### PR DESCRIPTION
The current sky130hd PDN is very dense, which heavily impacts the available routing resources on met4 and met5. Create a less dense PDN for larger designs, and use -snap_to_grid so the PDN ends up on track offsets.

Signed-off-by: Anton Blanchard <anton@linux.ibm.com>