### PR TITLE
global route: add GLOBAL_ROUTE_ARGS env variable

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -14,9 +14,8 @@ if {[info exist env(FASTROUTE_TCL)]} {
 }
 
 global_route -guide_file $env(RESULTS_DIR)/route.guide \
-               -congestion_iterations 100 \
                -congestion_report_file $env(REPORTS_DIR)/congestion.rpt \
-               -verbose
+               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 100 -verbose}}]
 
 set_propagated_clock [all_clocks]
 estimate_parasitics -global_routing


### PR DESCRIPTION
it defaults to the existing arguments.

Adjusting GLOBAL_ROUTE_ARGS can be useful to terminate the global route, so as to get a congestion report early to figure out why global route is taking a long time.

example use:

```
make GLOBAL_ROUTE_ARGS="-congestion_iterations 1 -verbose"
```

Gives a congestion.rpt file quickly that can be used to understand where the problem spots are in the design.
