### PR TITLE
Open road installation par update

### DIFF
--- a/docs/tutorials/FlowTutorial.md
+++ b/docs/tutorials/FlowTutorial.md
@@ -55,6 +55,7 @@ following commands:
 
 ```
 cd OpenROAD-flow-scripts
+git clean -xdi
 git checkout master
 git pull
 git submodule update


### PR DESCRIPTION
git repo clean added to flow tutorial docs and removed -m64 flag in tools/OpenROAD/scr/par/CMakeList.txt for open road tool installation on ubuntu 22.04 arm64.