### PR TITLE
github: add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "features": {
+  }
+}


### PR DESCRIPTION
@maliberty The idea is that the community can collaborate on this configuration such that all that is required to test and develop OpenROAD-flow-scripts is to fire up a github codespaces from any brows.

This is change is just meant to be an initial seed.

Further down the road, improvements to this config will make it faster and easier to set up OpenROAD-flow-scripts.

Rough idea for use-case:

1. Click on "code" in github and create github codespace
2. Run: build_openroad.sh --local (this will fail, but bring in scripts we need in the next step)
4. Run: sudo tools/OpenROAD/etc/DependencyInstaller.sh, then restart build_openroad.sh --local
5. . setup_env.sh
6. To create a launch configuraiton in tools/OpenROAD/.vscode/launch.settings, run: make DESIGN_CONFIG=designs/asap7/aes/config.mk vscode_debug_pdn
7. Run: code tools/OpenROAD
8. hit f7 to build
9. Set breakpoint, press f5, wait for the debugger to hit the breakpoint for the failing stage in step 5 above.

I didn't try, but it should be possible to run OpenROAD GUI, just, too with this setup: https://babyprogrammer.com/blog/running-gui-code-applications-in-github-codespaces-on-windows/


![image](https://user-images.githubusercontent.com/2798822/213512996-16b23899-0545-4766-bbc7-a3108710e716.png)

![image](https://user-images.githubusercontent.com/2798822/213513096-48b67c33-47af-48a3-ab9d-91a48fadc946.png)

![image](https://user-images.githubusercontent.com/2798822/213513657-be1d39b4-df69-4d41-b33b-2f3ba565b08a.png)




Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>