### PR TITLE
Fixing LayerMap wildcard issue with sky130hd.lydrc

### DIFF
--- a/flow/platforms/sky130hd/drc/sky130hd.lydrc
+++ b/flow/platforms/sky130hd/drc/sky130hd.lydrc
@@ -67,22 +67,22 @@ verbose(true)
 ########################
 
 # all except purpose (datatype) 5 -- label and 44 -- via
-li_wildcard = "67/0-4,6-43,45-*"
+li_wildcard = "67/0-4,6-43"
 mcon_wildcard = "67/44"
 
-m1_wildcard = "68/0-4,6-43,45-*"
+m1_wildcard = "68/0-4,6-43"
 via_wildcard = "68/44"
 
-m2_wildcard = "69/0-4,6-43,45-*"
+m2_wildcard = "69/0-4,6-43"
 via2_wildcard = "69/44"
 
-m3_wildcard = "70/0-4,6-43,45-*"
+m3_wildcard = "70/0-4,6-43"
 via3_wildcard = "70/44"
 
-m4_wildcard = "71/0-4,6-43,45-*"
+m4_wildcard = "71/0-4,6-43"
 via4_wildcard = "71/44"
 
-m5_wildcard = "72/0-4,6-43,45-*"
+m5_wildcard = "72/0-4,6-43"
 
 diff = input(65, 20)
 tap = polygons(65, 44)


### PR DESCRIPTION
The current sky130hd.lydrc file uses wildcards for describing a few layers for example :

```
li_wildcard = "67/0-4,6-43,45-*"
```

Which results in the error due to the `*` at the end of the variable:  ( attached log file `6_drc(old).log`)

```
ERROR: In ./platforms/sky130hd/drc/sky130hd.lydrc: Expected end of text here: * in LayerMap::map
Writing report database: /home/yatharth/open_road/OpenROAD-flow-scripts/flow/reports/sky130hd/ibex/base/6_drc.lyrdb ..
```

The variables are modified to 
```
li_wildcard = "67/0-4,6-43"

```
Without affecting the check or missing out on any conditions, the used layers do not map to any datatype above 44, and datatype 44 has to be avoided.
This is verified by the official sky130hd GDS layers csv. (attached file gds_layers.csv)

This results in a successful drc run for the `sky130hd `platform ( attached log file 6_drc.log)
[6_drc(old).log](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/files/10899017/6_drc.old.log)

[6_drc.log](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/files/10899022/6_drc.log)
[gds_layers.csv](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/files/10899024/gds_layers.csv)
