### PR TITLE
nangate45 bp_be_top drc fix

### DIFF
--- a/flow/designs/nangate45/bp_be_top/config.mk
+++ b/flow/designs/nangate45/bp_be_top/config.mk
@@ -24,7 +24,7 @@ export CORE_AREA   = 10.07 11.2 890 790
 
 export PLACE_PINS_ARGS = -exclude left:500-800 -exclude right:500-800 -exclude top:*
 
-export MACRO_PLACE_HALO = 10 10
+export MACRO_PLACE_HALO = 15 15
 export MACRO_PLACE_CHANNEL = 20 20
 
 export PLACE_DENSITY_LB_ADDON = 0.10


### PR DESCRIPTION
Signed-off-by: vijayank88 <paruthi143@gmail.com>
With latest OpenROAD head `nangate45/bp_be_top` design facing DRC error end of detail routing.
```
[ERROR] detailedroute__route__drc_errors fail test: 3.0 <= 0.0
```
fixes #721 `nangate45/bp_be` metadata check failure.