### PR TITLE
designs/asap7/mock-array-big: use -group and -order io pin constraints

### DIFF
--- a/flow/designs/asap7/mock-array-big/Element/io.tcl
+++ b/flow/designs/asap7/mock-array-big/Element/io.tcl
@@ -41,8 +41,7 @@ proc zip {list1 list2} {
 
 foreach {direction direction2 names} $assignments {
     set mirrored [zip {*}$names]
-    set_io_pin_constraint -region $direction:* -pin_names [lindex $names 0]
-    set_io_pin_constraint -region $direction2:* -pin_names [lindex $names 1]
+    set_io_pin_constraint -region $direction:* -pin_names [lindex $names 0] -group -order
     set_io_pin_constraint -mirrored_pins $mirrored
 }
 


### PR DESCRIPTION
also, drop constraints for mirrored pins

-group and -order doesn't seem to work.

The left edge of the Element:

```
[INFO PPL-0048] Restrict pins [io_ins_3[0] io_ins_3[1] io_ins_3[2] io_ins_3[3] io_ins_3[4] io_ins_3[5] io_ins_3[6] io_ins_3[7] io_outs_3[0] io_outs_3[1] io_outs_3[2] io_outs_3[3] io_outs_3[4] io_outs_3[5] io_outs_3[6] io_outs_3[7]] to region 0.0u-13.824u at the left edge.
[INFO PPL-0080] Mirroring pins io_ins_3[0] and io_outs_1[0].
[INFO PPL-0080] Mirroring pins io_ins_3[1] and io_outs_1[1].
[INFO PPL-0080] Mirroring pins io_ins_3[2] and io_outs_1[2].
[INFO PPL-0080] Mirroring pins io_ins_3[3] and io_outs_1[3].
[INFO PPL-0080] Mirroring pins io_ins_3[4] and io_outs_1[4].
```

![image](https://user-images.githubusercontent.com/2798822/226121548-471ac602-b9b7-4e7d-b5af-016d79952bf0.png)
