### PR TITLE
Add a fake lvt platform and design using nangate45 as a base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ flow/*.opennet
 flow/platforms/*
 !flow/platforms/asap7
 !flow/platforms/nangate45
+!flow/platforms/nangate45_fakelvt
 !flow/platforms/sky130hd
 !flow/platforms/sky130hs
 !flow/platforms/sky130io

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -17,6 +17,8 @@
 # DESIGN_CONFIG=./designs/nangate45/tiny-tests/config.mk
 # DESIGN_CONFIG=./designs/nangate45/tinyRocket/config.mk
 
+# DESIGN_CONFIG=./designs/nangate45_fakelvt/jpeg/config.mk
+
 # DESIGN_CONFIG=./designs/tsmc65lp/aes/config.mk
 # DESIGN_CONFIG=./designs/tsmc65lp/ariane/config.mk
 # DESIGN_CONFIG=./designs/tsmc65lp/black_parrot/config.mk

--- a/flow/designs/nangate45_fakelvt/jpeg/config.mk
+++ b/flow/designs/nangate45_fakelvt/jpeg/config.mk
@@ -1,0 +1,11 @@
+export DESIGN_NICKNAME = jpeg
+export DESIGN_NAME = jpeg_encoder
+export PLATFORM    = nangate45_fakelvt
+
+export VERILOG_FILES = $(sort $(wildcard ./designs/src/$(DESIGN_NICKNAME)/*.v))
+export VERILOG_INCLUDE_DIRS = ./designs/src/$(DESIGN_NICKNAME)/include
+export SDC_FILE = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
+export ABC_AREA = 1
+
+export CORE_UTILIZATION ?= 45
+export PLACE_DENSITY_LB_ADDON = 0.20

--- a/flow/designs/nangate45_fakelvt/jpeg/constraint.sdc
+++ b/flow/designs/nangate45_fakelvt/jpeg/constraint.sdc
@@ -1,0 +1,15 @@
+current_design jpeg_encoder
+
+set clk_name  clk 
+set clk_port_name clk
+set clk_period 1.0 
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs 
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]

--- a/flow/designs/nangate45_fakelvt/jpeg/metadata-base-ok.json
+++ b/flow/designs/nangate45_fakelvt/jpeg/metadata-base-ok.json
@@ -1,0 +1,1 @@
+../../nangate45/jpeg/metadata-base-ok.json

--- a/flow/designs/nangate45_fakelvt/jpeg/rules-base.json
+++ b/flow/designs/nangate45_fakelvt/jpeg/rules-base.json
@@ -1,0 +1,1 @@
+../../nangate45/jpeg/rules-base.json

--- a/flow/platforms/nangate45_fakelvt/FreePDK45.lyp
+++ b/flow/platforms/nangate45_fakelvt/FreePDK45.lyp
@@ -1,0 +1,1 @@
+../nangate45/FreePDK45.lyp

--- a/flow/platforms/nangate45_fakelvt/FreePDK45.lyt
+++ b/flow/platforms/nangate45_fakelvt/FreePDK45.lyt
@@ -1,0 +1,1 @@
+../nangate45/FreePDK45.lyt

--- a/flow/platforms/nangate45_fakelvt/LICENSE
+++ b/flow/platforms/nangate45_fakelvt/LICENSE
@@ -1,0 +1,1 @@
+../nangate45/LICENSE

--- a/flow/platforms/nangate45_fakelvt/README.md
+++ b/flow/platforms/nangate45_fakelvt/README.md
@@ -1,0 +1,1 @@
+../nangate45/README.md

--- a/flow/platforms/nangate45_fakelvt/cdl
+++ b/flow/platforms/nangate45_fakelvt/cdl
@@ -1,0 +1,1 @@
+../nangate45/cdl

--- a/flow/platforms/nangate45_fakelvt/cells_adders.v
+++ b/flow/platforms/nangate45_fakelvt/cells_adders.v
@@ -1,0 +1,1 @@
+../nangate45/cells_adders.v

--- a/flow/platforms/nangate45_fakelvt/cells_clkgate.v
+++ b/flow/platforms/nangate45_fakelvt/cells_clkgate.v
@@ -1,0 +1,1 @@
+../nangate45/cells_clkgate.v

--- a/flow/platforms/nangate45_fakelvt/cells_latch.v
+++ b/flow/platforms/nangate45_fakelvt/cells_latch.v
@@ -1,0 +1,1 @@
+../nangate45/cells_latch.v

--- a/flow/platforms/nangate45_fakelvt/config.mk
+++ b/flow/platforms/nangate45_fakelvt/config.mk
@@ -1,0 +1,121 @@
+# Process node
+export PROCESS = 45
+
+#-----------------------------------------------------
+# Tech/Libs
+# ----------------------------------------------------
+export TECH_LEF = $(PLATFORM_DIR)/lef/NangateOpenCellLibrary.tech.lef
+export SC_LEF = $(PLATFORM_DIR)/lef/NangateOpenCellLibrary.macro.mod.lef
+
+export LIB_FILES = $(PLATFORM_DIR)/lib/NangateOpenCellLibrary_typical.lib \
+		   $(PLATFORM_DIR)/lib/NangateOpenCellLibraryLVT_typical.lib
+                     $(ADDITIONAL_LIBS)
+export GDS_FILES = $(sort $(wildcard $(PLATFORM_DIR)/gds/*.gds)) \
+                     $(ADDITIONAL_GDS)
+# Dont use cells to ease congestion
+# Specify at least one filler cell if none
+export DONT_USE_CELLS = TAPCELL_X1 FILLCELL_X1 AOI211_X1 OAI211_X1
+
+# Fill cells used in fill cell insertion
+export FILL_CELLS = FILLCELL_X1 FILLCELL_X2 FILLCELL_X4 FILLCELL_X8 FILLCELL_X16 FILLCELL_X32
+
+# -----------------------------------------------------
+#  Yosys
+#  ----------------------------------------------------
+# Ungroup size for hierarchical synthesis
+export MAX_UNGROUP_SIZE ?= 10000
+# Set the TIEHI/TIELO cells
+# These are used in yosys synthesis to avoid logical 1/0's in the netlist
+export TIEHI_CELL_AND_PORT = LOGIC1_X1 Z
+export TIELO_CELL_AND_PORT = LOGIC0_X1 Z
+
+# Used in synthesis
+export MIN_BUF_CELL_AND_PORTS = BUF_X1 A Z
+
+
+# Yosys mapping files
+export LATCH_MAP_FILE = $(PLATFORM_DIR)/cells_latch.v
+export CLKGATE_MAP_FILE = $(PLATFORM_DIR)/cells_clkgate.v
+export ADDER_MAP_FILE ?= $(PLATFORM_DIR)/cells_adders.v
+#
+# Set yosys-abc clock period to first "-period" found in sdc file
+export ABC_CLOCK_PERIOD_IN_PS ?= $(shell sed -nr "s/^set clk_period (.+)|.* -period (.+) .*/\1\2/p" $(SDC_FILE) | head -1 | awk '{print $$1*1000}')
+export ABC_DRIVER_CELL = BUF_X1
+# BUF_X1, pin (A) = 0.974659. Arbitrarily multiply by 4
+export ABC_LOAD_IN_FF = 3.898
+
+#--------------------------------------------------------
+# Floorplan
+# -------------------------------------------------------
+
+# Placement site for core cells
+# This can be found in the technology lef
+export PLACE_SITE = FreePDK45_38x28_10R_NP_162NW_34O
+
+# IO Placer pin layers
+export IO_PLACER_H = metal5
+export IO_PLACER_V = metal6
+
+# Define default PDN config
+export PDN_TCL ?= $(PLATFORM_DIR)/grid_strategy-M1-M4-M7.tcl
+
+# Endcap and Welltie cells
+export TAPCELL_TCL = $(PLATFORM_DIR)/tapcell.tcl
+
+export MACRO_PLACE_HALO ?= 22.4 15.12
+export MACRO_PLACE_CHANNEL ?= 18.8 19.95
+
+#---------------------------------------------------------
+# Place
+# --------------------------------------------------------
+# Cell padding in SITE widths to ease rout-ability.  Applied to both sides
+export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 0
+export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 0
+#
+
+export PLACE_DENSITY ?= 0.30
+
+# --------------------------------------------------------
+#  CTS
+#  -------------------------------------------------------
+# TritonCTS options
+export CTS_BUF_CELL   ?= BUF_X4
+
+# ---------------------------------------------------------
+#  Route
+# ---------------------------------------------------------
+# FastRoute options
+export MIN_ROUTING_LAYER = metal2
+export MAX_ROUTING_LAYER = metal10
+
+# Define fastRoute tcl
+export FASTROUTE_TCL = $(PLATFORM_DIR)/fastroute.tcl
+
+# KLayout technology file
+export KLAYOUT_TECH_FILE = $(PLATFORM_DIR)/FreePDK45.lyt
+
+# KLayout DRC ruledeck
+export KLAYOUT_DRC_FILE = $(PLATFORM_DIR)/drc/FreePDK45.lydrc
+
+# KLayout LVS ruledeck
+export KLAYOUT_LVS_FILE = $(PLATFORM_DIR)/lvs/FreePDK45.lylvs
+
+# Allow empty GDS cell
+export GDS_ALLOW_EMPTY = fakeram.*
+
+export CDL_FILE = $(PLATFORM_DIR)/cdl/NangateOpenCellLibrary.cdl
+
+# Template definition for power grid analysis
+export TEMPLATE_PGA_CFG ?= $(PLATFORM_DIR)/template_pga.cfg
+
+# OpenRCX extRules
+export RCX_RULES               = $(PLATFORM_DIR)/rcx_patterns.rules
+# ---------------------------------------------------------
+#  IR Drop
+# ---------------------------------------------------------
+
+# IR drop estimation supply net name to be analyzed and supply voltage variable
+# For multiple nets: PWR_NETS_VOLTAGES  = "VDD1 1.8 VDD2 1.2"
+export PWR_NETS_VOLTAGES  ?= "VDD 1.1"
+export GND_NETS_VOLTAGES  ?= "VSS 0.0"
+export IR_DROP_LAYER ?= metal1

--- a/flow/platforms/nangate45_fakelvt/drc
+++ b/flow/platforms/nangate45_fakelvt/drc
@@ -1,0 +1,1 @@
+../nangate45/drc/

--- a/flow/platforms/nangate45_fakelvt/fakeram.cfg
+++ b/flow/platforms/nangate45_fakelvt/fakeram.cfg
@@ -1,0 +1,1 @@
+../nangate45/fakeram.cfg

--- a/flow/platforms/nangate45_fakelvt/fakeram.tcl
+++ b/flow/platforms/nangate45_fakelvt/fakeram.tcl
@@ -1,0 +1,1 @@
+../nangate45/fakeram.tcl

--- a/flow/platforms/nangate45_fakelvt/fastroute.tcl
+++ b/flow/platforms/nangate45_fakelvt/fastroute.tcl
@@ -1,0 +1,1 @@
+../nangate45/fastroute.tcl

--- a/flow/platforms/nangate45_fakelvt/gds
+++ b/flow/platforms/nangate45_fakelvt/gds
@@ -1,0 +1,1 @@
+../nangate45/gds

--- a/flow/platforms/nangate45_fakelvt/grid_strategy-M1-M4-M7.tcl
+++ b/flow/platforms/nangate45_fakelvt/grid_strategy-M1-M4-M7.tcl
@@ -1,0 +1,1 @@
+../nangate45/grid_strategy-M1-M4-M7.tcl

--- a/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.macro.mod.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.macro.mod.lef
@@ -1,0 +1,21146 @@
+VERSION 5.6 ;
+BUSBITCHARS "[]" ;
+DIVIDERCHAR "/" ;
+
+MACRO AND2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.19 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.54 0.91 ;
+      RECT 0.47 0.39 0.54 0.91 ;
+      RECT 0.045 0.39 0.54 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END AND2_X1
+
+MACRO AND2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.545 0.91 ;
+      RECT 0.475 0.39 0.545 0.91 ;
+      RECT 0.045 0.39 0.545 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+  END
+END AND2_X2
+
+MACRO AND2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.42 0.38 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.725 0.76 0.795 ;
+        RECT 0.69 0.525 0.76 0.795 ;
+        RECT 0.06 0.42 0.185 0.795 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.15 1.435 1.25 ;
+        RECT 0.995 0.68 1.435 0.75 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 0.995 1.625 1.485 ;
+        RECT 1.175 0.995 1.245 1.485 ;
+        RECT 0.795 0.995 0.865 1.485 ;
+        RECT 0.415 0.995 0.485 1.485 ;
+        RECT 0.04 0.995 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.355 ;
+        RECT 1.175 -0.085 1.245 0.355 ;
+        RECT 0.795 -0.085 0.865 0.215 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.86 0.675 1.25 ;
+      RECT 0.235 0.86 0.305 1.25 ;
+      RECT 0.235 0.86 0.92 0.93 ;
+      RECT 0.85 0.285 0.92 0.93 ;
+      RECT 0.425 0.285 0.92 0.355 ;
+      RECT 0.425 0.22 0.495 0.355 ;
+  END
+END AND2_X4
+
+MACRO AND3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.975 0.89 1.25 ;
+        RECT 0.82 0.15 0.89 1.25 ;
+        RECT 0.8 0.15 0.89 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 1 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.415 0.865 0.485 1.25 ;
+      RECT 0.045 0.865 0.115 1.25 ;
+      RECT 0.045 0.865 0.705 0.935 ;
+      RECT 0.635 0.35 0.705 0.935 ;
+      RECT 0.635 0.525 0.755 0.66 ;
+      RECT 0.045 0.35 0.705 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END AND3_X1
+
+MACRO AND3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X2 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.15 0.89 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.99 0.975 1.06 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+        RECT 0.225 0.975 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.99 -0.085 1.06 0.425 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.415 0.8 0.485 1.25 ;
+      RECT 0.045 0.8 0.115 1.25 ;
+      RECT 0.045 0.8 0.735 0.87 ;
+      RECT 0.665 0.355 0.735 0.87 ;
+      RECT 0.045 0.355 0.735 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END AND3_X2
+
+MACRO AND3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND3_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.595 0.555 0.73 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.42 0.95 0.7 ;
+        RECT 0.34 0.42 0.95 0.49 ;
+        RECT 0.34 0.42 0.41 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.12 0.765 1.14 0.835 ;
+        RECT 1.07 0.525 1.14 0.835 ;
+        RECT 0.12 0.525 0.19 0.835 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.745 0.15 1.815 1.25 ;
+        RECT 1.375 0.56 1.815 0.7 ;
+        RECT 1.375 0.15 1.445 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.935 1.035 2.005 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 1.175 1.035 1.245 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.415 1.035 0.485 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.195 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.985 0.9 1.055 1.25 ;
+      RECT 0.605 0.9 0.675 1.25 ;
+      RECT 0.235 0.9 0.305 1.25 ;
+      RECT 0.235 0.9 1.305 0.97 ;
+      RECT 1.235 0.26 1.305 0.97 ;
+      RECT 0.615 0.26 1.305 0.33 ;
+      RECT 0.615 0.15 0.685 0.33 ;
+  END
+END AND3_X4
+
+MACRO AND4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.99 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.84 0.675 1.25 ;
+      RECT 0.235 0.84 0.305 1.25 ;
+      RECT 0.235 0.84 0.925 0.91 ;
+      RECT 0.855 0.35 0.925 0.91 ;
+      RECT 0.045 0.35 0.925 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END AND4_X1
+
+MACRO AND4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.18 0.975 1.25 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.18 -0.085 1.25 0.425 ;
+        RECT 0.795 -0.085 0.865 0.27 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.8 0.675 1.25 ;
+      RECT 0.235 0.8 0.305 1.25 ;
+      RECT 0.235 0.8 0.925 0.87 ;
+      RECT 0.855 0.355 0.925 0.87 ;
+      RECT 0.045 0.355 0.925 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END AND4_X2
+
+MACRO AND4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AND4_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.56 0.935 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.065 0.425 1.135 0.66 ;
+        RECT 0.565 0.425 1.135 0.495 ;
+        RECT 0.565 0.425 0.7 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.355 0.77 1.345 0.84 ;
+        RECT 1.2 0.525 1.345 0.84 ;
+        RECT 0.355 0.525 0.425 0.84 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.135 0.905 1.535 0.975 ;
+        RECT 1.465 0.525 1.535 0.975 ;
+        RECT 0.135 0.525 0.205 0.975 ;
+        RECT 0.06 0.525 0.205 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.14 0.15 2.21 0.925 ;
+        RECT 1.77 0.56 2.21 0.7 ;
+        RECT 1.77 0.15 1.84 0.925 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.33 1.065 2.4 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.57 1.175 1.64 1.485 ;
+        RECT 1.19 1.175 1.26 1.485 ;
+        RECT 0.81 1.175 0.88 1.485 ;
+        RECT 0.43 1.175 0.5 1.485 ;
+        RECT 0.055 1.065 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.33 -0.085 2.4 0.425 ;
+        RECT 1.95 -0.085 2.02 0.425 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.215 1.04 1.705 1.11 ;
+      RECT 1.635 0.29 1.705 1.11 ;
+      RECT 0.785 0.29 1.705 0.36 ;
+  END
+END AND4_X4
+
+MACRO ANTENNA_X1
+  CLASS CORE ANTENNACELL ;
+  ORIGIN 0 0 ;
+  FOREIGN ANTENNA_X1 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    # unknown
+    ANTENNADIFFAREA  0.0 ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.42 0.13 0.75 ;
+    END
+  END A
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END ANTENNA_X1
+
+MACRO AOI211_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.41 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.21 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.275 0.355 0.905 0.425 ;
+        RECT 0.835 0.15 0.905 0.425 ;
+        RECT 0.44 0.15 0.525 0.425 ;
+        RECT 0.275 0.355 0.345 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.835 0.905 0.905 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 1.18 0.525 1.25 ;
+      RECT 0.455 0.905 0.525 1.25 ;
+      RECT 0.085 0.905 0.155 1.25 ;
+  END
+END AOI211_X1
+
+MACRO AOI211_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.39 0.56 0.525 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.75 0.835 ;
+        RECT 0.68 0.525 0.75 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.19 0.56 1.325 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.54 0.425 1.65 0.7 ;
+        RECT 0.965 0.425 1.65 0.495 ;
+        RECT 0.965 0.425 1.035 0.66 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.765 1.475 1.055 ;
+        RECT 0.82 0.765 1.475 0.835 ;
+        RECT 0.2 0.285 1.32 0.355 ;
+        RECT 1.185 0.15 1.32 0.355 ;
+        RECT 1.025 0.765 1.095 1.055 ;
+        RECT 0.82 0.285 0.89 0.835 ;
+        RECT 0.2 0.15 0.335 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 0.42 1.035 0.49 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.355 ;
+        RECT 0.825 -0.085 0.895 0.215 ;
+        RECT 0.43 -0.085 0.5 0.215 ;
+        RECT 0.045 -0.085 0.115 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.815 1.18 1.665 1.25 ;
+      RECT 1.595 0.975 1.665 1.25 ;
+      RECT 0.05 0.9 0.12 1.25 ;
+      RECT 1.22 0.975 1.29 1.25 ;
+      RECT 0.815 0.9 0.885 1.25 ;
+      RECT 0.05 0.9 0.885 0.97 ;
+  END
+END AOI211_X2
+
+MACRO AOI211_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI211_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.15 1.82 1.175 ;
+        RECT 1.375 0.56 1.82 0.7 ;
+        RECT 1.375 0.15 1.445 1.175 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.935 0.9 2.005 1.485 ;
+        RECT 1.555 0.9 1.625 1.485 ;
+        RECT 1.175 0.9 1.245 1.485 ;
+        RECT 0.795 0.9 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.995 0.15 1.065 1.175 ;
+      RECT 0.995 0.525 1.31 0.66 ;
+      RECT 0.235 0.765 0.305 1.115 ;
+      RECT 0.235 0.765 0.93 0.835 ;
+      RECT 0.86 0.39 0.93 0.835 ;
+      RECT 0.045 0.39 0.93 0.46 ;
+      RECT 0.605 0.15 0.675 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+      RECT 0.045 1.18 0.485 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+  END
+END AOI211_X4
+
+MACRO AOI21_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.51 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.2 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.265 0.355 0.525 0.425 ;
+        RECT 0.44 0.15 0.525 0.425 ;
+        RECT 0.265 0.355 0.335 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.645 0.905 0.715 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.645 -0.085 0.715 0.355 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 1.18 0.525 1.25 ;
+      RECT 0.455 0.905 0.525 1.25 ;
+      RECT 0.085 0.905 0.155 1.25 ;
+  END
+END AOI21_X1
+
+MACRO AOI21_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.215 0.56 0.35 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.56 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.77 1.18 0.84 ;
+        RECT 1.11 0.525 1.18 0.84 ;
+        RECT 0.63 0.525 0.7 0.84 ;
+        RECT 0.57 0.525 0.7 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.435 0.905 1.13 0.975 ;
+        RECT 0.25 0.355 0.905 0.425 ;
+        RECT 0.835 0.15 0.905 0.425 ;
+        RECT 0.435 0.355 0.505 0.975 ;
+        RECT 0.25 0.15 0.335 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 0.265 1.205 0.335 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.425 ;
+        RECT 0.455 -0.085 0.525 0.285 ;
+        RECT 0.08 -0.085 0.15 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.215 0.975 1.285 1.25 ;
+      RECT 0.085 0.975 0.155 1.25 ;
+      RECT 0.085 1.07 1.285 1.14 ;
+  END
+END AOI21_X2
+
+MACRO AOI21_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI21_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.535 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.165 0.69 2.06 0.76 ;
+        RECT 1.925 0.56 2.06 0.76 ;
+        RECT 1.165 0.56 1.3 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.25 0.42 2.32 0.66 ;
+        RECT 0.925 0.42 2.32 0.49 ;
+        RECT 1.525 0.42 1.66 0.625 ;
+        RECT 0.925 0.42 0.995 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.14 0.825 2.21 1.115 ;
+        RECT 0.63 0.825 2.21 0.895 ;
+        RECT 0.63 0.26 2.055 0.33 ;
+        RECT 1.76 0.825 1.83 1.115 ;
+        RECT 1.38 0.825 1.45 1.115 ;
+        RECT 1 0.825 1.07 1.115 ;
+        RECT 0.63 0.15 0.7 0.895 ;
+        RECT 0.25 0.355 0.7 0.425 ;
+        RECT 0.25 0.15 0.32 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 0.62 1.205 0.69 1.485 ;
+        RECT 0.24 1.205 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.33 -0.085 2.4 0.35 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 0.81 -0.085 0.88 0.195 ;
+        RECT 0.43 -0.085 0.5 0.195 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.81 1.18 2.4 1.25 ;
+      RECT 2.33 0.84 2.4 1.25 ;
+      RECT 0.43 0.965 0.5 1.24 ;
+      RECT 0.06 0.965 0.13 1.24 ;
+      RECT 1.95 0.96 2.02 1.25 ;
+      RECT 1.57 0.96 1.64 1.25 ;
+      RECT 1.19 0.96 1.26 1.25 ;
+      RECT 0.81 0.965 0.88 1.25 ;
+      RECT 0.06 0.965 0.88 1.035 ;
+  END
+END AOI21_X4
+
+MACRO AOI221_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.74 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.355 1.055 0.425 ;
+        RECT 0.985 0.15 1.055 0.425 ;
+        RECT 0.805 0.355 0.89 1.115 ;
+        RECT 0.425 0.15 0.495 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.225 0.905 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.605 -0.085 0.675 0.215 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.615 1.18 1.055 1.25 ;
+      RECT 0.985 0.905 1.055 1.25 ;
+      RECT 0.615 0.905 0.685 1.25 ;
+      RECT 0.415 0.77 0.485 1.18 ;
+      RECT 0.045 0.77 0.115 1.18 ;
+      RECT 0.045 0.77 0.485 0.84 ;
+  END
+END AOI221_X1
+
+MACRO AOI221_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.18 0.79 1.13 0.86 ;
+        RECT 1.06 0.525 1.13 0.86 ;
+        RECT 0.18 0.56 0.25 0.86 ;
+        RECT 0.06 0.56 0.25 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.42 0.945 0.7 ;
+        RECT 0.34 0.42 0.945 0.49 ;
+        RECT 0.34 0.42 0.41 0.66 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.585 0.56 0.725 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.57 0.525 1.66 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.525 1.91 0.7 ;
+        RECT 1.34 0.765 1.84 0.835 ;
+        RECT 1.77 0.525 1.84 0.835 ;
+        RECT 1.34 0.525 1.41 0.835 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.195 0.9 1.86 0.97 ;
+        RECT 0.2 0.28 1.675 0.35 ;
+        RECT 1.195 0.28 1.275 0.97 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 0.795 1.205 0.865 1.485 ;
+        RECT 0.415 1.205 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.945 -0.085 2.015 0.425 ;
+        RECT 1.175 -0.085 1.245 0.195 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 1.07 2.015 1.14 ;
+      RECT 1.945 0.865 2.015 1.14 ;
+      RECT 0.045 0.865 0.115 1.14 ;
+      RECT 0.2 0.93 1.09 1 ;
+  END
+END AOI221_X2
+
+MACRO AOI221_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI221_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.18 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.27 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.525 0.51 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.17 0.15 2.24 1.25 ;
+        RECT 1.795 0.56 2.24 0.7 ;
+        RECT 1.795 0.15 1.885 0.7 ;
+        RECT 1.795 0.15 1.865 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 0.975 2.425 1.485 ;
+        RECT 1.975 0.975 2.045 1.485 ;
+        RECT 1.6 1.005 1.67 1.485 ;
+        RECT 1.215 0.975 1.285 1.485 ;
+        RECT 0.875 1.035 0.945 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.425 ;
+        RECT 1.975 -0.085 2.045 0.425 ;
+        RECT 1.605 -0.085 1.675 0.425 ;
+        RECT 1.215 -0.085 1.285 0.285 ;
+        RECT 0.495 -0.085 0.565 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.415 0.15 1.485 1.25 ;
+      RECT 1.415 0.525 1.73 0.66 ;
+      RECT 0.315 0.765 0.385 1.04 ;
+      RECT 0.315 0.765 1.35 0.835 ;
+      RECT 1.28 0.355 1.35 0.835 ;
+      RECT 0.125 0.355 1.35 0.425 ;
+      RECT 0.71 0.15 0.78 0.425 ;
+      RECT 0.125 0.15 0.195 0.425 ;
+      RECT 1.03 0.9 1.1 1.25 ;
+      RECT 0.695 0.9 0.765 1.25 ;
+      RECT 0.695 0.9 1.1 0.97 ;
+      RECT 0.495 0.975 0.565 1.25 ;
+      RECT 0.125 0.975 0.195 1.25 ;
+      RECT 0.125 1.105 0.565 1.175 ;
+  END
+END AOI221_X4
+
+MACRO AOI222_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.315 0.525 1.46 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.525 1.08 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.525 0.72 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.91 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.215 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.5 0.375 1.46 0.45 ;
+        RECT 1.325 0.175 1.46 0.45 ;
+        RECT 1.145 0.375 1.215 1.115 ;
+        RECT 0.5 0.175 0.57 0.45 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 0.415 0.905 0.485 1.485 ;
+        RECT 0.04 0.905 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 0.945 -0.085 1.015 0.31 ;
+        RECT 0.04 -0.085 0.11 0.45 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.575 1.18 1.395 1.25 ;
+      RECT 1.325 0.905 1.395 1.25 ;
+      RECT 0.945 0.905 1.015 1.25 ;
+      RECT 0.575 0.905 0.645 1.25 ;
+      RECT 0.235 0.77 0.305 1.18 ;
+      RECT 0.755 0.77 0.825 1.115 ;
+      RECT 0.235 0.77 0.825 0.84 ;
+  END
+END AOI222_X1
+
+MACRO AOI222_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.56 2.045 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.285 0.56 2.42 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.56 1.28 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.475 0.42 1.545 0.66 ;
+        RECT 0.91 0.42 1.545 0.49 ;
+        RECT 0.91 0.42 1.08 0.66 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.56 0.52 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.69 0.425 0.76 0.66 ;
+        RECT 0.06 0.425 0.76 0.495 ;
+        RECT 0.06 0.425 0.19 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.31 0.77 2.38 1.115 ;
+        RECT 1.77 0.77 2.38 0.84 ;
+        RECT 0.39 0.285 2.035 0.355 ;
+        RECT 1.94 0.77 2.01 1.115 ;
+        RECT 1.77 0.285 1.84 0.84 ;
+        RECT 1.145 0.15 1.28 0.355 ;
+        RECT 0.39 0.15 0.525 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 0.605 0.905 0.675 1.485 ;
+        RECT 0.225 0.905 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.31 -0.085 2.38 0.25 ;
+        RECT 1.555 -0.085 1.625 0.195 ;
+        RECT 0.765 -0.085 0.9 0.215 ;
+        RECT 0.04 -0.085 0.11 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.1 0.355 2.57 0.425 ;
+      RECT 2.5 0.15 2.57 0.425 ;
+      RECT 2.1 0.15 2.17 0.425 ;
+      RECT 1.715 0.15 2.17 0.22 ;
+      RECT 0.995 1.18 2.57 1.25 ;
+      RECT 2.5 0.905 2.57 1.25 ;
+      RECT 2.12 0.905 2.19 1.25 ;
+      RECT 1.745 0.905 1.815 1.25 ;
+      RECT 1.365 0.905 1.435 1.25 ;
+      RECT 0.995 0.905 1.065 1.25 ;
+      RECT 0.795 0.77 0.865 1.18 ;
+      RECT 0.415 0.77 0.485 1.18 ;
+      RECT 0.045 0.77 0.115 1.18 ;
+      RECT 1.555 0.77 1.625 1.115 ;
+      RECT 1.175 0.77 1.245 1.115 ;
+      RECT 0.045 0.77 1.625 0.84 ;
+  END
+END AOI222_X2
+
+MACRO AOI222_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI222_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.235 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.135 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.525 1.335 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.33 0.15 2.41 1.205 ;
+        RECT 1.95 0.56 2.41 0.7 ;
+        RECT 2.325 0.15 2.41 0.7 ;
+        RECT 1.95 0.15 2.02 1.205 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.51 0.93 2.58 1.485 ;
+        RECT 2.13 0.93 2.2 1.485 ;
+        RECT 1.75 0.93 1.82 1.485 ;
+        RECT 1.37 0.93 1.44 1.485 ;
+        RECT 0.995 1.065 1.065 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.51 -0.085 2.58 0.425 ;
+        RECT 2.14 -0.085 2.21 0.425 ;
+        RECT 1.75 -0.085 1.82 0.425 ;
+        RECT 1.37 -0.085 1.44 0.285 ;
+        RECT 0.46 -0.085 0.53 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.57 0.15 1.64 1.205 ;
+      RECT 1.57 0.525 1.885 0.66 ;
+      RECT 0.28 0.765 0.35 1.04 ;
+      RECT 0.28 0.765 1.505 0.835 ;
+      RECT 1.435 0.355 1.505 0.835 ;
+      RECT 0.09 0.355 1.505 0.425 ;
+      RECT 0.84 0.15 0.91 0.425 ;
+      RECT 0.09 0.15 0.16 0.425 ;
+      RECT 1.18 0.93 1.25 1.205 ;
+      RECT 0.66 0.93 0.73 1.065 ;
+      RECT 0.66 0.93 1.25 1 ;
+      RECT 0.09 1.135 0.91 1.205 ;
+      RECT 0.84 1.07 0.91 1.205 ;
+      RECT 0.46 0.93 0.53 1.205 ;
+      RECT 0.09 0.93 0.16 1.205 ;
+  END
+END AOI222_X4
+
+MACRO AOI22_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.42 0.7 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.42 0.89 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.725 0.69 1.005 ;
+        RECT 0.44 0.725 0.69 0.795 ;
+        RECT 0.44 0.15 0.51 0.795 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.24 1.205 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.81 -0.085 0.88 0.355 ;
+        RECT 0.055 -0.085 0.125 0.355 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 1.07 0.88 1.14 ;
+      RECT 0.81 0.865 0.88 1.14 ;
+      RECT 0.435 0.865 0.505 1.14 ;
+      RECT 0.06 0.865 0.13 1.14 ;
+  END
+END AOI22_X1
+
+MACRO AOI22_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.155 0.56 1.29 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.48 0.425 1.55 0.66 ;
+        RECT 0.955 0.425 1.55 0.495 ;
+        RECT 0.955 0.425 1.08 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.56 0.53 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.755 0.835 ;
+        RECT 0.685 0.525 0.755 0.835 ;
+        RECT 0.06 0.525 0.195 0.835 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.765 1.445 1.065 ;
+        RECT 0.82 0.765 1.445 0.835 ;
+        RECT 0.395 0.28 1.285 0.355 ;
+        RECT 1.15 0.15 1.285 0.355 ;
+        RECT 0.99 0.765 1.06 1.065 ;
+        RECT 0.82 0.28 0.89 0.835 ;
+        RECT 0.395 0.15 0.53 0.355 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 0.61 1.035 0.68 1.485 ;
+        RECT 0.23 1.035 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.56 -0.085 1.63 0.36 ;
+        RECT 0.77 -0.085 0.905 0.205 ;
+        RECT 0.045 -0.085 0.115 0.39 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.8 1.18 1.63 1.25 ;
+      RECT 1.56 0.975 1.63 1.25 ;
+      RECT 0.42 0.9 0.49 1.25 ;
+      RECT 0.05 0.9 0.12 1.25 ;
+      RECT 1.18 0.975 1.25 1.25 ;
+      RECT 0.8 0.9 0.87 1.25 ;
+      RECT 0.05 0.9 0.87 0.97 ;
+  END
+END AOI22_X2
+
+MACRO AOI22_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN AOI22_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.915 0.69 2.79 0.76 ;
+        RECT 2.655 0.56 2.79 0.76 ;
+        RECT 1.915 0.56 2.05 0.76 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.42 3.045 0.66 ;
+        RECT 1.715 0.42 3.045 0.49 ;
+        RECT 2.295 0.42 2.43 0.625 ;
+        RECT 1.715 0.42 1.785 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.69 1.29 0.76 ;
+        RECT 1.155 0.56 1.29 0.76 ;
+        RECT 0.395 0.56 0.53 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.445 0.42 1.515 0.66 ;
+        RECT 0.125 0.42 1.515 0.49 ;
+        RECT 0.755 0.42 0.89 0.625 ;
+        RECT 0.125 0.42 0.195 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.89 0.825 2.96 1.115 ;
+        RECT 1.75 0.825 2.96 0.895 ;
+        RECT 0.395 0.26 2.805 0.33 ;
+        RECT 2.51 0.825 2.58 1.115 ;
+        RECT 2.13 0.825 2.2 1.115 ;
+        RECT 1.75 0.725 1.82 1.115 ;
+        RECT 1.58 0.725 1.82 0.795 ;
+        RECT 1.58 0.26 1.65 0.795 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 1.37 1.065 1.44 1.485 ;
+        RECT 0.99 1.065 1.06 1.485 ;
+        RECT 0.61 1.065 0.68 1.485 ;
+        RECT 0.23 1.065 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.08 -0.085 3.15 0.335 ;
+        RECT 2.29 -0.085 2.425 0.16 ;
+        RECT 1.53 -0.085 1.665 0.16 ;
+        RECT 0.77 -0.085 0.905 0.16 ;
+        RECT 0.045 -0.085 0.115 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.56 1.18 3.15 1.25 ;
+      RECT 3.08 0.84 3.15 1.25 ;
+      RECT 2.7 0.96 2.77 1.25 ;
+      RECT 2.32 0.96 2.39 1.25 ;
+      RECT 1.94 0.96 2.01 1.25 ;
+      RECT 1.56 0.87 1.63 1.25 ;
+      RECT 1.18 0.87 1.25 1.16 ;
+      RECT 0.8 0.87 0.87 1.16 ;
+      RECT 0.42 0.87 0.49 1.16 ;
+      RECT 0.05 0.87 0.12 1.16 ;
+      RECT 0.05 0.87 1.63 0.94 ;
+  END
+END AOI22_X4
+
+MACRO BUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.19 0.51 1.24 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.225 0.965 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.225 -0.085 0.295 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.355 0.9 ;
+      RECT 0.285 0.39 0.355 0.9 ;
+      RECT 0.045 0.39 0.355 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END BUF_X1
+
+MACRO BUF_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X16 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.715 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.42 0.15 4.49 0.925 ;
+        RECT 1.77 0.28 4.49 0.42 ;
+        RECT 4.05 0.28 4.12 0.925 ;
+        RECT 4.04 0.15 4.11 0.42 ;
+        RECT 3.66 0.15 3.73 0.925 ;
+        RECT 3.28 0.15 3.35 0.925 ;
+        RECT 2.9 0.15 2.97 0.925 ;
+        RECT 2.52 0.15 2.59 0.925 ;
+        RECT 2.14 0.15 2.21 0.925 ;
+        RECT 1.77 0.15 1.84 0.925 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.61 1.205 4.68 1.485 ;
+        RECT 4.23 1.205 4.3 1.485 ;
+        RECT 3.85 1.205 3.92 1.485 ;
+        RECT 3.47 1.205 3.54 1.485 ;
+        RECT 3.09 1.205 3.16 1.485 ;
+        RECT 2.71 1.205 2.78 1.485 ;
+        RECT 2.33 1.205 2.4 1.485 ;
+        RECT 1.95 1.205 2.02 1.485 ;
+        RECT 1.57 1.205 1.64 1.485 ;
+        RECT 1.19 0.975 1.26 1.485 ;
+        RECT 0.81 0.975 0.88 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.61 -0.085 4.68 0.2 ;
+        RECT 4.23 -0.085 4.3 0.2 ;
+        RECT 3.85 -0.085 3.92 0.2 ;
+        RECT 3.47 -0.085 3.54 0.2 ;
+        RECT 3.09 -0.085 3.16 0.2 ;
+        RECT 2.71 -0.085 2.78 0.2 ;
+        RECT 2.33 -0.085 2.4 0.2 ;
+        RECT 1.95 -0.085 2.02 0.2 ;
+        RECT 1.57 -0.085 1.64 0.34 ;
+        RECT 1.19 -0.085 1.26 0.34 ;
+        RECT 0.81 -0.085 0.88 0.34 ;
+        RECT 0.43 -0.085 0.5 0.34 ;
+        RECT 0.055 -0.085 0.125 0.34 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.38 0.15 1.45 1.25 ;
+      RECT 1 0.15 1.07 1.25 ;
+      RECT 0.62 0.15 0.69 1.25 ;
+      RECT 0.25 0.15 0.32 1.25 ;
+      RECT 1.635 1.05 4.63 1.12 ;
+      RECT 4.56 0.525 4.63 1.12 ;
+      RECT 3.45 0.525 3.52 1.12 ;
+      RECT 2.69 0.525 2.76 1.12 ;
+      RECT 1.635 0.525 1.705 1.12 ;
+      RECT 0.25 0.525 1.705 0.66 ;
+  END
+END BUF_X16
+
+MACRO BUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X2 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.23 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.465 0.56 0.7 0.7 ;
+        RECT 0.465 0.15 0.535 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.645 0.975 0.715 1.485 ;
+        RECT 0.265 1.04 0.335 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.645 -0.085 0.715 0.425 ;
+        RECT 0.265 -0.085 0.335 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.085 0.82 0.155 1.25 ;
+      RECT 0.085 0.82 0.395 0.89 ;
+      RECT 0.325 0.39 0.395 0.89 ;
+      RECT 0.085 0.39 0.395 0.46 ;
+      RECT 0.085 0.15 0.155 0.46 ;
+  END
+END BUF_X2
+
+MACRO BUF_X32
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X32 0 0 ;
+  SIZE 9.31 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.1 0.93 2.8 1 ;
+        RECT 2.665 0.56 2.8 1 ;
+        RECT 1.905 0.56 2.04 1 ;
+        RECT 1.12 0.56 1.255 1 ;
+        RECT 0.1 0.525 0.17 1 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 8.99 0.15 9.06 1.25 ;
+        RECT 3.3 0.28 9.06 0.42 ;
+        RECT 8.61 0.15 8.68 0.785 ;
+        RECT 8.23 0.15 8.3 0.785 ;
+        RECT 7.85 0.15 7.92 0.785 ;
+        RECT 7.47 0.15 7.54 0.785 ;
+        RECT 7.09 0.15 7.16 0.785 ;
+        RECT 6.71 0.15 6.78 0.785 ;
+        RECT 6.33 0.15 6.4 0.785 ;
+        RECT 5.95 0.15 6.02 0.785 ;
+        RECT 5.57 0.15 5.64 0.785 ;
+        RECT 5.19 0.15 5.26 0.785 ;
+        RECT 4.81 0.15 4.88 0.785 ;
+        RECT 4.43 0.15 4.5 0.785 ;
+        RECT 4.05 0.15 4.12 0.785 ;
+        RECT 3.67 0.15 3.74 0.785 ;
+        RECT 3.3 0.15 3.37 0.785 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 9.31 1.485 ;
+        RECT 9.18 1.065 9.25 1.485 ;
+        RECT 8.8 1.065 8.87 1.485 ;
+        RECT 8.42 1.065 8.49 1.485 ;
+        RECT 8.04 1.065 8.11 1.485 ;
+        RECT 7.66 1.065 7.73 1.485 ;
+        RECT 7.28 1.065 7.35 1.485 ;
+        RECT 6.9 1.065 6.97 1.485 ;
+        RECT 6.52 1.065 6.59 1.485 ;
+        RECT 6.14 1.065 6.21 1.485 ;
+        RECT 5.76 1.065 5.83 1.485 ;
+        RECT 5.38 1.065 5.45 1.485 ;
+        RECT 5 1.065 5.07 1.485 ;
+        RECT 4.62 1.065 4.69 1.485 ;
+        RECT 4.24 1.065 4.31 1.485 ;
+        RECT 3.86 1.065 3.93 1.485 ;
+        RECT 3.48 1.065 3.55 1.485 ;
+        RECT 3.08 1.065 3.15 1.485 ;
+        RECT 2.695 1.065 2.765 1.485 ;
+        RECT 2.315 1.065 2.385 1.485 ;
+        RECT 1.935 1.065 2.005 1.485 ;
+        RECT 1.555 1.065 1.625 1.485 ;
+        RECT 1.175 1.065 1.245 1.485 ;
+        RECT 0.795 1.065 0.865 1.485 ;
+        RECT 0.415 1.065 0.485 1.485 ;
+        RECT 0.04 1.065 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 9.31 0.085 ;
+        RECT 9.18 -0.085 9.25 0.2 ;
+        RECT 8.8 -0.085 8.87 0.2 ;
+        RECT 8.42 -0.085 8.49 0.2 ;
+        RECT 8.04 -0.085 8.11 0.2 ;
+        RECT 7.66 -0.085 7.73 0.2 ;
+        RECT 7.28 -0.085 7.35 0.2 ;
+        RECT 6.9 -0.085 6.97 0.2 ;
+        RECT 6.52 -0.085 6.59 0.2 ;
+        RECT 6.14 -0.085 6.21 0.2 ;
+        RECT 5.76 -0.085 5.83 0.2 ;
+        RECT 5.38 -0.085 5.45 0.2 ;
+        RECT 5 -0.085 5.07 0.2 ;
+        RECT 4.62 -0.085 4.69 0.2 ;
+        RECT 4.24 -0.085 4.31 0.2 ;
+        RECT 3.86 -0.085 3.93 0.2 ;
+        RECT 3.48 -0.085 3.55 0.2 ;
+        RECT 3.08 -0.085 3.15 0.22 ;
+        RECT 2.695 -0.085 2.765 0.34 ;
+        RECT 2.315 -0.085 2.385 0.34 ;
+        RECT 1.935 -0.085 2.005 0.34 ;
+        RECT 1.555 -0.085 1.625 0.34 ;
+        RECT 1.175 -0.085 1.245 0.34 ;
+        RECT 0.795 -0.085 0.865 0.34 ;
+        RECT 0.415 -0.085 0.485 0.34 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.165 0.85 8.88 0.92 ;
+      RECT 8.745 0.56 8.88 0.92 ;
+      RECT 2.885 0.405 2.955 0.865 ;
+      RECT 2.505 0.15 2.575 0.865 ;
+      RECT 2.13 0.15 2.2 0.865 ;
+      RECT 1.745 0.405 1.815 0.865 ;
+      RECT 1.365 0.15 1.435 0.865 ;
+      RECT 0.985 0.15 1.055 0.865 ;
+      RECT 0.615 0.405 0.685 0.865 ;
+      RECT 0.235 0.15 0.305 0.865 ;
+      RECT 7.605 0.56 7.74 0.92 ;
+      RECT 6.465 0.56 6.6 0.92 ;
+      RECT 5.325 0.56 5.46 0.92 ;
+      RECT 4.185 0.56 4.32 0.92 ;
+      RECT 3.165 0.405 3.235 0.92 ;
+      RECT 0.235 0.405 3.235 0.495 ;
+      RECT 2.89 0.15 2.96 0.495 ;
+      RECT 1.75 0.15 1.82 0.495 ;
+      RECT 0.605 0.15 0.675 0.495 ;
+  END
+END BUF_X32
+
+MACRO BUF_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X4 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.065 1.25 ;
+        RECT 0.615 0.56 1.065 0.7 ;
+        RECT 0.615 0.15 0.685 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.175 -0.085 1.245 0.37 ;
+        RECT 0.795 -0.085 0.865 0.37 ;
+        RECT 0.415 -0.085 0.485 0.37 ;
+        RECT 0.04 -0.085 0.11 0.37 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.235 0.15 0.305 1.25 ;
+      RECT 0.235 0.525 0.55 0.66 ;
+  END
+END BUF_X4
+
+MACRO BUF_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN BUF_X8 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.125 0.15 2.195 1.25 ;
+        RECT 0.995 0.56 2.195 0.7 ;
+        RECT 1.755 0.56 1.825 1.25 ;
+        RECT 1.745 0.15 1.815 0.7 ;
+        RECT 1.365 0.15 1.435 1.25 ;
+        RECT 0.995 0.15 1.065 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 0.975 2.385 1.485 ;
+        RECT 1.935 0.975 2.005 1.485 ;
+        RECT 1.555 0.975 1.625 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.315 -0.085 2.385 0.425 ;
+        RECT 1.935 -0.085 2.005 0.425 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.185 -0.085 1.255 0.425 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.425 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.605 0.15 0.675 1.25 ;
+      RECT 0.235 0.15 0.305 1.25 ;
+      RECT 0.235 0.525 0.925 0.66 ;
+  END
+END BUF_X8
+
+MACRO CLKBUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.21 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.15 0.51 1.24 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.245 0.965 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.245 -0.085 0.315 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.065 0.83 0.135 1.24 ;
+      RECT 0.065 0.83 0.37 0.9 ;
+      RECT 0.3 0.35 0.37 0.9 ;
+      RECT 0.065 0.35 0.37 0.42 ;
+      RECT 0.065 0.15 0.135 0.42 ;
+  END
+END CLKBUF_X1
+
+MACRO CLKBUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X2 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.15 0.51 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.905 0.115 1.25 ;
+      RECT 0.045 0.905 0.36 0.975 ;
+      RECT 0.29 0.35 0.36 0.975 ;
+      RECT 0.045 0.35 0.36 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END CLKBUF_X2
+
+MACRO CLKBUF_X3
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKBUF_X3 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.18 0.865 1.175 ;
+        RECT 0.425 0.42 0.865 0.56 ;
+        RECT 0.425 0.18 0.495 1.175 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 0.9 0.675 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.235 ;
+        RECT 0.225 -0.085 0.295 0.235 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.765 0.115 1.175 ;
+      RECT 0.045 0.765 0.355 0.835 ;
+      RECT 0.285 0.38 0.355 0.835 ;
+      RECT 0.045 0.38 0.355 0.45 ;
+      RECT 0.045 0.18 0.115 0.45 ;
+  END
+END CLKBUF_X3
+
+MACRO CLKGATETST_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X1 0 0 ;
+  SIZE 2.85 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.075 0.7 2.22 0.84 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.7 0.38 0.84 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.7 0.185 0.84 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.705 0.35 2.79 1.235 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.85 1.485 ;
+        RECT 2.48 1.045 2.615 1.485 ;
+        RECT 2.135 0.94 2.205 1.485 ;
+        RECT 1.755 0.94 1.825 1.485 ;
+        RECT 1.185 1.01 1.32 1.485 ;
+        RECT 0.385 1.04 0.52 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.85 0.085 ;
+        RECT 2.485 -0.085 2.62 0.385 ;
+        RECT 1.75 -0.085 1.82 0.42 ;
+        RECT 1.185 -0.085 1.32 0.38 ;
+        RECT 0.385 -0.085 0.52 0.385 ;
+        RECT 0.04 -0.085 0.11 0.42 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.33 0.525 2.4 1.005 ;
+      RECT 2.33 0.525 2.64 0.66 ;
+      RECT 2.14 0.525 2.64 0.595 ;
+      RECT 2.14 0.285 2.21 0.595 ;
+      RECT 1.935 0.15 2.005 1.21 ;
+      RECT 1.935 0.15 2.07 0.22 ;
+      RECT 1.565 0.93 1.69 1.205 ;
+      RECT 1.62 0.585 1.69 1.205 ;
+      RECT 1.105 0.585 1.69 0.655 ;
+      RECT 1.565 0.285 1.635 0.655 ;
+      RECT 0.805 0.285 0.875 1.095 ;
+      RECT 0.805 0.735 1.555 0.805 ;
+      RECT 1.405 0.875 1.475 1.235 ;
+      RECT 0.67 1.16 1.12 1.23 ;
+      RECT 1.05 0.875 1.12 1.23 ;
+      RECT 0.67 0.15 0.74 1.23 ;
+      RECT 1.05 0.875 1.475 0.945 ;
+      RECT 0.945 0.445 1.475 0.515 ;
+      RECT 1.405 0.285 1.475 0.515 ;
+      RECT 0.945 0.15 1.015 0.515 ;
+      RECT 0.67 0.15 1.015 0.22 ;
+      RECT 0.045 0.905 0.115 1.235 ;
+      RECT 0.045 0.905 0.57 0.975 ;
+      RECT 0.5 0.45 0.57 0.975 ;
+      RECT 0.235 0.45 0.57 0.52 ;
+      RECT 0.235 0.285 0.305 0.52 ;
+  END
+END CLKGATETST_X1
+
+MACRO CLKGATETST_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X2 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.18 0.85 2.825 0.92 ;
+        RECT 2.72 0.525 2.825 0.92 ;
+        RECT 2.18 0.525 2.25 0.92 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.375 0.725 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.56 0.545 0.725 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.52 0.15 2.6 0.785 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+        RECT 2.675 1.24 2.81 1.485 ;
+        RECT 2.275 1.24 2.41 1.485 ;
+        RECT 1.83 1.24 1.965 1.485 ;
+        RECT 1.515 0.91 1.585 1.485 ;
+        RECT 0.73 1.115 0.865 1.485 ;
+        RECT 0.225 0.94 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+        RECT 2.7 -0.085 2.77 0.195 ;
+        RECT 2.325 -0.085 2.395 0.195 ;
+        RECT 1.765 -0.085 1.9 0.185 ;
+        RECT 1.45 -0.085 1.52 0.405 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.68 1.08 1.75 1.245 ;
+      RECT 2.895 0.15 2.965 1.24 ;
+      RECT 1.68 1.08 2.965 1.15 ;
+      RECT 2.045 0.39 2.115 0.925 ;
+      RECT 2.045 0.39 2.45 0.46 ;
+      RECT 2.17 0.325 2.45 0.46 ;
+      RECT 2.17 0.15 2.24 0.46 ;
+      RECT 1.38 0.76 1.775 0.83 ;
+      RECT 1.705 0.28 1.775 0.83 ;
+      RECT 1.61 0.28 1.775 0.35 ;
+      RECT 1.145 0.285 1.215 1.03 ;
+      RECT 1.145 0.525 1.63 0.66 ;
+      RECT 1.08 0.285 1.215 0.42 ;
+      RECT 0.045 0.15 0.115 1.125 ;
+      RECT 0.41 0.95 1.015 1.02 ;
+      RECT 0.945 0.15 1.015 1.02 ;
+      RECT 0.41 0.805 0.48 1.02 ;
+      RECT 0.045 0.805 0.48 0.875 ;
+      RECT 0.945 0.61 1.08 0.745 ;
+      RECT 0.945 0.15 1.285 0.22 ;
+      RECT 0.61 0.41 0.68 0.885 ;
+      RECT 0.61 0.41 0.87 0.545 ;
+      RECT 0.425 0.41 0.87 0.48 ;
+      RECT 0.425 0.15 0.495 0.48 ;
+  END
+END CLKGATETST_X2
+
+MACRO CLKGATETST_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X4 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.21 0.77 2.85 0.85 ;
+        RECT 2.72 0.525 2.85 0.85 ;
+        RECT 2.21 0.525 2.28 0.85 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.38 0.775 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.56 0.185 0.775 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.455 0.18 3.525 0.925 ;
+        RECT 3.085 0.42 3.525 0.56 ;
+        RECT 3.085 0.18 3.155 0.925 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.645 0.975 3.715 1.485 ;
+        RECT 3.265 0.975 3.335 1.485 ;
+        RECT 2.885 1.2 2.955 1.485 ;
+        RECT 2.505 1.2 2.575 1.485 ;
+        RECT 2.13 1.205 2.2 1.485 ;
+        RECT 1.49 1.165 1.625 1.485 ;
+        RECT 0.755 1.13 0.825 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.645 -0.085 3.715 0.2 ;
+        RECT 3.265 -0.085 3.335 0.2 ;
+        RECT 2.885 -0.085 2.955 0.2 ;
+        RECT 2.125 -0.085 2.195 0.285 ;
+        RECT 1.53 -0.085 1.6 0.285 ;
+        RECT 0.755 -0.085 0.825 0.195 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.29 0.93 3.015 1 ;
+      RECT 2.945 0.35 3.015 1 ;
+      RECT 2.655 0.35 3.015 0.42 ;
+      RECT 2.655 0.185 2.725 0.42 ;
+      RECT 2.48 0.185 2.725 0.255 ;
+      RECT 1.13 1.03 1.205 1.25 ;
+      RECT 1.13 1.03 2.125 1.1 ;
+      RECT 2.055 0.39 2.125 1.1 ;
+      RECT 1.13 0.525 1.2 1.25 ;
+      RECT 2.425 0.39 2.495 0.66 ;
+      RECT 1.13 0.525 1.645 0.66 ;
+      RECT 1.39 0.185 1.46 0.66 ;
+      RECT 2.055 0.39 2.495 0.46 ;
+      RECT 1.11 0.185 1.46 0.255 ;
+      RECT 1.265 0.865 1.99 0.935 ;
+      RECT 1.92 0.15 1.99 0.935 ;
+      RECT 1.265 0.795 1.335 0.935 ;
+      RECT 1.405 0.725 1.78 0.795 ;
+      RECT 1.71 0.15 1.78 0.795 ;
+      RECT 0.575 0.975 0.645 1.25 ;
+      RECT 0.575 0.975 1.065 1.045 ;
+      RECT 0.975 0.39 1.065 1.045 ;
+      RECT 0.975 0.39 1.325 0.46 ;
+      RECT 0.975 0.26 1.045 1.045 ;
+      RECT 0.575 0.26 1.045 0.33 ;
+      RECT 0.575 0.15 0.645 0.33 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.91 0.91 ;
+      RECT 0.84 0.415 0.91 0.91 ;
+      RECT 0.235 0.415 0.91 0.485 ;
+      RECT 0.235 0.15 0.335 0.485 ;
+  END
+END CLKGATETST_X4
+
+MACRO CLKGATETST_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATETST_X8 0 0 ;
+  SIZE 5.51 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.385 0.845 3.925 0.915 ;
+        RECT 3.855 0.56 3.925 0.915 ;
+        RECT 3.765 0.56 3.925 0.63 ;
+        RECT 3.1 0.56 3.17 0.915 ;
+        RECT 3.035 0.56 3.17 0.63 ;
+        RECT 2.385 0.525 2.455 0.915 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.33 0.7 0.51 0.84 ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.7 0.25 0.84 ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.205 0.15 5.275 1.25 ;
+        RECT 4.12 0.56 5.275 0.7 ;
+        RECT 4.825 0.15 4.895 1.25 ;
+        RECT 4.445 0.15 4.515 1.25 ;
+        RECT 4.075 0.975 4.19 1.25 ;
+        RECT 4.12 0.15 4.19 1.25 ;
+        RECT 4.075 0.15 4.19 0.285 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.51 1.485 ;
+        RECT 5.395 0.975 5.465 1.485 ;
+        RECT 5.015 0.975 5.085 1.485 ;
+        RECT 4.635 0.975 4.705 1.485 ;
+        RECT 4.26 0.975 4.33 1.485 ;
+        RECT 3.845 1.01 3.98 1.485 ;
+        RECT 3.465 1.01 3.6 1.485 ;
+        RECT 3.085 1.01 3.22 1.485 ;
+        RECT 2.705 1.01 2.84 1.485 ;
+        RECT 2.365 1.06 2.435 1.485 ;
+        RECT 1.915 1.1 2.05 1.485 ;
+        RECT 1.535 1.1 1.67 1.485 ;
+        RECT 0.75 1.24 0.885 1.485 ;
+        RECT 0.41 1.215 0.545 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.51 0.085 ;
+        RECT 5.395 -0.085 5.465 0.285 ;
+        RECT 5.015 -0.085 5.085 0.285 ;
+        RECT 4.635 -0.085 4.705 0.285 ;
+        RECT 4.255 -0.085 4.325 0.285 ;
+        RECT 3.845 -0.085 3.98 0.25 ;
+        RECT 3.085 -0.085 3.22 0.16 ;
+        RECT 2.33 -0.085 2.465 0.16 ;
+        RECT 1.95 -0.085 2.02 0.425 ;
+        RECT 1.575 -0.085 1.645 0.265 ;
+        RECT 0.75 -0.085 0.885 0.175 ;
+        RECT 0.44 -0.085 0.51 0.285 ;
+        RECT 0.065 -0.085 0.135 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.235 0.71 3.79 0.78 ;
+      RECT 2.52 0.71 3.03 0.78 ;
+      RECT 3.235 0.705 3.7 0.78 ;
+      RECT 3.63 0.16 3.7 0.78 ;
+      RECT 2.9 0.425 2.97 0.78 ;
+      RECT 3.235 0.425 3.305 0.78 ;
+      RECT 2.71 0.425 3.305 0.495 ;
+      RECT 3.63 0.35 4.055 0.485 ;
+      RECT 3.47 0.16 3.7 0.23 ;
+      RECT 1.16 0.56 1.23 1.185 ;
+      RECT 1.16 0.965 2.305 1.035 ;
+      RECT 2.235 0.29 2.305 1.035 ;
+      RECT 2.575 0.56 2.735 0.63 ;
+      RECT 1.16 0.56 1.75 0.63 ;
+      RECT 3.37 0.555 3.52 0.625 ;
+      RECT 2.575 0.29 2.645 0.63 ;
+      RECT 1.435 0.18 1.505 0.63 ;
+      RECT 3.37 0.29 3.44 0.625 ;
+      RECT 2.235 0.29 3.44 0.36 ;
+      RECT 1.155 0.18 1.505 0.25 ;
+      RECT 1.315 0.83 2.17 0.9 ;
+      RECT 2.1 0.195 2.17 0.9 ;
+      RECT 1.315 0.715 1.385 0.9 ;
+      RECT 1.45 0.695 1.885 0.765 ;
+      RECT 1.815 0.185 1.885 0.765 ;
+      RECT 1.73 0.185 1.885 0.39 ;
+      RECT 0.565 1.065 1.085 1.135 ;
+      RECT 1.015 0.25 1.085 1.135 ;
+      RECT 1.015 0.425 1.37 0.495 ;
+      RECT 0.6 0.25 1.085 0.32 ;
+      RECT 0.6 0.15 0.67 0.32 ;
+      RECT 0.07 0.905 0.14 1.25 ;
+      RECT 0.07 0.905 0.95 0.975 ;
+      RECT 0.87 0.42 0.95 0.975 ;
+      RECT 0.26 0.42 0.95 0.49 ;
+      RECT 0.26 0.15 0.33 0.49 ;
+  END
+END CLKGATETST_X8
+
+MACRO CLKGATE_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X1 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.54 0.42 1.895 0.56 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.91 0.525 1.08 0.7 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.31 0.175 2.41 1.09 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.03 0.915 2.1 1.485 ;
+        RECT 1.585 0.89 1.655 1.485 ;
+        RECT 0.955 0.9 1.09 1.485 ;
+        RECT 0.225 0.955 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.12 -0.085 2.19 0.225 ;
+        RECT 1.585 -0.085 1.655 0.195 ;
+        RECT 0.985 -0.085 1.055 0.32 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.785 0.765 1.855 1.09 ;
+      RECT 1.785 0.765 2.245 0.835 ;
+      RECT 2.175 0.35 2.245 0.835 ;
+      RECT 1.97 0.35 2.245 0.42 ;
+      RECT 1.97 0.185 2.04 0.42 ;
+      RECT 1.405 0.195 1.475 1.09 ;
+      RECT 1.145 0.525 1.475 0.66 ;
+      RECT 1.175 0.765 1.245 1.05 ;
+      RECT 0.695 0.765 1.245 0.835 ;
+      RECT 0.695 0.39 0.765 0.835 ;
+      RECT 0.695 0.39 1.245 0.46 ;
+      RECT 1.175 0.27 1.245 0.46 ;
+      RECT 0.51 0.98 0.715 1.05 ;
+      RECT 0.51 0.22 0.58 1.05 ;
+      RECT 0.175 0.59 0.58 0.725 ;
+      RECT 0.51 0.22 0.71 0.29 ;
+      RECT 0.04 0.265 0.11 1.04 ;
+      RECT 0.04 0.45 0.44 0.52 ;
+  END
+END CLKGATE_X1
+
+MACRO CLKGATE_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.42 1.65 0.66 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.34 0.42 0.51 0.59 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.32 0.185 2.41 1.215 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.505 0.94 2.575 1.485 ;
+        RECT 2.095 0.94 2.165 1.485 ;
+        RECT 1.725 0.89 1.795 1.485 ;
+        RECT 0.985 0.98 1.055 1.485 ;
+        RECT 0.225 0.94 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.505 -0.085 2.575 0.22 ;
+        RECT 2.095 -0.085 2.165 0.22 ;
+        RECT 1.565 -0.085 1.635 0.235 ;
+        RECT 0.955 -0.085 1.09 0.285 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.915 0.805 1.985 1.215 ;
+      RECT 1.915 0.805 2.255 0.875 ;
+      RECT 2.185 0.39 2.255 0.875 ;
+      RECT 1.725 0.39 2.255 0.46 ;
+      RECT 1.725 0.185 1.795 0.46 ;
+      RECT 1.12 1.18 1.64 1.25 ;
+      RECT 1.57 0.755 1.64 1.25 ;
+      RECT 0.36 1.18 0.92 1.25 ;
+      RECT 0.85 0.79 0.92 1.25 ;
+      RECT 1.12 0.79 1.19 1.25 ;
+      RECT 0.36 0.805 0.43 1.25 ;
+      RECT 0.04 0.295 0.11 1.17 ;
+      RECT 0.04 0.805 0.43 0.875 ;
+      RECT 0.85 0.79 1.19 0.86 ;
+      RECT 1.57 0.755 1.785 0.825 ;
+      RECT 1.715 0.56 1.785 0.825 ;
+      RECT 1.715 0.56 2.095 0.63 ;
+      RECT 1.42 0.49 1.49 0.975 ;
+      RECT 1.065 0.49 1.49 0.56 ;
+      RECT 1.385 0.185 1.455 0.56 ;
+      RECT 1.255 0.65 1.325 1.115 ;
+      RECT 0.74 0.65 1.325 0.72 ;
+      RECT 0.74 0.585 0.99 0.72 ;
+      RECT 0.92 0.35 0.99 0.72 ;
+      RECT 0.92 0.35 1.28 0.42 ;
+      RECT 0.605 0.2 0.675 1.115 ;
+      RECT 0.175 0.655 0.675 0.725 ;
+      RECT 0.175 0.525 0.245 0.725 ;
+  END
+END CLKGATE_X2
+
+MACRO CLKGATE_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.895 0.39 1.965 0.66 ;
+        RECT 1.535 0.39 1.965 0.46 ;
+        RECT 1.535 0.39 1.65 0.7 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.42 0.51 0.63 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.925 0.15 2.995 1.24 ;
+        RECT 2.555 0.42 2.995 0.56 ;
+        RECT 2.555 0.15 2.625 1.24 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.115 0.965 3.185 1.485 ;
+        RECT 2.735 0.965 2.805 1.485 ;
+        RECT 2.355 1.065 2.425 1.485 ;
+        RECT 1.975 1.065 2.045 1.485 ;
+        RECT 1.57 1.24 1.705 1.485 ;
+        RECT 0.995 0.965 1.065 1.485 ;
+        RECT 0.235 0.965 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.115 -0.085 3.185 0.215 ;
+        RECT 2.735 -0.085 2.805 0.215 ;
+        RECT 2.325 -0.085 2.46 0.185 ;
+        RECT 1.58 -0.085 1.65 0.285 ;
+        RECT 0.995 -0.085 1.065 0.32 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.165 0.905 2.235 1.24 ;
+      RECT 1.79 0.905 1.86 1.24 ;
+      RECT 1.79 0.905 2.49 0.975 ;
+      RECT 2.42 0.255 2.49 0.975 ;
+      RECT 1.95 0.255 2.49 0.325 ;
+      RECT 0.05 0.15 0.12 1.24 ;
+      RECT 0.37 1.165 0.885 1.235 ;
+      RECT 0.815 0.83 0.885 1.235 ;
+      RECT 1.13 1.105 1.64 1.175 ;
+      RECT 1.57 0.765 1.64 1.175 ;
+      RECT 0.37 0.83 0.44 1.235 ;
+      RECT 1.13 0.83 1.2 1.175 ;
+      RECT 0.815 0.83 1.2 0.9 ;
+      RECT 0.05 0.83 0.44 0.9 ;
+      RECT 1.57 0.765 2.32 0.835 ;
+      RECT 2.25 0.525 2.32 0.835 ;
+      RECT 0.92 0.56 0.99 0.9 ;
+      RECT 1.715 0.525 1.785 0.835 ;
+      RECT 1.4 0.15 1.47 1.04 ;
+      RECT 1.19 0.56 1.47 0.63 ;
+      RECT 1.265 0.695 1.335 0.87 ;
+      RECT 1.055 0.695 1.335 0.765 ;
+      RECT 1.055 0.39 1.125 0.765 ;
+      RECT 0.75 0.39 0.82 0.66 ;
+      RECT 0.75 0.39 1.255 0.46 ;
+      RECT 1.185 0.3 1.255 0.46 ;
+      RECT 0.615 0.2 0.685 1.095 ;
+      RECT 0.185 0.695 0.685 0.765 ;
+      RECT 0.185 0.525 0.255 0.765 ;
+  END
+END CLKGATE_X4
+
+MACRO CLKGATE_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN CLKGATE_X8 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.625 0.86 2.935 0.93 ;
+        RECT 2.865 0.525 2.935 0.93 ;
+        RECT 2.13 0.525 2.22 0.93 ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.345 0.56 0.51 0.7 ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.615 0.15 4.685 1.235 ;
+        RECT 3.485 0.42 4.685 0.56 ;
+        RECT 4.235 0.15 4.305 1.235 ;
+        RECT 3.855 0.15 3.925 1.235 ;
+        RECT 3.485 0.15 3.555 1.235 ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.805 0.96 4.875 1.485 ;
+        RECT 4.425 0.96 4.495 1.485 ;
+        RECT 4.045 0.96 4.115 1.485 ;
+        RECT 3.665 0.96 3.735 1.485 ;
+        RECT 3.275 0.96 3.345 1.485 ;
+        RECT 2.88 1.205 2.95 1.485 ;
+        RECT 2.5 1.205 2.57 1.485 ;
+        RECT 2.12 1.205 2.19 1.485 ;
+        RECT 1.725 1.065 1.795 1.485 ;
+        RECT 1.355 1.175 1.49 1.485 ;
+        RECT 1.005 0.995 1.075 1.485 ;
+        RECT 0.23 0.96 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.805 -0.085 4.875 0.285 ;
+        RECT 4.425 -0.085 4.495 0.285 ;
+        RECT 4.045 -0.085 4.115 0.285 ;
+        RECT 3.67 -0.085 3.74 0.285 ;
+        RECT 3.245 -0.085 3.38 0.16 ;
+        RECT 2.47 -0.085 2.605 0.16 ;
+        RECT 1.715 -0.085 1.85 0.16 ;
+        RECT 1.355 -0.085 1.49 0.16 ;
+        RECT 1.005 -0.085 1.075 0.285 ;
+        RECT 0.2 -0.085 0.335 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.07 0.725 3.14 1.235 ;
+      RECT 2.66 0.995 2.795 1.2 ;
+      RECT 2.28 0.995 2.415 1.2 ;
+      RECT 1.905 0.995 2.04 1.2 ;
+      RECT 1.905 0.995 3.14 1.065 ;
+      RECT 3.005 0.725 3.42 0.795 ;
+      RECT 3.35 0.525 3.42 0.795 ;
+      RECT 2.31 0.725 2.74 0.795 ;
+      RECT 2.67 0.39 2.74 0.795 ;
+      RECT 3.005 0.39 3.075 0.795 ;
+      RECT 2.31 0.39 2.38 0.795 ;
+      RECT 2.67 0.39 3.075 0.46 ;
+      RECT 2.095 0.39 2.38 0.46 ;
+      RECT 0.87 0.725 1.275 0.795 ;
+      RECT 1.205 0.15 1.275 0.795 ;
+      RECT 3.155 0.255 3.225 0.66 ;
+      RECT 2.5 0.255 2.57 0.66 ;
+      RECT 1.825 0.255 1.895 0.66 ;
+      RECT 1.205 0.255 3.225 0.325 ;
+      RECT 0.44 1.15 0.94 1.22 ;
+      RECT 0.87 0.86 0.94 1.22 ;
+      RECT 0.44 0.765 0.51 1.22 ;
+      RECT 1.49 1.005 1.645 1.075 ;
+      RECT 1.49 0.43 1.56 1.075 ;
+      RECT 0.87 0.86 1.56 0.93 ;
+      RECT 0.18 0.765 0.51 0.835 ;
+      RECT 0.18 0.605 0.25 0.835 ;
+      RECT 1.49 0.43 1.645 0.5 ;
+      RECT 0.585 1.01 0.805 1.08 ;
+      RECT 0.735 0.525 0.805 1.08 ;
+      RECT 0.735 0.525 1.14 0.66 ;
+      RECT 0.865 0.18 0.935 0.66 ;
+      RECT 0.585 0.18 0.935 0.25 ;
+      RECT 0.045 0.15 0.115 1.235 ;
+      RECT 0.575 0.39 0.645 0.87 ;
+      RECT 0.045 0.39 0.8 0.46 ;
+  END
+END CLKGATE_X8
+
+MACRO DFFRS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFRS_X1 0 0 ;
+  SIZE 4.56 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.12 0.585 4.31 0.84 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.7 1.345 0.84 ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.7 0.89 0.84 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.28 4.385 0.495 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.4 0.51 0.875 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.185 0.13 1.075 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.56 1.485 ;
+        RECT 4.255 0.915 4.325 1.485 ;
+        RECT 3.325 1.03 3.46 1.485 ;
+        RECT 2.795 0.835 2.93 1.485 ;
+        RECT 2.415 0.89 2.55 1.485 ;
+        RECT 1.655 0.99 1.79 1.485 ;
+        RECT 1.345 0.925 1.415 1.485 ;
+        RECT 0.965 1.065 1.035 1.485 ;
+        RECT 0.56 1.095 0.695 1.485 ;
+        RECT 0.215 1.1 0.35 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.56 0.085 ;
+        RECT 4.225 -0.085 4.36 0.16 ;
+        RECT 3.135 -0.085 3.27 0.285 ;
+        RECT 2.415 -0.085 2.55 0.285 ;
+        RECT 1.47 -0.085 1.605 0.285 ;
+        RECT 0.935 -0.085 1.07 0.285 ;
+        RECT 0.215 -0.085 0.35 0.2 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.68 1.18 4.055 1.25 ;
+      RECT 3.985 0.15 4.055 1.25 ;
+      RECT 1.955 1.165 2.275 1.235 ;
+      RECT 2.205 0.35 2.275 1.235 ;
+      RECT 3.68 0.76 3.75 1.25 ;
+      RECT 3.02 0.76 3.09 1.07 ;
+      RECT 3.02 0.76 3.75 0.83 ;
+      RECT 3.62 0.15 3.69 0.46 ;
+      RECT 2.98 0.35 3.69 0.42 ;
+      RECT 2.205 0.35 2.76 0.42 ;
+      RECT 2.69 0.165 2.76 0.42 ;
+      RECT 2.98 0.165 3.05 0.42 ;
+      RECT 2.69 0.165 3.05 0.235 ;
+      RECT 3.62 0.15 4.055 0.22 ;
+      RECT 3.85 0.62 3.92 1.115 ;
+      RECT 2.5 0.62 3.92 0.69 ;
+      RECT 3.76 0.285 3.83 0.69 ;
+      RECT 3.545 0.895 3.615 1.115 ;
+      RECT 3.175 0.895 3.245 1.115 ;
+      RECT 3.175 0.895 3.615 0.965 ;
+      RECT 2.635 0.755 2.705 1.07 ;
+      RECT 2.345 0.755 2.705 0.825 ;
+      RECT 2.345 0.485 2.415 0.825 ;
+      RECT 2.345 0.485 3.545 0.555 ;
+      RECT 2.825 0.3 2.895 0.555 ;
+      RECT 2.065 0.185 2.135 1.085 ;
+      RECT 1.09 0.495 2.135 0.63 ;
+      RECT 1.875 0.855 1.945 1.075 ;
+      RECT 1.505 0.855 1.575 1.075 ;
+      RECT 1.505 0.855 1.945 0.925 ;
+      RECT 0.955 0.925 1.26 0.995 ;
+      RECT 0.955 0.35 1.025 0.995 ;
+      RECT 0.595 0.555 1.025 0.625 ;
+      RECT 0.95 0.35 1.025 0.625 ;
+      RECT 0.95 0.35 1.9 0.425 ;
+      RECT 0.2 0.96 0.88 1.03 ;
+      RECT 0.2 0.265 0.27 1.03 ;
+      RECT 0.2 0.265 0.695 0.335 ;
+      RECT 4.45 0.185 4.52 1.25 ;
+  END
+END DFFRS_X1
+
+MACRO DFFRS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFRS_X2 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.485 0.28 4.69 0.46 ;
+        RECT 4.485 0.28 4.555 0.575 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.545 1.46 0.7 ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.545 1.27 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.62 0.54 4.72 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.625 0.4 0.7 0.965 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.2 0.32 0.965 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.59 0.765 4.66 1.485 ;
+        RECT 3.695 1.03 3.83 1.485 ;
+        RECT 3.195 0.765 3.265 1.485 ;
+        RECT 2.815 0.955 2.885 1.485 ;
+        RECT 2.055 0.955 2.125 1.485 ;
+        RECT 1.715 0.895 1.785 1.485 ;
+        RECT 1.335 1.08 1.405 1.485 ;
+        RECT 0.875 1.205 0.945 1.485 ;
+        RECT 0.425 1.205 0.495 1.485 ;
+        RECT 0.05 0.925 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.56 -0.085 4.695 0.215 ;
+        RECT 3.505 -0.085 3.64 0.285 ;
+        RECT 2.785 -0.085 2.92 0.285 ;
+        RECT 1.87 -0.085 1.94 0.32 ;
+        RECT 1.335 -0.085 1.405 0.32 ;
+        RECT 0.805 -0.085 0.875 0.2 ;
+        RECT 0.425 -0.085 0.495 0.2 ;
+        RECT 0.05 -0.085 0.12 0.415 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.05 1.18 4.39 1.25 ;
+      RECT 4.32 0.15 4.39 1.25 ;
+      RECT 2.325 1.14 2.64 1.21 ;
+      RECT 2.57 0.35 2.64 1.21 ;
+      RECT 4.05 0.76 4.12 1.25 ;
+      RECT 3.39 0.76 3.46 1.04 ;
+      RECT 3.39 0.76 4.12 0.83 ;
+      RECT 3.985 0.15 4.055 0.46 ;
+      RECT 3.35 0.35 4.055 0.42 ;
+      RECT 2.57 0.35 3.13 0.42 ;
+      RECT 3.06 0.185 3.13 0.42 ;
+      RECT 3.35 0.185 3.42 0.42 ;
+      RECT 3.06 0.185 3.42 0.255 ;
+      RECT 3.985 0.15 4.39 0.22 ;
+      RECT 4.185 0.62 4.255 1.115 ;
+      RECT 2.895 0.62 4.255 0.69 ;
+      RECT 4.13 0.285 4.2 0.69 ;
+      RECT 3.915 0.895 3.985 1.115 ;
+      RECT 3.545 0.895 3.615 1.115 ;
+      RECT 3.545 0.895 3.985 0.965 ;
+      RECT 3.005 0.755 3.075 1.04 ;
+      RECT 2.76 0.755 3.075 0.825 ;
+      RECT 2.76 0.485 2.83 0.825 ;
+      RECT 2.76 0.485 3.915 0.555 ;
+      RECT 3.195 0.32 3.265 0.555 ;
+      RECT 2.425 0.2 2.505 1.075 ;
+      RECT 1.58 0.58 2.505 0.65 ;
+      RECT 2.245 0.82 2.315 1.075 ;
+      RECT 1.875 0.82 1.945 1.075 ;
+      RECT 1.875 0.82 2.315 0.89 ;
+      RECT 1.065 0.845 1.63 0.915 ;
+      RECT 1.065 0.41 1.135 0.915 ;
+      RECT 0.84 0.525 1.135 0.66 ;
+      RECT 1.065 0.41 2.27 0.48 ;
+      RECT 1.715 0.205 1.785 0.48 ;
+      RECT 0.49 1.035 1.225 1.105 ;
+      RECT 0.49 0.265 0.56 1.105 ;
+      RECT 0.385 0.525 0.56 0.66 ;
+      RECT 0.49 0.265 1.065 0.335 ;
+      RECT 4.785 0.25 4.855 1.24 ;
+  END
+END DFFRS_X2
+
+MACRO DFFR_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFR_X1 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.6 0.56 0.72 0.745 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.455 0.64 2.89 0.71 ;
+        RECT 2.455 0.56 2.6 0.71 ;
+        RECT 2.105 1.18 2.525 1.25 ;
+        RECT 2.455 0.56 2.525 1.25 ;
+        RECT 2.105 0.93 2.175 1.25 ;
+        RECT 1.815 0.93 2.175 1 ;
+        RECT 1.495 1.165 1.885 1.235 ;
+        RECT 1.815 0.93 1.885 1.235 ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.175 0.42 0.32 0.56 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.66 0.185 3.74 1.25 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.285 0.4 3.36 1.25 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.465 0.975 3.535 1.485 ;
+        RECT 3.08 1.065 3.15 1.485 ;
+        RECT 2.7 0.98 2.77 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.295 1.03 1.43 1.485 ;
+        RECT 0.575 1.015 0.645 1.485 ;
+        RECT 0.23 1.065 0.3 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.465 -0.085 3.535 0.195 ;
+        RECT 2.7 -0.085 2.77 0.32 ;
+        RECT 1.895 -0.085 2.03 0.285 ;
+        RECT 1.515 -0.085 1.585 0.41 ;
+        RECT 0.575 -0.085 0.645 0.32 ;
+        RECT 0.23 -0.085 0.3 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.89 0.81 2.96 1.25 ;
+      RECT 2.59 0.81 3.185 0.88 ;
+      RECT 3.115 0.265 3.185 0.88 ;
+      RECT 3.525 0.265 3.595 0.66 ;
+      RECT 3.05 0.265 3.595 0.335 ;
+      RECT 2.32 0.185 2.39 1.115 ;
+      RECT 2.98 0.425 3.05 0.66 ;
+      RECT 2.32 0.425 3.05 0.495 ;
+      RECT 1.68 0.76 1.75 0.96 ;
+      RECT 1.19 0.76 2.255 0.83 ;
+      RECT 2.185 0.35 2.255 0.83 ;
+      RECT 1.69 0.35 2.255 0.42 ;
+      RECT 1.69 0.185 1.76 0.42 ;
+      RECT 0.42 0.185 0.49 1.25 ;
+      RECT 0.82 0.15 0.89 0.785 ;
+      RECT 1.985 0.485 2.12 0.67 ;
+      RECT 1.09 0.485 2.12 0.555 ;
+      RECT 0.42 0.425 0.89 0.495 ;
+      RECT 1.09 0.15 1.16 0.555 ;
+      RECT 0.82 0.15 1.16 0.22 ;
+      RECT 0.955 0.29 1.025 1.125 ;
+      RECT 0.955 0.625 1.895 0.695 ;
+      RECT 1.135 0.895 1.205 1.125 ;
+      RECT 1.495 1.025 1.63 1.095 ;
+      RECT 1.495 0.895 1.565 1.095 ;
+      RECT 1.135 0.895 1.565 0.965 ;
+      RECT 0.04 0.185 0.11 1.25 ;
+      RECT 0.04 0.7 0.355 0.835 ;
+  END
+END DFFR_X1
+
+MACRO DFFR_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFR_X2 0 0 ;
+  SIZE 4.18 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.52 0.74 0.7 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.52 0.56 2.905 0.7 ;
+        RECT 2.17 1.15 2.59 1.22 ;
+        RECT 2.52 0.56 2.59 1.22 ;
+        RECT 2.17 0.965 2.24 1.22 ;
+        RECT 1.835 0.965 2.24 1.035 ;
+        RECT 1.515 1.165 1.905 1.235 ;
+        RECT 1.835 0.965 1.905 1.235 ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.42 0.32 0.56 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.86 0.185 3.935 1.08 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.41 0.645 3.55 0.785 ;
+        RECT 3.48 0.185 3.55 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.18 1.485 ;
+        RECT 4.05 1.065 4.12 1.485 ;
+        RECT 3.67 1.065 3.74 1.485 ;
+        RECT 3.19 1.065 3.26 1.485 ;
+        RECT 2.725 1 2.86 1.485 ;
+        RECT 1.97 1.1 2.105 1.485 ;
+        RECT 1.315 1.03 1.45 1.485 ;
+        RECT 0.59 1.015 0.66 1.485 ;
+        RECT 0.245 0.945 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.18 0.085 ;
+        RECT 4.05 -0.085 4.12 0.335 ;
+        RECT 3.67 -0.085 3.74 0.335 ;
+        RECT 3.295 -0.085 3.365 0.195 ;
+        RECT 2.69 -0.085 2.76 0.32 ;
+        RECT 1.9 -0.085 2.035 0.285 ;
+        RECT 1.535 -0.085 1.605 0.41 ;
+        RECT 0.59 -0.085 0.66 0.32 ;
+        RECT 0.245 -0.085 0.315 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.97 0.85 3.04 1.22 ;
+      RECT 2.655 0.85 3.79 0.92 ;
+      RECT 3.72 0.525 3.79 0.92 ;
+      RECT 3.07 0.4 3.14 0.92 ;
+      RECT 2.655 0.765 2.725 0.92 ;
+      RECT 2.375 0.215 2.445 1.085 ;
+      RECT 3.24 0.265 3.31 0.66 ;
+      RECT 2.375 0.385 2.95 0.455 ;
+      RECT 2.88 0.265 2.95 0.455 ;
+      RECT 2.88 0.265 3.31 0.335 ;
+      RECT 2.285 0.215 2.445 0.285 ;
+      RECT 1.7 0.76 1.77 0.96 ;
+      RECT 1.7 0.83 2.26 0.9 ;
+      RECT 2.19 0.35 2.26 0.9 ;
+      RECT 1.235 0.76 1.77 0.83 ;
+      RECT 1.75 0.35 2.26 0.42 ;
+      RECT 1.75 0.185 1.82 0.42 ;
+      RECT 0.44 0.185 0.51 0.98 ;
+      RECT 0.83 0.15 0.9 0.82 ;
+      RECT 2.055 0.485 2.125 0.705 ;
+      RECT 1.105 0.485 2.125 0.555 ;
+      RECT 1.105 0.15 1.175 0.555 ;
+      RECT 0.44 0.385 0.9 0.455 ;
+      RECT 0.83 0.15 1.175 0.22 ;
+      RECT 0.97 0.29 1.04 1.125 ;
+      RECT 1.85 0.625 1.925 0.765 ;
+      RECT 0.97 0.625 1.925 0.695 ;
+      RECT 1.155 0.895 1.225 1.125 ;
+      RECT 1.515 1.025 1.65 1.095 ;
+      RECT 1.515 0.895 1.585 1.095 ;
+      RECT 1.155 0.895 1.585 0.965 ;
+      RECT 0.06 0.185 0.13 1.22 ;
+      RECT 0.06 0.655 0.375 0.79 ;
+  END
+END DFFR_X2
+
+MACRO DFFS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFS_X1 0 0 ;
+  SIZE 3.8 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.34 0.56 0.51 0.7 ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.625 0.7 2.79 0.84 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.59 1.84 0.84 ;
+        RECT 1.705 0.59 1.84 0.725 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.575 0.56 3.74 0.7 ;
+        RECT 3.575 0.185 3.645 1.16 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.195 0.56 3.36 0.7 ;
+        RECT 3.195 0.185 3.265 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.8 1.485 ;
+        RECT 3.38 1.205 3.45 1.485 ;
+        RECT 2.855 1.005 2.925 1.485 ;
+        RECT 2.48 1.065 2.615 1.485 ;
+        RECT 1.755 0.905 1.825 1.485 ;
+        RECT 1.41 0.885 1.48 1.485 ;
+        RECT 1.015 0.94 1.085 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.8 0.085 ;
+        RECT 3.385 -0.085 3.455 0.46 ;
+        RECT 2.67 -0.085 2.805 0.34 ;
+        RECT 1.75 -0.085 1.82 0.375 ;
+        RECT 1.04 -0.085 1.11 0.32 ;
+        RECT 0.225 -0.085 0.295 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.01 0.995 3.505 1.065 ;
+      RECT 3.435 0.525 3.505 1.065 ;
+      RECT 3.01 0.42 3.08 1.065 ;
+      RECT 2.375 0.42 3.08 0.49 ;
+      RECT 2.905 0.185 2.975 0.49 ;
+      RECT 2.105 1.045 2.24 1.115 ;
+      RECT 2.17 0.29 2.24 1.115 ;
+      RECT 2.17 0.56 2.925 0.63 ;
+      RECT 2.105 0.29 2.24 0.36 ;
+      RECT 2.7 0.93 2.77 1.15 ;
+      RECT 2.33 0.93 2.4 1.15 ;
+      RECT 2.33 0.93 2.77 1 ;
+      RECT 1.57 0.815 1.67 1.09 ;
+      RECT 0.635 0.72 0.73 0.855 ;
+      RECT 1.57 0.15 1.64 1.09 ;
+      RECT 1.97 0.665 2.095 0.8 ;
+      RECT 0.635 0.42 0.705 0.855 ;
+      RECT 0.175 0.42 0.245 0.685 ;
+      RECT 1.97 0.15 2.04 0.8 ;
+      RECT 1.57 0.44 2.04 0.51 ;
+      RECT 0.175 0.42 0.705 0.49 ;
+      RECT 0.905 0.385 1.35 0.455 ;
+      RECT 1.28 0.15 1.35 0.455 ;
+      RECT 0.445 0.15 0.515 0.49 ;
+      RECT 0.905 0.15 0.975 0.455 ;
+      RECT 1.97 0.15 2.32 0.22 ;
+      RECT 1.28 0.15 1.64 0.22 ;
+      RECT 0.445 0.15 0.975 0.22 ;
+      RECT 1.22 0.75 1.29 1.09 ;
+      RECT 0.94 0.75 1.485 0.82 ;
+      RECT 1.415 0.285 1.485 0.82 ;
+      RECT 0.94 0.685 1.01 0.82 ;
+      RECT 0.59 0.975 0.865 1.045 ;
+      RECT 0.795 0.545 0.865 1.045 ;
+      RECT 1.28 0.545 1.35 0.685 ;
+      RECT 0.77 0.545 1.35 0.615 ;
+      RECT 0.77 0.285 0.84 0.615 ;
+      RECT 0.59 0.285 0.84 0.355 ;
+      RECT 0.04 0.185 0.11 1.16 ;
+      RECT 0.04 0.765 0.57 0.835 ;
+  END
+END DFFS_X1
+
+MACRO DFFS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFFS_X2 0 0 ;
+  SIZE 3.99 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.56 0.51 0.7 ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.675 0.56 2.79 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.59 1.84 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.1 0.4 3.17 0.925 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.48 0.4 3.55 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.99 1.485 ;
+        RECT 3.66 1.205 3.73 1.485 ;
+        RECT 3.285 1.205 3.355 1.485 ;
+        RECT 2.91 1.205 2.98 1.485 ;
+        RECT 2.53 1.065 2.665 1.485 ;
+        RECT 1.805 0.94 1.875 1.485 ;
+        RECT 1.46 0.94 1.53 1.485 ;
+        RECT 1.08 0.94 1.15 1.485 ;
+        RECT 0.235 0.94 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.99 0.085 ;
+        RECT 3.66 -0.085 3.73 0.195 ;
+        RECT 3.28 -0.085 3.35 0.195 ;
+        RECT 2.72 -0.085 2.855 0.34 ;
+        RECT 1.8 -0.085 1.87 0.32 ;
+        RECT 1.09 -0.085 1.16 0.37 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.85 0.26 3.92 1.215 ;
+      RECT 2.92 0.99 3.92 1.06 ;
+      RECT 3.235 0.525 3.305 1.06 ;
+      RECT 2.92 0.795 2.99 1.06 ;
+      RECT 2.45 0.795 2.99 0.865 ;
+      RECT 2.155 1.045 2.29 1.115 ;
+      RECT 2.22 0.29 2.29 1.115 ;
+      RECT 3.615 0.265 3.685 0.66 ;
+      RECT 2.22 0.405 3.035 0.475 ;
+      RECT 2.965 0.265 3.035 0.475 ;
+      RECT 2.155 0.29 2.29 0.36 ;
+      RECT 2.965 0.265 3.685 0.335 ;
+      RECT 2.75 0.93 2.82 1.15 ;
+      RECT 2.38 0.93 2.45 1.15 ;
+      RECT 2.38 0.93 2.82 1 ;
+      RECT 1.615 0.94 1.72 1.075 ;
+      RECT 1.615 0.15 1.685 1.075 ;
+      RECT 0.65 0.735 0.755 0.87 ;
+      RECT 2.02 0.665 2.145 0.8 ;
+      RECT 0.65 0.425 0.72 0.87 ;
+      RECT 0.19 0.425 0.26 0.695 ;
+      RECT 2.02 0.15 2.09 0.8 ;
+      RECT 1.615 0.455 2.09 0.525 ;
+      RECT 0.955 0.435 1.295 0.505 ;
+      RECT 1.225 0.15 1.295 0.505 ;
+      RECT 0.19 0.425 0.72 0.495 ;
+      RECT 0.955 0.15 1.025 0.505 ;
+      RECT 0.455 0.15 0.525 0.495 ;
+      RECT 2.02 0.15 2.395 0.22 ;
+      RECT 1.225 0.15 1.685 0.22 ;
+      RECT 0.455 0.15 1.025 0.22 ;
+      RECT 0.965 0.77 1.535 0.84 ;
+      RECT 1.465 0.285 1.535 0.84 ;
+      RECT 0.585 0.975 0.89 1.045 ;
+      RECT 0.82 0.285 0.89 1.045 ;
+      RECT 0.82 0.57 1.4 0.705 ;
+      RECT 0.59 0.285 0.89 0.355 ;
+      RECT 0.05 0.185 0.12 1.215 ;
+      RECT 0.05 0.765 0.585 0.835 ;
+  END
+END DFFS_X2
+
+MACRO DFF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFF_X1 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.53 0.97 0.7 ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.56 0.53 1.67 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.1 0.26 3.17 1.13 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.72 0.26 2.79 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 2.905 0.985 2.975 1.485 ;
+        RECT 2.345 1.1 2.48 1.485 ;
+        RECT 1.61 0.9 1.68 1.485 ;
+        RECT 1.005 1.08 1.075 1.485 ;
+        RECT 0.24 0.98 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 2.905 -0.085 2.975 0.46 ;
+        RECT 2.345 -0.085 2.48 0.37 ;
+        RECT 1.61 -0.085 1.68 0.36 ;
+        RECT 0.975 -0.085 1.11 0.3 ;
+        RECT 0.24 -0.085 0.31 0.405 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.57 0.225 2.64 1.115 ;
+      RECT 2.57 0.85 3.035 0.92 ;
+      RECT 2.965 0.525 3.035 0.92 ;
+      RECT 2.265 0.73 2.64 0.8 ;
+      RECT 2 0.285 2.07 1.2 ;
+      RECT 2 0.525 2.505 0.66 ;
+      RECT 1.14 1.18 1.495 1.25 ;
+      RECT 1.425 0.225 1.495 1.25 ;
+      RECT 0.485 1.18 0.94 1.25 ;
+      RECT 0.87 0.945 0.94 1.25 ;
+      RECT 1.14 0.945 1.21 1.25 ;
+      RECT 0.87 0.945 1.21 1.015 ;
+      RECT 1.425 0.765 1.925 0.835 ;
+      RECT 1.855 0.15 1.925 0.835 ;
+      RECT 1.855 0.15 2.205 0.22 ;
+      RECT 1.275 0.37 1.345 0.995 ;
+      RECT 0.38 0.15 0.45 0.545 ;
+      RECT 0.785 0.37 1.345 0.44 ;
+      RECT 1.2 0.27 1.27 0.44 ;
+      RECT 0.785 0.15 0.855 0.44 ;
+      RECT 0.38 0.15 0.855 0.22 ;
+      RECT 0.635 0.285 0.705 1.115 ;
+      RECT 0.635 0.765 1.19 0.835 ;
+      RECT 1.12 0.53 1.19 0.835 ;
+      RECT 0.06 0.27 0.13 1.13 ;
+      RECT 0.06 0.61 0.57 0.745 ;
+  END
+END DFF_X1
+
+MACRO DFF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DFF_X2 0 0 ;
+  SIZE 3.61 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.94 0.56 1.08 0.7 ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.57 0.56 1.65 0.7 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.29 0.25 3.36 1.115 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.25 2.98 0.925 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.61 1.485 ;
+        RECT 3.485 0.84 3.555 1.485 ;
+        RECT 3.105 1.205 3.175 1.485 ;
+        RECT 2.73 1.205 2.8 1.485 ;
+        RECT 2.35 0.875 2.485 1.485 ;
+        RECT 1.62 0.9 1.69 1.485 ;
+        RECT 1.015 1.08 1.085 1.485 ;
+        RECT 0.255 0.965 0.325 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.61 0.085 ;
+        RECT 3.485 -0.085 3.555 0.46 ;
+        RECT 3.105 -0.085 3.175 0.46 ;
+        RECT 2.73 -0.085 2.8 0.46 ;
+        RECT 2.35 -0.085 2.485 0.45 ;
+        RECT 1.62 -0.085 1.69 0.385 ;
+        RECT 0.985 -0.085 1.12 0.215 ;
+        RECT 0.255 -0.085 0.325 0.385 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.575 1.045 3.215 1.115 ;
+      RECT 3.145 0.525 3.215 1.115 ;
+      RECT 2.575 0.2 2.645 1.115 ;
+      RECT 2.245 0.735 2.645 0.805 ;
+      RECT 2.01 0.35 2.08 0.975 ;
+      RECT 2.01 0.525 2.51 0.66 ;
+      RECT 1.15 1.18 1.505 1.25 ;
+      RECT 1.435 0.25 1.505 1.25 ;
+      RECT 0.5 1.18 0.935 1.25 ;
+      RECT 0.865 0.945 0.935 1.25 ;
+      RECT 1.15 0.945 1.22 1.25 ;
+      RECT 0.865 0.945 1.22 1.015 ;
+      RECT 1.435 0.765 1.945 0.835 ;
+      RECT 1.875 0.215 1.945 0.835 ;
+      RECT 1.875 0.215 2.215 0.285 ;
+      RECT 1.285 0.285 1.355 1.115 ;
+      RECT 0.39 0.15 0.46 0.7 ;
+      RECT 0.825 0.285 1.355 0.355 ;
+      RECT 0.825 0.15 0.895 0.355 ;
+      RECT 0.39 0.15 0.895 0.22 ;
+      RECT 0.61 1 0.76 1.07 ;
+      RECT 0.69 0.285 0.76 1.07 ;
+      RECT 0.69 0.765 1.215 0.835 ;
+      RECT 1.145 0.565 1.215 0.835 ;
+      RECT 0.61 0.285 0.76 0.355 ;
+      RECT 0.075 0.325 0.145 1.055 ;
+      RECT 0.075 0.765 0.625 0.835 ;
+      RECT 0.555 0.565 0.625 0.835 ;
+  END
+END DFF_X2
+
+MACRO DLH_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLH_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.95 0.525 1.08 0.7 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.2 0.525 0.32 0.7 ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.185 0.51 0.785 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.595 1.025 1.665 1.485 ;
+        RECT 0.845 0.965 0.915 1.485 ;
+        RECT 0.25 0.985 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.595 -0.085 1.665 0.445 ;
+        RECT 0.805 -0.085 0.94 0.285 ;
+        RECT 0.25 -0.085 0.32 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.79 0.32 1.86 1.16 ;
+      RECT 1.485 0.525 1.86 0.595 ;
+      RECT 1.19 1.045 1.415 1.115 ;
+      RECT 1.345 0.35 1.415 1.115 ;
+      RECT 1.345 0.66 1.725 0.795 ;
+      RECT 0.785 0.35 0.855 0.66 ;
+      RECT 0.785 0.35 1.415 0.42 ;
+      RECT 1.025 1.18 1.43 1.25 ;
+      RECT 1.025 0.765 1.095 1.25 ;
+      RECT 0.65 0.185 0.72 1.115 ;
+      RECT 0.65 0.765 1.215 0.835 ;
+      RECT 1.145 0.49 1.215 0.835 ;
+      RECT 1.145 0.49 1.28 0.56 ;
+      RECT 0.505 1.18 0.78 1.25 ;
+      RECT 0.065 0.185 0.135 1.24 ;
+      RECT 0.505 0.85 0.575 1.25 ;
+      RECT 0.065 0.85 0.575 0.92 ;
+  END
+END DLH_X1
+
+MACRO DLH_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLH_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.135 0.525 1.27 0.7 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.18 0.525 0.32 0.7 ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.185 0.51 0.785 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.78 1.08 1.85 1.485 ;
+        RECT 1.03 1.04 1.1 1.485 ;
+        RECT 0.62 1 0.69 1.485 ;
+        RECT 0.24 1.055 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.78 -0.085 1.85 0.32 ;
+        RECT 1.03 -0.085 1.1 0.32 ;
+        RECT 0.62 -0.085 0.69 0.255 ;
+        RECT 0.24 -0.085 0.31 0.255 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.975 0.185 2.045 1.215 ;
+      RECT 1.705 0.495 2.045 0.63 ;
+      RECT 1.4 0.78 1.47 1.2 ;
+      RECT 1.4 0.78 1.91 0.875 ;
+      RECT 1.545 0.74 1.91 0.875 ;
+      RECT 0.985 0.78 1.91 0.85 ;
+      RECT 0.985 0.525 1.055 0.85 ;
+      RECT 1.545 0.185 1.615 0.875 ;
+      RECT 1.41 0.185 1.615 0.32 ;
+      RECT 0.82 0.975 0.92 1.25 ;
+      RECT 0.85 0.175 0.92 1.25 ;
+      RECT 1.405 0.39 1.475 0.67 ;
+      RECT 0.85 0.39 1.475 0.46 ;
+      RECT 0.82 0.175 0.92 0.31 ;
+      RECT 0.045 0.185 0.115 1.24 ;
+      RECT 0.045 0.85 0.78 0.92 ;
+      RECT 0.71 0.375 0.78 0.92 ;
+  END
+END DLH_X2
+
+MACRO DLL_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLL_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.56 0.43 0.7 ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.525 1.705 0.7 ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.26 1.46 0.84 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.575 1.04 1.645 1.485 ;
+        RECT 1.035 0.95 1.105 1.485 ;
+        RECT 0.275 0.915 0.345 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.575 -0.085 1.645 0.235 ;
+        RECT 1.035 -0.085 1.105 0.42 ;
+        RECT 0.275 -0.085 0.345 0.415 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.235 1.18 1.51 1.25 ;
+      RECT 1.44 0.905 1.51 1.25 ;
+      RECT 1.77 0.195 1.84 1.24 ;
+      RECT 1.44 0.905 1.84 0.975 ;
+      RECT 1.23 0.285 1.3 1.085 ;
+      RECT 0.9 0.775 1.3 0.845 ;
+      RECT 0.665 0.285 0.735 1.085 ;
+      RECT 0.665 0.525 1.165 0.66 ;
+      RECT 0.53 0.15 0.6 1.25 ;
+      RECT 0.095 0.28 0.165 1.085 ;
+      RECT 0.095 0.78 0.6 0.85 ;
+      RECT 0.53 0.15 0.845 0.22 ;
+  END
+END DLL_X1
+
+MACRO DLL_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN DLL_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.51 0.38 0.7 ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.525 1.89 0.7 ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.58 0.26 1.65 1.005 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.76 1.205 1.83 1.485 ;
+        RECT 1.385 1.205 1.455 1.485 ;
+        RECT 0.985 0.875 1.055 1.485 ;
+        RECT 0.225 0.9 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.76 -0.085 1.83 0.195 ;
+        RECT 1.385 -0.085 1.455 0.395 ;
+        RECT 0.985 -0.085 1.055 0.46 ;
+        RECT 0.225 -0.085 0.295 0.37 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.185 1.07 1.32 1.25 ;
+      RECT 1.955 0.195 2.025 1.24 ;
+      RECT 1.185 1.07 2.025 1.14 ;
+      RECT 1.19 0.325 1.26 1.005 ;
+      RECT 0.85 0.73 1.26 0.8 ;
+      RECT 0.615 0.335 0.685 1.015 ;
+      RECT 0.615 0.525 1.125 0.66 ;
+      RECT 0.045 0.3 0.115 1.145 ;
+      RECT 0.045 0.765 0.55 0.835 ;
+      RECT 0.48 0.195 0.55 0.835 ;
+      RECT 0.48 0.195 0.82 0.265 ;
+  END
+END DLL_X2
+
+MACRO FA_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN FA_X1 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.905 0.825 2.66 0.895 ;
+        RECT 2.53 0.7 2.66 0.895 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.34 0.42 2.47 0.56 ;
+        RECT 1.41 0.42 2.47 0.49 ;
+    END
+  END B
+  PIN CI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.555 2.275 0.625 ;
+        RECT 0.63 0.42 0.7 0.625 ;
+    END
+  END CI
+  PIN CO
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.195 0.135 1.215 ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.89 0.195 2.98 1.215 ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+        RECT 2.695 1.205 2.765 1.485 ;
+        RECT 1.705 1.095 1.84 1.485 ;
+        RECT 1.36 0.965 1.43 1.485 ;
+        RECT 1.015 1.095 1.085 1.485 ;
+        RECT 0.25 0.94 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+        RECT 2.665 -0.085 2.8 0.16 ;
+        RECT 1.705 -0.085 1.84 0.16 ;
+        RECT 1.36 -0.085 1.43 0.195 ;
+        RECT 1.025 -0.085 1.095 0.33 ;
+        RECT 0.25 -0.085 0.32 0.33 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.13 0.96 2.2 1.24 ;
+      RECT 2.13 0.96 2.82 1.03 ;
+      RECT 2.75 0.225 2.82 1.03 ;
+      RECT 2.1 0.225 2.82 0.295 ;
+      RECT 0.63 0.69 0.7 1.215 ;
+      RECT 0.495 0.69 2.115 0.76 ;
+      RECT 0.495 0.23 0.565 0.76 ;
+      RECT 0.205 0.525 0.565 0.66 ;
+      RECT 0.495 0.23 0.735 0.3 ;
+      RECT 1.93 0.96 2 1.24 ;
+      RECT 1.555 0.96 1.625 1.24 ;
+      RECT 1.555 0.96 2 1.03 ;
+      RECT 0.835 0.395 1.275 0.465 ;
+      RECT 1.205 0.195 1.275 0.465 ;
+      RECT 0.835 0.195 0.905 0.465 ;
+      RECT 1.205 0.96 1.275 1.235 ;
+      RECT 0.8 0.96 0.935 1.215 ;
+      RECT 0.8 0.96 1.275 1.03 ;
+      RECT 1.52 0.225 2.03 0.295 ;
+  END
+END FA_X1
+
+MACRO TAPCELL_X1
+  #CLASS CORE ;
+  CLASS CORE WELLTAP ;
+  ORIGIN 0 0 ;
+  FOREIGN TAPCELL_X1 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+        RECT 0.06 0.975 0.13 1.315 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+        RECT 0.06 0.085 0.13 0.425 ;
+    END
+  END VSS
+END TAPCELL_X1
+
+MACRO FILLCELL_X1
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X1 0 0 ;
+  SIZE 0.19 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END FILLCELL_X1
+
+MACRO FILLCELL_X16
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X16 0 0 ;
+  SIZE 3.04 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.04 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.04 0.085 ;
+    END
+  END VSS
+END FILLCELL_X16
+
+MACRO FILLCELL_X2
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X2 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.19 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.19 0.085 ;
+    END
+  END VSS
+END FILLCELL_X2
+
+MACRO FILLCELL_X32
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X32 0 0 ;
+  SIZE 6.08 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 6.08 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 6.08 0.085 ;
+    END
+  END VSS
+END FILLCELL_X32
+
+MACRO FILLCELL_X4
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X4 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+    END
+  END VSS
+END FILLCELL_X4
+
+MACRO FILLCELL_X8
+  #CLASS CORE ;
+  CLASS CORE SPACER ;
+  ORIGIN 0 0 ;
+  FOREIGN FILLCELL_X8 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+    END
+  END VSS
+END FILLCELL_X8
+
+MACRO HA_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN HA_X1 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.56 1.08 0.7 ;
+        RECT 0.67 0.56 1.08 0.63 ;
+        RECT 0.355 0.725 0.74 0.795 ;
+        RECT 0.67 0.56 0.74 0.795 ;
+        RECT 0.355 0.525 0.425 0.795 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.86 0.89 0.93 ;
+        RECT 0.805 0.7 0.89 0.93 ;
+        RECT 0.195 0.525 0.265 0.93 ;
+    END
+  END B
+  PIN CO
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.15 1.85 1.25 ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.29 0.525 0.36 ;
+        RECT 0.455 0.15 0.525 0.36 ;
+        RECT 0.06 0.995 0.37 1.065 ;
+        RECT 0.06 0.29 0.13 1.065 ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.59 1.08 1.66 1.485 ;
+        RECT 1.22 0.94 1.29 1.485 ;
+        RECT 0.645 1.08 0.715 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 1.59 -0.085 1.66 0.285 ;
+        RECT 1.03 -0.085 1.1 0.285 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.08 -0.085 0.15 0.225 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.4 0.15 1.47 1.115 ;
+      RECT 1.4 0.525 1.705 0.66 ;
+      RECT 1.22 0.15 1.47 0.285 ;
+      RECT 1.035 0.765 1.105 1.115 ;
+      RECT 1.035 0.765 1.25 0.835 ;
+      RECT 1.18 0.425 1.25 0.835 ;
+      RECT 0.535 0.425 0.605 0.66 ;
+      RECT 0.535 0.425 1.25 0.495 ;
+      RECT 0.84 0.15 0.91 0.495 ;
+      RECT 0.05 1.13 0.56 1.2 ;
+  END
+END HA_X1
+
+MACRO INV_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.165 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.23 0.15 0.325 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END INV_X1
+
+MACRO INV_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X16 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.095 1.05 3.095 1.12 ;
+        RECT 3.025 0.525 3.095 1.12 ;
+        RECT 2 0.525 2.07 1.12 ;
+        RECT 1.2 0.525 1.27 1.12 ;
+        RECT 0.095 0.525 0.165 1.12 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.885 0.15 2.955 0.985 ;
+        RECT 0.235 0.28 2.955 0.42 ;
+        RECT 2.505 0.15 2.575 0.985 ;
+        RECT 2.135 0.28 2.205 0.985 ;
+        RECT 2.125 0.15 2.195 0.42 ;
+        RECT 1.745 0.15 1.815 0.985 ;
+        RECT 1.365 0.15 1.435 0.985 ;
+        RECT 0.985 0.15 1.055 0.985 ;
+        RECT 0.605 0.16 0.675 0.985 ;
+        RECT 0.235 0.18 0.305 0.985 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.205 3.145 1.485 ;
+        RECT 2.695 1.205 2.765 1.485 ;
+        RECT 2.315 1.205 2.385 1.485 ;
+        RECT 1.935 1.205 2.005 1.485 ;
+        RECT 1.555 1.205 1.625 1.485 ;
+        RECT 1.175 1.205 1.245 1.485 ;
+        RECT 0.795 1.205 0.865 1.485 ;
+        RECT 0.415 1.205 0.485 1.485 ;
+        RECT 0.04 1.205 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 3.075 -0.085 3.145 0.365 ;
+        RECT 2.695 -0.085 2.765 0.21 ;
+        RECT 2.315 -0.085 2.385 0.21 ;
+        RECT 1.935 -0.085 2.005 0.21 ;
+        RECT 1.555 -0.085 1.625 0.21 ;
+        RECT 1.175 -0.085 1.245 0.21 ;
+        RECT 0.795 -0.085 0.865 0.21 ;
+        RECT 0.415 -0.085 0.485 0.21 ;
+        RECT 0.04 -0.085 0.11 0.365 ;
+    END
+  END VSS
+END INV_X16
+
+MACRO INV_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X2 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.15 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.43 -0.085 0.5 0.425 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END INV_X2
+
+MACRO INV_X32
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X32 0 0 ;
+  SIZE 6.27 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.115 0.93 5.85 1 ;
+        RECT 5.78 0.525 5.85 1 ;
+        RECT 4.62 0.525 4.69 1 ;
+        RECT 3.48 0.525 3.55 1 ;
+        RECT 2.34 0.525 2.41 1 ;
+        RECT 1.2 0.525 1.27 1 ;
+        RECT 0.115 0.525 0.185 1 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.945 0.16 6.015 1.005 ;
+        RECT 0.25 0.28 6.015 0.42 ;
+        RECT 5.56 0.16 5.63 0.865 ;
+        RECT 5.18 0.16 5.25 0.865 ;
+        RECT 4.81 0.28 4.88 0.865 ;
+        RECT 4.8 0.16 4.87 0.42 ;
+        RECT 4.42 0.16 4.49 0.865 ;
+        RECT 4.04 0.16 4.11 0.865 ;
+        RECT 3.665 0.16 3.735 0.865 ;
+        RECT 3.28 0.16 3.35 0.865 ;
+        RECT 2.9 0.16 2.97 0.865 ;
+        RECT 2.525 0.16 2.595 0.865 ;
+        RECT 2.14 0.16 2.21 0.865 ;
+        RECT 1.76 0.16 1.83 0.865 ;
+        RECT 1.39 0.16 1.46 0.865 ;
+        RECT 1 0.16 1.07 0.865 ;
+        RECT 0.62 0.16 0.69 0.865 ;
+        RECT 0.25 0.16 0.32 0.865 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 6.27 1.485 ;
+        RECT 6.13 1.065 6.2 1.485 ;
+        RECT 5.75 1.065 5.82 1.485 ;
+        RECT 5.37 1.065 5.44 1.485 ;
+        RECT 4.99 1.065 5.06 1.485 ;
+        RECT 4.61 1.065 4.68 1.485 ;
+        RECT 4.23 1.065 4.3 1.485 ;
+        RECT 3.85 1.065 3.92 1.485 ;
+        RECT 3.47 1.065 3.54 1.485 ;
+        RECT 3.09 1.065 3.16 1.485 ;
+        RECT 2.71 1.065 2.78 1.485 ;
+        RECT 2.33 1.065 2.4 1.485 ;
+        RECT 1.95 1.065 2.02 1.485 ;
+        RECT 1.57 1.065 1.64 1.485 ;
+        RECT 1.19 1.065 1.26 1.485 ;
+        RECT 0.81 1.065 0.88 1.485 ;
+        RECT 0.43 1.065 0.5 1.485 ;
+        RECT 0.055 1.065 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 6.27 0.085 ;
+        RECT 6.13 -0.085 6.2 0.335 ;
+        RECT 5.75 -0.085 5.82 0.195 ;
+        RECT 5.37 -0.085 5.44 0.195 ;
+        RECT 4.99 -0.085 5.06 0.195 ;
+        RECT 4.61 -0.085 4.68 0.195 ;
+        RECT 4.23 -0.085 4.3 0.195 ;
+        RECT 3.85 -0.085 3.92 0.195 ;
+        RECT 3.47 -0.085 3.54 0.195 ;
+        RECT 3.09 -0.085 3.16 0.195 ;
+        RECT 2.71 -0.085 2.78 0.195 ;
+        RECT 2.33 -0.085 2.4 0.195 ;
+        RECT 1.95 -0.085 2.02 0.195 ;
+        RECT 1.57 -0.085 1.64 0.195 ;
+        RECT 1.19 -0.085 1.26 0.195 ;
+        RECT 0.81 -0.085 0.88 0.195 ;
+        RECT 0.43 -0.085 0.5 0.195 ;
+        RECT 0.055 -0.085 0.125 0.335 ;
+    END
+  END VSS
+END INV_X32
+
+MACRO INV_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X4 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.685 1.04 ;
+        RECT 0.235 0.56 0.685 0.7 ;
+        RECT 0.61 0.15 0.685 0.7 ;
+        RECT 0.235 0.15 0.305 1.04 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.98 0.865 1.485 ;
+        RECT 0.415 0.98 0.485 1.485 ;
+        RECT 0.04 0.98 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.425 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END INV_X4
+
+MACRO INV_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN INV_X8 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.17 0.7 ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.15 1.445 1.04 ;
+        RECT 0.235 0.56 1.445 0.7 ;
+        RECT 0.985 0.15 1.055 1.04 ;
+        RECT 0.605 0.15 0.675 1.04 ;
+        RECT 0.235 0.15 0.305 1.04 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 0.97 1.625 1.485 ;
+        RECT 1.175 0.97 1.245 1.485 ;
+        RECT 0.795 0.97 0.865 1.485 ;
+        RECT 0.415 0.97 0.485 1.485 ;
+        RECT 0.04 0.97 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.36 ;
+        RECT 1.175 -0.085 1.245 0.36 ;
+        RECT 0.795 -0.085 0.865 0.36 ;
+        RECT 0.415 -0.085 0.485 0.36 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+END INV_X8
+
+MACRO LOGIC0_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN LOGIC0_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.15 0.13 0.84 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.245 1.115 0.315 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.24 -0.085 0.31 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 0.975 0.18 1.25 ;
+  END
+END LOGIC0_X1
+
+MACRO LOGIC1_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN LOGIC1_X1 0 0 ;
+  SIZE 0.38 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.56 0.13 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.38 1.485 ;
+        RECT 0.24 1.115 0.31 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.38 0.085 ;
+        RECT 0.245 -0.085 0.315 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.06 0.15 0.18 0.425 ;
+  END
+END LOGIC1_X1
+
+MACRO MUX2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN MUX2_X1 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.95 0.7 ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.595 0.835 ;
+        RECT 0.525 0.535 0.595 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.18 0.19 1.27 1.23 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 0.985 0.975 1.055 1.485 ;
+        RECT 0.225 1.035 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.985 -0.085 1.055 0.24 ;
+        RECT 0.225 -0.085 0.295 0.24 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.58 1.07 0.92 1.14 ;
+      RECT 0.85 0.84 0.92 1.14 ;
+      RECT 0.85 0.84 1.115 0.91 ;
+      RECT 1.045 0.39 1.115 0.91 ;
+      RECT 0.83 0.39 1.115 0.46 ;
+      RECT 0.83 0.22 0.9 0.46 ;
+      RECT 0.58 0.22 0.9 0.29 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 0.045 0.9 0.755 0.97 ;
+      RECT 0.685 0.39 0.755 0.97 ;
+      RECT 0.045 0.39 0.755 0.46 ;
+      RECT 0.045 0.19 0.115 0.46 ;
+  END
+END MUX2_X1
+
+MACRO MUX2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN MUX2_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.225 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.925 0.85 1.535 0.92 ;
+        RECT 1.465 0.525 1.535 0.92 ;
+        RECT 0.925 0.525 0.995 0.92 ;
+        RECT 0.77 0.525 0.995 0.7 ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.15 1.29 0.785 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.405 1.205 1.475 1.485 ;
+        RECT 1.035 1.205 1.105 1.485 ;
+        RECT 0.24 1.24 0.375 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.405 -0.085 1.475 0.285 ;
+        RECT 1.03 -0.085 1.1 0.285 ;
+        RECT 0.46 -0.085 0.53 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.6 0.15 1.67 1.25 ;
+      RECT 0.79 0.985 1.67 1.055 ;
+      RECT 0.79 0.765 0.86 1.055 ;
+      RECT 0.425 0.765 0.86 0.835 ;
+      RECT 0.425 0.525 0.495 0.835 ;
+      RECT 0.655 0.9 0.725 1.075 ;
+      RECT 0.29 0.9 0.725 0.97 ;
+      RECT 0.29 0.385 0.36 0.97 ;
+      RECT 1.065 0.385 1.135 0.66 ;
+      RECT 0.09 0.385 1.135 0.455 ;
+      RECT 0.845 0.15 0.915 0.455 ;
+      RECT 0.09 0.15 0.16 0.455 ;
+      RECT 0.46 1.175 0.955 1.245 ;
+      RECT 0.46 1.065 0.53 1.245 ;
+      RECT 0.09 1.065 0.53 1.135 ;
+      RECT 0.09 0.86 0.16 1.135 ;
+  END
+END MUX2_X2
+
+MACRO NAND2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.355 0.5 0.425 ;
+        RECT 0.43 0.15 0.5 0.425 ;
+        RECT 0.25 0.355 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.43 0.975 0.5 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END NAND2_X1
+
+MACRO NAND2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.77 0.81 0.84 ;
+        RECT 0.74 0.525 0.81 0.84 ;
+        RECT 0.25 0.525 0.32 0.84 ;
+        RECT 0.175 0.525 0.32 0.66 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.905 0.7 1.25 ;
+        RECT 0.04 0.905 0.7 0.975 ;
+        RECT 0.04 0.39 0.51 0.46 ;
+        RECT 0.44 0.15 0.51 0.46 ;
+        RECT 0.25 0.905 0.32 1.25 ;
+        RECT 0.04 0.39 0.11 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.82 1.04 0.89 1.485 ;
+        RECT 0.44 1.04 0.51 1.485 ;
+        RECT 0.065 1.04 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.82 -0.085 0.89 0.425 ;
+        RECT 0.065 -0.085 0.135 0.285 ;
+    END
+  END VSS
+END NAND2_X2
+
+MACRO NAND2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.14 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.38 0.525 0.51 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.35 1.475 1.07 ;
+        RECT 0.275 0.785 1.475 0.855 ;
+        RECT 1.39 0.35 1.475 0.855 ;
+        RECT 1 0.35 1.475 0.42 ;
+        RECT 1.025 0.785 1.095 1.07 ;
+        RECT 0.645 0.785 0.715 1.07 ;
+        RECT 0.275 0.785 0.345 1.07 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.04 1.665 1.485 ;
+        RECT 1.215 1.04 1.285 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.645 -0.085 0.715 0.285 ;
+        RECT 0.265 -0.085 0.335 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.595 0.15 1.665 0.425 ;
+      RECT 0.085 0.355 0.905 0.425 ;
+      RECT 0.835 0.15 0.905 0.425 ;
+      RECT 0.455 0.15 0.525 0.425 ;
+      RECT 0.085 0.15 0.155 0.425 ;
+      RECT 0.835 0.15 1.665 0.22 ;
+  END
+END NAND2_X4
+
+MACRO NAND3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.54 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.605 0.15 0.675 1.25 ;
+        RECT 0.235 0.8 0.675 0.87 ;
+        RECT 0.235 0.8 0.32 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NAND3_X1
+
+MACRO NAND3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.595 0.56 0.73 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.95 0.42 1.08 0.7 ;
+        RECT 0.38 0.42 1.08 0.49 ;
+        RECT 0.38 0.42 0.45 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 1.215 0.84 ;
+        RECT 1.145 0.525 1.215 0.84 ;
+        RECT 0.195 0.7 0.32 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.025 0.905 1.095 1.25 ;
+        RECT 0.06 0.905 1.095 0.975 ;
+        RECT 0.06 0.265 0.75 0.335 ;
+        RECT 0.645 0.905 0.715 1.25 ;
+        RECT 0.265 0.905 0.335 1.25 ;
+        RECT 0.06 0.265 0.13 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.215 1.04 1.285 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.335 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NAND3_X2
+
+MACRO NAND3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND3_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.66 0.555 1.89 0.625 ;
+        RECT 1.66 0.29 1.73 0.625 ;
+        RECT 0.82 0.29 1.73 0.36 ;
+        RECT 0.625 0.555 0.89 0.625 ;
+        RECT 0.82 0.29 0.89 0.625 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.525 0.69 2.13 0.76 ;
+        RECT 2.06 0.525 2.13 0.76 ;
+        RECT 1.525 0.425 1.595 0.76 ;
+        RECT 0.955 0.425 1.595 0.495 ;
+        RECT 0.38 0.69 1.08 0.76 ;
+        RECT 0.955 0.425 1.08 0.76 ;
+        RECT 0.38 0.525 0.45 0.76 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.19 0.825 2.3 0.895 ;
+        RECT 2.23 0.525 2.3 0.895 ;
+        RECT 1.19 0.56 1.325 0.895 ;
+        RECT 0.19 0.525 0.26 0.895 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.055 0.98 2.435 1.05 ;
+        RECT 2.365 0.355 2.435 1.05 ;
+        RECT 1.795 0.355 2.435 0.425 ;
+        RECT 2.165 0.98 2.235 1.22 ;
+        RECT 0.265 0.98 2.235 1.12 ;
+        RECT 1.795 0.15 1.865 0.425 ;
+        RECT 1.785 0.98 1.855 1.22 ;
+        RECT 1.405 0.98 1.475 1.22 ;
+        RECT 1.025 0.98 1.095 1.22 ;
+        RECT 0.645 0.98 0.715 1.22 ;
+        RECT 0.055 0.355 0.715 0.425 ;
+        RECT 0.645 0.15 0.715 0.425 ;
+        RECT 0.265 0.98 0.335 1.22 ;
+        RECT 0.055 0.355 0.125 1.05 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 1.17 2.425 1.485 ;
+        RECT 1.945 1.205 2.08 1.485 ;
+        RECT 1.565 1.205 1.7 1.485 ;
+        RECT 1.185 1.205 1.32 1.485 ;
+        RECT 0.805 1.195 0.94 1.485 ;
+        RECT 0.425 1.195 0.56 1.485 ;
+        RECT 0.08 1.16 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.195 ;
+        RECT 1.215 -0.085 1.285 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NAND3_X4
+
+MACRO NAND4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.42 0.555 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.42 0.375 0.66 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.42 0.185 0.66 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.355 0.865 0.425 ;
+        RECT 0.795 0.15 0.865 0.425 ;
+        RECT 0.615 0.84 0.7 1.25 ;
+        RECT 0.63 0.355 0.7 1.25 ;
+        RECT 0.235 0.84 0.7 0.91 ;
+        RECT 0.235 0.84 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 0.975 0.485 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.04 -0.085 0.11 0.355 ;
+    END
+  END VSS
+END NAND4_X1
+
+MACRO NAND4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.42 0.945 0.625 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.285 1.27 0.66 ;
+        RECT 0.575 0.285 1.27 0.355 ;
+        RECT 0.575 0.285 0.645 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.39 0.725 1.405 0.795 ;
+        RECT 1.335 0.525 1.405 0.795 ;
+        RECT 0.39 0.525 0.51 0.795 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.86 1.59 0.93 ;
+        RECT 1.52 0.525 1.59 0.93 ;
+        RECT 0.195 0.525 0.32 0.93 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.375 0.995 1.51 1.25 ;
+        RECT 0.06 0.995 1.51 1.065 ;
+        RECT 0.995 0.995 1.13 1.25 ;
+        RECT 0.285 0.15 0.94 0.22 ;
+        RECT 0.615 0.995 0.75 1.25 ;
+        RECT 0.235 0.995 0.37 1.25 ;
+        RECT 0.06 0.39 0.355 0.46 ;
+        RECT 0.285 0.15 0.355 0.46 ;
+        RECT 0.06 0.39 0.13 1.065 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.065 1.665 1.485 ;
+        RECT 1.215 1.13 1.285 1.485 ;
+        RECT 0.835 1.13 0.905 1.485 ;
+        RECT 0.455 1.13 0.525 1.485 ;
+        RECT 0.08 1.13 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.39 ;
+        RECT 0.08 -0.085 0.15 0.25 ;
+    END
+  END VSS
+END NAND4_X2
+
+MACRO NAND4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NAND4_X4 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.405 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.17 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.525 2.22 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.525 2.98 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.27 0.84 3.34 1.155 ;
+        RECT 0.09 0.84 3.34 0.98 ;
+        RECT 2.89 0.84 2.96 1.155 ;
+        RECT 2.51 0.84 2.58 1.155 ;
+        RECT 2.13 0.84 2.2 1.155 ;
+        RECT 1.68 0.84 1.75 1.155 ;
+        RECT 1.22 0.84 1.29 1.155 ;
+        RECT 0.84 0.84 0.91 1.155 ;
+        RECT 0.685 0.285 0.755 0.98 ;
+        RECT 0.225 0.285 0.755 0.355 ;
+        RECT 0.46 0.84 0.53 1.155 ;
+        RECT 0.09 0.84 0.16 1.155 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.05 1.095 3.185 1.485 ;
+        RECT 2.67 1.095 2.805 1.485 ;
+        RECT 2.29 1.095 2.425 1.485 ;
+        RECT 1.91 1.095 2.045 1.485 ;
+        RECT 1.38 1.095 1.515 1.485 ;
+        RECT 1 1.095 1.135 1.485 ;
+        RECT 0.62 1.095 0.755 1.485 ;
+        RECT 0.24 1.095 0.375 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.05 -0.085 3.185 0.3 ;
+        RECT 2.67 -0.085 2.805 0.3 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.51 0.39 3.34 0.46 ;
+      RECT 3.27 0.185 3.34 0.46 ;
+      RECT 1.76 0.15 1.83 0.46 ;
+      RECT 2.89 0.185 2.96 0.46 ;
+      RECT 2.51 0.15 2.58 0.46 ;
+      RECT 1.76 0.15 2.58 0.22 ;
+      RECT 1.38 0.525 2.045 0.595 ;
+      RECT 1.91 0.285 2.045 0.595 ;
+      RECT 1.38 0.285 1.515 0.595 ;
+      RECT 1.91 0.285 2.425 0.355 ;
+      RECT 1.005 0.285 1.515 0.355 ;
+      RECT 1.6 0.15 1.67 0.46 ;
+      RECT 0.84 0.15 0.91 0.46 ;
+      RECT 0.09 0.15 0.16 0.46 ;
+      RECT 0.09 0.15 1.67 0.22 ;
+  END
+END NAND4_X4
+
+MACRO NOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X1 0 0 ;
+  SIZE 0.57 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.43 0.975 0.5 1.25 ;
+        RECT 0.25 0.975 0.5 1.045 ;
+        RECT 0.25 0.15 0.32 1.045 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.57 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.57 0.085 ;
+        RECT 0.43 -0.085 0.5 0.425 ;
+        RECT 0.055 -0.085 0.125 0.425 ;
+    END
+  END VSS
+END NOR2_X1
+
+MACRO NOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.42 0.51 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.725 0.89 0.795 ;
+        RECT 0.76 0.525 0.89 0.795 ;
+        RECT 0.195 0.525 0.265 0.795 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.26 0.75 0.33 ;
+        RECT 0.455 0.91 0.525 1.25 ;
+        RECT 0.06 0.91 0.525 0.98 ;
+        RECT 0.06 0.26 0.13 0.98 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.835 1.045 0.905 1.485 ;
+        RECT 0.08 1.045 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.835 -0.085 0.905 0.335 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR2_X2
+
+MACRO NOR2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.09 0.42 1.16 0.66 ;
+        RECT 0.59 0.42 1.16 0.49 ;
+        RECT 0.59 0.42 0.7 0.66 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.215 0.91 1.535 0.98 ;
+        RECT 1.465 0.525 1.535 0.98 ;
+        RECT 0.805 0.56 0.94 0.98 ;
+        RECT 0.215 0.525 0.285 0.98 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.28 1.51 0.35 ;
+        RECT 1.225 0.28 1.295 0.845 ;
+        RECT 0.44 0.28 0.525 0.845 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.6 0.71 1.67 1.485 ;
+        RECT 0.835 1.045 0.905 1.485 ;
+        RECT 0.08 0.71 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.39 ;
+        RECT 1.215 -0.085 1.285 0.195 ;
+        RECT 0.835 -0.085 0.905 0.195 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.39 ;
+    END
+  END VSS
+END NOR2_X4
+
+MACRO NOR3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.545 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.175 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.15 0.7 1 ;
+        RECT 0.235 0.355 0.7 0.425 ;
+        RECT 0.235 0.15 0.305 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.22 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NOR3_X1
+
+MACRO NOR3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.62 0.56 0.755 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.92 0.425 0.99 0.66 ;
+        RECT 0.39 0.425 0.99 0.495 ;
+        RECT 0.39 0.425 0.51 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 1.27 0.84 ;
+        RECT 1.145 0.525 1.27 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.285 1.13 0.355 ;
+        RECT 0.645 0.905 0.715 1.18 ;
+        RECT 0.06 0.905 0.715 0.975 ;
+        RECT 0.06 0.285 0.13 0.975 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.215 1.065 1.285 1.485 ;
+        RECT 0.08 1.065 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.215 -0.085 1.285 0.335 ;
+        RECT 0.835 -0.085 0.905 0.195 ;
+        RECT 0.455 -0.085 0.525 0.195 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR3_X2
+
+MACRO NOR3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR3_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.185 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.13 0.525 2.23 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.39 2.38 0.46 ;
+        RECT 2.31 0.15 2.38 0.46 ;
+        RECT 1.93 0.15 2 0.46 ;
+        RECT 1.365 0.15 1.435 0.46 ;
+        RECT 0.985 0.15 1.055 0.46 ;
+        RECT 0.605 0.765 0.675 1.115 ;
+        RECT 0.605 0.15 0.675 0.46 ;
+        RECT 0.235 0.765 0.675 0.835 ;
+        RECT 0.235 0.39 0.32 0.835 ;
+        RECT 0.235 0.15 0.305 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.5 0.9 2.57 1.485 ;
+        RECT 2.09 0.935 2.225 1.485 ;
+        RECT 1.745 0.9 1.815 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.505 -0.085 2.575 0.425 ;
+        RECT 2.09 -0.085 2.225 0.325 ;
+        RECT 1.525 -0.085 1.85 0.325 ;
+        RECT 1.145 -0.085 1.28 0.325 ;
+        RECT 0.765 -0.085 0.9 0.325 ;
+        RECT 0.385 -0.085 0.52 0.325 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.31 0.765 2.38 1.175 ;
+      RECT 1.93 0.765 2 1.175 ;
+      RECT 1.365 0.765 1.435 1.115 ;
+      RECT 0.995 0.765 1.065 1.115 ;
+      RECT 0.995 0.765 2.38 0.835 ;
+      RECT 0.045 1.18 1.625 1.25 ;
+      RECT 1.555 0.9 1.625 1.25 ;
+      RECT 1.175 0.9 1.245 1.25 ;
+      RECT 0.795 0.9 0.865 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+  END
+END NOR3_X4
+
+MACRO NOR4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.975 0.865 1.25 ;
+        RECT 0.63 0.975 0.865 1.045 ;
+        RECT 0.63 0.15 0.7 1.045 ;
+        RECT 0.235 0.355 0.7 0.425 ;
+        RECT 0.61 0.15 0.7 0.425 ;
+        RECT 0.235 0.15 0.305 0.425 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.04 0.975 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+END NOR4_X1
+
+MACRO NOR4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.81 0.56 0.945 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.11 0.42 1.18 0.66 ;
+        RECT 0.57 0.42 1.18 0.49 ;
+        RECT 0.57 0.42 0.7 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.38 0.765 1.46 0.835 ;
+        RECT 1.33 0.525 1.46 0.835 ;
+        RECT 0.38 0.525 0.45 0.835 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.2 0.91 1.65 0.98 ;
+        RECT 1.525 0.84 1.65 0.98 ;
+        RECT 1.525 0.525 1.595 0.98 ;
+        RECT 0.2 0.525 0.27 0.98 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.405 0.15 1.475 0.425 ;
+        RECT 0.055 0.26 1.475 0.33 ;
+        RECT 0.055 1.055 0.94 1.125 ;
+        RECT 0.055 0.26 0.13 1.125 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.065 1.665 1.485 ;
+        RECT 0.08 1.205 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.185 -0.085 1.32 0.16 ;
+        RECT 0.805 -0.085 0.94 0.16 ;
+        RECT 0.425 -0.085 0.56 0.16 ;
+        RECT 0.08 -0.085 0.15 0.195 ;
+    END
+  END VSS
+END NOR4_X2
+
+MACRO NOR4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN NOR4_X4 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.51 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.18 0.525 1.27 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.525 2.245 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.525 3 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.39 3.375 0.46 ;
+        RECT 3.305 0.15 3.375 0.46 ;
+        RECT 2.925 0.15 2.995 0.46 ;
+        RECT 2.545 0.15 2.615 0.46 ;
+        RECT 2.165 0.15 2.235 0.46 ;
+        RECT 1.79 0.15 1.86 0.46 ;
+        RECT 1.37 0.15 1.44 0.46 ;
+        RECT 0.985 0.15 1.055 0.46 ;
+        RECT 0.605 0.765 0.675 1.115 ;
+        RECT 0.605 0.15 0.675 0.46 ;
+        RECT 0.235 0.765 0.675 0.835 ;
+        RECT 0.235 0.39 0.32 0.835 ;
+        RECT 0.235 0.15 0.305 1.115 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.085 0.935 3.22 1.485 ;
+        RECT 2.705 0.935 2.84 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.085 -0.085 3.22 0.325 ;
+        RECT 2.705 -0.085 2.84 0.325 ;
+        RECT 2.325 -0.085 2.46 0.325 ;
+        RECT 1.945 -0.085 2.08 0.325 ;
+        RECT 1.525 -0.085 1.66 0.325 ;
+        RECT 1.145 -0.085 1.28 0.325 ;
+        RECT 0.765 -0.085 0.9 0.325 ;
+        RECT 0.385 -0.085 0.52 0.325 ;
+        RECT 0.04 -0.085 0.11 0.36 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.305 0.765 3.375 1.175 ;
+      RECT 2.925 0.765 2.995 1.175 ;
+      RECT 2.545 0.765 2.615 1.175 ;
+      RECT 2.165 0.765 2.235 1.115 ;
+      RECT 1.795 0.765 1.865 1.115 ;
+      RECT 1.795 0.765 3.375 0.835 ;
+      RECT 0.995 1.18 2.425 1.25 ;
+      RECT 2.355 0.9 2.425 1.25 ;
+      RECT 1.975 0.9 2.045 1.25 ;
+      RECT 1.365 0.9 1.435 1.25 ;
+      RECT 0.995 0.9 1.065 1.25 ;
+      RECT 0.045 1.18 0.865 1.25 ;
+      RECT 0.795 0.765 0.865 1.25 ;
+      RECT 0.415 0.9 0.485 1.25 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 1.555 0.765 1.625 1.115 ;
+      RECT 1.175 0.765 1.245 1.115 ;
+      RECT 0.795 0.765 1.625 0.835 ;
+  END
+END NOR4_X4
+
+MACRO OAI211_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.79 0.525 0.89 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.4 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.835 0.78 0.905 1.055 ;
+        RECT 0.25 0.78 0.905 0.85 ;
+        RECT 0.455 0.78 0.525 1.055 ;
+        RECT 0.25 0.78 0.525 0.855 ;
+        RECT 0.25 0.285 0.335 0.855 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.645 1.04 0.715 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.835 -0.085 0.905 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.455 0.15 0.525 0.425 ;
+      RECT 0.085 0.15 0.155 0.425 ;
+      RECT 0.085 0.15 0.525 0.22 ;
+  END
+END OAI211_X1
+
+MACRO OAI211_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.765 0.755 0.835 ;
+        RECT 0.685 0.525 0.755 0.835 ;
+        RECT 0.185 0.525 0.32 0.835 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.53 0.7 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.19 0.525 1.29 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.96 0.77 1.65 0.84 ;
+        RECT 1.525 0.525 1.65 0.84 ;
+        RECT 0.96 0.525 1.03 0.84 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.39 1.51 0.46 ;
+        RECT 1.215 0.905 1.285 1.25 ;
+        RECT 0.27 0.905 1.285 0.975 ;
+        RECT 0.82 0.39 0.89 0.975 ;
+        RECT 0.645 0.905 0.715 1.25 ;
+        RECT 0.27 0.905 0.34 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.595 1.04 1.665 1.485 ;
+        RECT 0.835 1.04 0.905 1.485 ;
+        RECT 0.455 1.04 0.525 1.485 ;
+        RECT 0.08 1.04 0.15 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.45 -0.085 0.52 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.595 0.185 1.665 0.46 ;
+      RECT 0.08 0.39 0.66 0.46 ;
+      RECT 0.59 0.185 0.66 0.46 ;
+      RECT 0.08 0.185 0.15 0.46 ;
+      RECT 0.59 0.185 1.665 0.255 ;
+  END
+END OAI211_X2
+
+MACRO OAI211_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI211_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.39 1.52 0.66 ;
+        RECT 0.125 0.39 1.52 0.46 ;
+        RECT 0.805 0.39 0.875 0.66 ;
+        RECT 0.125 0.39 0.195 0.66 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.42 0.77 1.245 0.84 ;
+        RECT 1.175 0.525 1.245 0.84 ;
+        RECT 0.42 0.525 0.51 0.84 ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.77 2.8 0.84 ;
+        RECT 2.665 0.56 2.8 0.84 ;
+        RECT 1.91 0.56 2.045 0.84 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.965 0.425 3.035 0.66 ;
+        RECT 1.67 0.425 3.035 0.495 ;
+        RECT 2.31 0.425 2.41 0.7 ;
+        RECT 1.67 0.425 1.74 0.66 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.905 3.17 0.975 ;
+        RECT 3.1 0.29 3.17 0.975 ;
+        RECT 1.72 0.29 3.17 0.36 ;
+        RECT 2.695 0.905 2.765 1.25 ;
+        RECT 1.935 0.905 2.005 1.25 ;
+        RECT 1.365 0.905 1.435 1.25 ;
+        RECT 0.985 0.905 1.055 1.25 ;
+        RECT 0.605 0.905 0.675 1.25 ;
+        RECT 0.235 0.905 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.04 3.145 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 1.175 1.04 1.245 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 1.145 -0.085 1.28 0.16 ;
+        RECT 0.385 -0.085 0.52 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.225 1.625 0.295 ;
+      RECT 1.555 0.15 1.625 0.295 ;
+      RECT 0.045 0.15 0.115 0.295 ;
+      RECT 1.555 0.15 3.18 0.22 ;
+  END
+END OAI211_X4
+
+MACRO OAI21_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.525 0.51 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.765 0.51 1.25 ;
+        RECT 0.25 0.765 0.51 0.835 ;
+        RECT 0.25 0.285 0.32 0.835 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.63 0.975 0.7 1.485 ;
+        RECT 0.065 0.975 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.63 -0.085 0.7 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.44 0.15 0.51 0.425 ;
+      RECT 0.07 0.15 0.14 0.425 ;
+      RECT 0.07 0.15 0.51 0.22 ;
+  END
+END OAI21_X1
+
+MACRO OAI21_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.19 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.525 0.89 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.77 1.135 0.84 ;
+        RECT 1.065 0.525 1.135 0.84 ;
+        RECT 0.44 0.525 0.57 0.84 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.905 1.27 0.975 ;
+        RECT 1.2 0.355 1.27 0.975 ;
+        RECT 0.58 0.355 1.27 0.425 ;
+        RECT 0.795 0.905 0.865 1.25 ;
+        RECT 0.235 0.905 0.305 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 1.04 1.245 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.485 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.415 0.15 1.28 0.22 ;
+  END
+END OAI21_X2
+
+MACRO OAI21_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI21_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.43 0.525 0.515 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.15 0.69 2.04 0.76 ;
+        RECT 1.905 0.56 2.04 0.76 ;
+        RECT 1.15 0.56 1.285 0.76 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.42 2.275 0.66 ;
+        RECT 0.91 0.42 2.275 0.49 ;
+        RECT 1.525 0.42 1.66 0.625 ;
+        RECT 0.91 0.42 0.98 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 0.845 2.41 0.915 ;
+        RECT 2.34 0.285 2.41 0.915 ;
+        RECT 0.96 0.285 2.41 0.355 ;
+        RECT 1.935 0.845 2.005 1.19 ;
+        RECT 1.175 0.845 1.245 1.19 ;
+        RECT 0.605 0.845 0.675 1.19 ;
+        RECT 0.235 0.845 0.305 1.19 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.83 0.425 ;
+      RECT 0.76 0.15 0.83 0.425 ;
+      RECT 0.42 0.15 0.49 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.76 0.15 2.42 0.22 ;
+  END
+END OAI21_X4
+
+MACRO OAI221_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.74 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.985 0.85 1.055 1.25 ;
+        RECT 0.425 0.85 1.055 0.92 ;
+        RECT 0.805 0.4 0.89 0.92 ;
+        RECT 0.425 0.85 0.495 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.605 1.04 0.675 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.985 0.15 1.055 0.425 ;
+      RECT 0.615 0.15 0.685 0.425 ;
+      RECT 0.615 0.15 1.055 0.22 ;
+      RECT 0.045 0.355 0.485 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+  END
+END OAI221_X1
+
+MACRO OAI221_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X2 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.9 2.03 0.97 ;
+        RECT 1.93 0.525 2.03 0.97 ;
+        RECT 0.955 0.525 1.025 0.97 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.155 0.765 1.84 0.835 ;
+        RECT 1.715 0.525 1.84 0.835 ;
+        RECT 1.155 0.525 1.225 0.835 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.38 0.525 1.48 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.525 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 0.89 0.84 ;
+        RECT 0.76 0.525 0.89 0.84 ;
+        RECT 0.195 0.525 0.265 0.84 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.755 1.035 1.89 1.245 ;
+        RECT 0.06 1.035 1.89 1.105 ;
+        RECT 0.995 1.035 1.13 1.245 ;
+        RECT 0.06 0.39 0.75 0.46 ;
+        RECT 0.425 1.035 0.56 1.245 ;
+        RECT 0.06 0.39 0.13 1.105 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.975 1.065 2.045 1.485 ;
+        RECT 1.405 1.17 1.475 1.485 ;
+        RECT 0.835 1.17 0.905 1.485 ;
+        RECT 0.085 1.17 0.155 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.565 -0.085 1.7 0.19 ;
+        RECT 1.185 -0.085 1.32 0.19 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.975 0.15 2.045 0.425 ;
+      RECT 0.05 0.255 2.045 0.325 ;
+      RECT 1 0.39 1.89 0.46 ;
+  END
+END OAI221_X2
+
+MACRO OAI221_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI221_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.585 0.525 0.7 0.7 ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.775 0.525 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.155 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.245 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.395 0.525 0.51 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.165 0.185 2.235 1.25 ;
+        RECT 1.795 0.7 2.235 0.84 ;
+        RECT 1.795 0.185 1.865 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.355 0.975 2.425 1.485 ;
+        RECT 1.975 0.975 2.045 1.485 ;
+        RECT 1.595 0.975 1.665 1.485 ;
+        RECT 1.19 1.04 1.26 1.485 ;
+        RECT 0.47 1.04 0.54 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.355 -0.085 2.425 0.46 ;
+        RECT 1.975 -0.085 2.045 0.46 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.19 -0.085 1.26 0.2 ;
+        RECT 0.82 -0.085 0.955 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.415 0.185 1.485 1.25 ;
+      RECT 1.415 0.525 1.73 0.66 ;
+      RECT 0.66 0.775 0.73 1.12 ;
+      RECT 0.1 0.775 0.17 1.12 ;
+      RECT 0.1 0.775 1.35 0.845 ;
+      RECT 1.28 0.39 1.35 0.845 ;
+      RECT 0.29 0.39 1.35 0.46 ;
+      RECT 0.29 0.285 0.36 0.46 ;
+      RECT 0.67 0.255 1.11 0.325 ;
+      RECT 0.67 0.15 0.74 0.325 ;
+      RECT 0.47 0.15 0.54 0.285 ;
+      RECT 0.1 0.15 0.17 0.285 ;
+      RECT 0.1 0.15 0.54 0.22 ;
+  END
+END OAI221_X4
+
+MACRO OAI222_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.34 0.525 1.46 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.115 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.755 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.945 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.525 0.51 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.2 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.36 0.795 1.43 1.14 ;
+        RECT 0.52 0.795 1.43 0.865 ;
+        RECT 1.18 0.4 1.27 0.865 ;
+        RECT 0.52 0.795 0.59 1.14 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 0.98 1.04 1.05 1.485 ;
+        RECT 0.05 1.04 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 0.395 -0.085 0.53 0.19 ;
+        RECT 0.05 -0.085 0.12 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.575 0.39 1.05 0.46 ;
+      RECT 0.98 0.15 1.05 0.46 ;
+      RECT 1.36 0.15 1.43 0.425 ;
+      RECT 0.98 0.265 1.43 0.335 ;
+      RECT 0.245 0.15 0.315 0.425 ;
+      RECT 0.245 0.255 0.86 0.325 ;
+      RECT 0.79 0.15 0.86 0.325 ;
+  END
+END OAI222_X1
+
+MACRO OAI222_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X2 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.85 0.725 2.465 0.795 ;
+        RECT 2.34 0.525 2.465 0.795 ;
+        RECT 1.85 0.525 1.92 0.795 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.15 0.42 2.22 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.77 1.65 0.84 ;
+        RECT 1.525 0.525 1.65 0.84 ;
+        RECT 0.955 0.525 1.025 0.84 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.525 1.29 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.195 0.77 0.83 0.84 ;
+        RECT 0.76 0.525 0.83 0.84 ;
+        RECT 0.195 0.525 0.32 0.84 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.53 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.53 0.285 2.6 1.25 ;
+        RECT 0.09 0.905 2.6 0.975 ;
+        RECT 1.925 0.285 2.6 0.355 ;
+        RECT 1.605 0.905 1.675 1.25 ;
+        RECT 0.84 0.905 0.91 1.25 ;
+        RECT 0.09 0.905 0.16 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.14 1.04 2.21 1.485 ;
+        RECT 1.22 1.04 1.29 1.485 ;
+        RECT 0.46 1.04 0.53 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 0.65 -0.085 0.72 0.285 ;
+        RECT 0.27 -0.085 0.34 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.005 0.355 1.84 0.425 ;
+      RECT 1.77 0.15 1.84 0.425 ;
+      RECT 1.77 0.15 2.625 0.22 ;
+      RECT 0.09 0.355 0.91 0.425 ;
+      RECT 0.84 0.15 0.91 0.425 ;
+      RECT 0.465 0.15 0.535 0.425 ;
+      RECT 0.09 0.15 0.16 0.425 ;
+      RECT 0.84 0.15 1.705 0.22 ;
+  END
+END OAI222_X2
+
+MACRO OAI222_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI222_X4 0 0 ;
+  SIZE 2.66 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.56 0.9 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.495 0.56 0.7 0.7 ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.56 1.13 0.7 ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.195 0.56 1.33 0.7 ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.29 0.15 2.36 1.25 ;
+        RECT 1.915 0.56 2.36 0.7 ;
+        RECT 1.915 0.15 1.985 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.66 1.485 ;
+        RECT 2.475 0.975 2.545 1.485 ;
+        RECT 2.095 0.975 2.165 1.485 ;
+        RECT 1.715 0.975 1.785 1.485 ;
+        RECT 1.335 1.04 1.405 1.485 ;
+        RECT 0.415 1.03 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.66 0.085 ;
+        RECT 2.475 -0.085 2.545 0.425 ;
+        RECT 2.095 -0.085 2.165 0.425 ;
+        RECT 1.715 -0.085 1.785 0.335 ;
+        RECT 1.335 -0.085 1.405 0.22 ;
+        RECT 0.965 -0.085 1.035 0.22 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.535 0.15 1.605 1.16 ;
+      RECT 1.535 0.525 1.85 0.66 ;
+      RECT 0.88 0.785 0.95 1.075 ;
+      RECT 0.045 0.785 0.115 1.075 ;
+      RECT 0.045 0.785 1.465 0.855 ;
+      RECT 1.395 0.285 1.465 0.855 ;
+      RECT 0.2 0.285 1.465 0.355 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.045 0.15 0.9 0.22 ;
+      RECT 0.58 0.42 1.25 0.49 ;
+  END
+END OAI222_X4
+
+MACRO OAI22_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.575 0.525 0.7 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.39 0.725 0.46 ;
+        RECT 0.44 0.39 0.51 1.05 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.81 0.975 0.88 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.21 -0.085 0.345 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.81 0.185 0.88 0.46 ;
+      RECT 0.06 0.185 0.13 0.46 ;
+      RECT 0.06 0.245 0.88 0.315 ;
+  END
+END OAI22_X1
+
+MACRO OAI22_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.185 0.525 1.27 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.765 1.515 0.835 ;
+        RECT 1.445 0.525 1.515 0.835 ;
+        RECT 0.82 0.525 0.95 0.835 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.525 0.525 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.75 0.835 ;
+        RECT 0.68 0.525 0.75 0.835 ;
+        RECT 0.06 0.525 0.185 0.835 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.9 1.65 0.97 ;
+        RECT 1.58 0.39 1.65 0.97 ;
+        RECT 0.96 0.39 1.65 0.46 ;
+        RECT 1.185 0.9 1.255 1.25 ;
+        RECT 0.425 0.9 0.495 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.355 0.865 0.425 ;
+      RECT 0.795 0.15 0.865 0.425 ;
+      RECT 0.415 0.15 0.485 0.425 ;
+      RECT 0.045 0.15 0.115 0.425 ;
+      RECT 0.795 0.15 1.66 0.22 ;
+  END
+END OAI22_X2
+
+MACRO OAI22_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI22_X4 0 0 ;
+  SIZE 3.23 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.91 0.725 2.805 0.795 ;
+        RECT 2.67 0.56 2.805 0.795 ;
+        RECT 1.91 0.56 2.045 0.795 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.91 0.425 3.035 0.7 ;
+        RECT 1.645 0.425 3.035 0.495 ;
+        RECT 2.32 0.425 2.39 0.66 ;
+        RECT 1.645 0.425 1.715 0.66 ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.385 0.725 1.28 0.795 ;
+        RECT 1.145 0.56 1.28 0.795 ;
+        RECT 0.385 0.56 0.52 0.795 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.39 0.425 1.52 0.7 ;
+        RECT 0.15 0.425 1.52 0.495 ;
+        RECT 0.795 0.425 0.865 0.66 ;
+        RECT 0.15 0.425 0.22 0.66 ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.865 3.17 0.935 ;
+        RECT 3.1 0.29 3.17 0.935 ;
+        RECT 1.72 0.29 3.17 0.36 ;
+        RECT 2.695 0.865 2.765 1.21 ;
+        RECT 1.935 0.865 2.005 1.21 ;
+        RECT 1.175 0.865 1.245 1.21 ;
+        RECT 0.425 0.865 0.495 1.21 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.23 1.485 ;
+        RECT 3.075 1.04 3.145 1.485 ;
+        RECT 2.315 1.04 2.385 1.485 ;
+        RECT 1.555 1.04 1.625 1.485 ;
+        RECT 0.795 1.04 0.865 1.485 ;
+        RECT 0.04 1.04 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.23 0.085 ;
+        RECT 1.365 -0.085 1.435 0.195 ;
+        RECT 0.985 -0.085 1.055 0.195 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.26 1.595 0.33 ;
+      RECT 1.525 0.15 1.595 0.33 ;
+      RECT 0.045 0.185 0.115 0.33 ;
+      RECT 1.525 0.15 3.18 0.22 ;
+  END
+END OAI22_X4
+
+MACRO OAI33_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OAI33_X1 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.765 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.955 0.525 1.08 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.525 1.27 0.7 ;
+    END
+  END A3
+  PIN B1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END B2
+  PIN B3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END B3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.365 1.26 0.435 ;
+        RECT 1.19 0.15 1.26 0.435 ;
+        RECT 0.63 0.365 0.7 1 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.19 0.975 1.26 1.485 ;
+        RECT 0.055 0.975 0.125 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 0.4 -0.085 0.535 0.16 ;
+        RECT 0.055 -0.085 0.125 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.215 0.225 1.105 0.295 ;
+  END
+END OAI33_X1
+
+MACRO OR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.15 0.7 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.415 0.965 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.54 0.9 ;
+      RECT 0.47 0.35 0.54 0.9 ;
+      RECT 0.235 0.35 0.54 0.42 ;
+      RECT 0.235 0.15 0.305 0.42 ;
+  END
+END OR2_X1
+
+MACRO OR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X2 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.615 0.15 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+        RECT 0.415 1.04 0.485 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.795 -0.085 0.865 0.425 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.905 0.115 1.25 ;
+      RECT 0.045 0.905 0.545 0.975 ;
+      RECT 0.475 0.355 0.545 0.975 ;
+      RECT 0.235 0.355 0.545 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR2_X2
+
+MACRO OR2_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR2_X4 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.76 0.835 ;
+        RECT 0.69 0.525 0.76 0.835 ;
+        RECT 0.06 0.525 0.15 0.835 ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.15 1.435 1.095 ;
+        RECT 0.995 0.56 1.435 0.7 ;
+        RECT 0.995 0.15 1.075 0.7 ;
+        RECT 0.995 0.15 1.065 1.095 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.555 1.035 1.625 1.485 ;
+        RECT 1.175 1.035 1.245 1.485 ;
+        RECT 0.795 1.035 0.865 1.485 ;
+        RECT 0.04 1.035 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.555 -0.085 1.625 0.425 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.425 0.9 0.495 1.25 ;
+      RECT 0.425 0.9 0.925 0.97 ;
+      RECT 0.855 0.355 0.925 0.97 ;
+      RECT 0.235 0.355 0.925 0.425 ;
+      RECT 0.605 0.15 0.675 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR2_X4
+
+MACRO OR3_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X1 0 0 ;
+  SIZE 0.95 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.15 0.89 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.95 1.485 ;
+        RECT 0.605 0.965 0.675 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.95 0.085 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.73 0.9 ;
+      RECT 0.66 0.35 0.73 0.9 ;
+      RECT 0.045 0.35 0.73 0.42 ;
+      RECT 0.415 0.15 0.485 0.42 ;
+      RECT 0.045 0.15 0.115 0.42 ;
+  END
+END OR3_X1
+
+MACRO OR3_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X2 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.57 0.7 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.15 0.89 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.985 0.975 1.055 1.485 ;
+        RECT 0.605 0.975 0.675 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.985 -0.085 1.055 0.425 ;
+        RECT 0.605 -0.085 0.675 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.73 0.91 ;
+      RECT 0.66 0.39 0.73 0.91 ;
+      RECT 0.045 0.39 0.73 0.46 ;
+      RECT 0.415 0.15 0.485 0.46 ;
+      RECT 0.045 0.15 0.115 0.46 ;
+  END
+END OR3_X2
+
+MACRO OR3_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR3_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.61 0.56 0.745 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.915 0.42 0.985 0.66 ;
+        RECT 0.375 0.42 0.985 0.49 ;
+        RECT 0.375 0.42 0.51 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.77 1.2 0.84 ;
+        RECT 1.13 0.525 1.2 0.84 ;
+        RECT 0.185 0.7 0.32 0.84 ;
+        RECT 0.185 0.525 0.255 0.84 ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.79 0.26 1.86 1.25 ;
+        RECT 1.415 0.56 1.86 0.7 ;
+        RECT 1.415 0.26 1.485 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.975 1.035 2.045 1.485 ;
+        RECT 1.595 1.035 1.665 1.485 ;
+        RECT 1.21 1.045 1.28 1.485 ;
+        RECT 0.075 1.035 0.145 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.975 -0.085 2.045 0.335 ;
+        RECT 1.595 -0.085 1.665 0.335 ;
+        RECT 1.21 -0.085 1.28 0.195 ;
+        RECT 0.83 -0.085 0.9 0.195 ;
+        RECT 0.45 -0.085 0.52 0.195 ;
+        RECT 0.075 -0.085 0.145 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.65 0.91 0.72 1.25 ;
+      RECT 0.65 0.91 1.35 0.98 ;
+      RECT 1.28 0.26 1.35 0.98 ;
+      RECT 0.235 0.26 1.35 0.33 ;
+  END
+END OR3_X4
+
+MACRO OR4_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.99 0.15 1.08 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.795 0.965 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.83 0.115 1.24 ;
+      RECT 0.045 0.83 0.92 0.9 ;
+      RECT 0.85 0.35 0.92 0.9 ;
+      RECT 0.235 0.35 0.92 0.42 ;
+      RECT 0.605 0.15 0.675 0.42 ;
+      RECT 0.235 0.15 0.305 0.42 ;
+  END
+END OR4_X1
+
+MACRO OR4_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X2 0 0 ;
+  SIZE 1.33 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.525 0.375 0.7 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.525 0.565 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.76 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.995 0.15 1.08 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.33 1.485 ;
+        RECT 1.175 0.975 1.245 1.485 ;
+        RECT 0.795 0.975 0.865 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.33 0.085 ;
+        RECT 1.175 -0.085 1.245 0.425 ;
+        RECT 0.795 -0.085 0.865 0.285 ;
+        RECT 0.415 -0.085 0.485 0.285 ;
+        RECT 0.04 -0.085 0.11 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.045 0.84 0.115 1.25 ;
+      RECT 0.045 0.84 0.925 0.91 ;
+      RECT 0.855 0.355 0.925 0.91 ;
+      RECT 0.235 0.355 0.925 0.425 ;
+      RECT 0.605 0.15 0.675 0.425 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+  END
+END OR4_X2
+
+MACRO OR4_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN OR4_X4 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A1
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.525 0.89 0.7 ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.39 1.14 0.66 ;
+        RECT 0.505 0.39 1.14 0.46 ;
+        RECT 0.505 0.39 0.575 0.66 ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.31 0.77 1.33 0.84 ;
+        RECT 1.26 0.525 1.33 0.84 ;
+        RECT 0.31 0.525 0.38 0.84 ;
+        RECT 0.25 0.525 0.38 0.7 ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.115 0.905 1.52 0.975 ;
+        RECT 1.45 0.525 1.52 0.975 ;
+        RECT 0.115 0.525 0.185 0.975 ;
+        RECT 0.06 0.525 0.185 0.7 ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.13 0.15 2.2 1.25 ;
+        RECT 1.755 0.56 2.2 0.7 ;
+        RECT 1.755 0.15 1.825 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 2.315 1.045 2.385 1.485 ;
+        RECT 1.935 1.045 2.005 1.485 ;
+        RECT 1.555 1.205 1.625 1.485 ;
+        RECT 0.04 1.045 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 2.315 -0.085 2.385 0.4 ;
+        RECT 1.905 -0.085 2.04 0.365 ;
+        RECT 1.525 -0.085 1.66 0.325 ;
+        RECT 1.145 -0.085 1.28 0.16 ;
+        RECT 0.765 -0.085 0.9 0.16 ;
+        RECT 0.385 -0.085 0.52 0.16 ;
+        RECT 0.04 -0.085 0.11 0.4 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.77 1.04 1.685 1.11 ;
+      RECT 1.615 0.39 1.685 1.11 ;
+      RECT 1.37 0.39 1.685 0.46 ;
+      RECT 0.235 0.15 0.305 0.425 ;
+      RECT 1.37 0.15 1.44 0.46 ;
+      RECT 0.235 0.225 1.44 0.295 ;
+  END
+END OR4_X4
+
+MACRO SDFFRS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFRS_X1 0 0 ;
+  SIZE 5.51 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.07 0.765 5.26 0.98 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.92 0.7 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.19 0.39 5.335 0.56 ;
+        RECT 4.76 0.39 5.335 0.46 ;
+        RECT 4.76 0.765 5.005 0.835 ;
+        RECT 4.76 0.39 4.83 0.835 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.56 0.695 4.69 0.84 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.11 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.575 0.7 1.67 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.045 0.26 0.13 1.105 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.36 0.51 0.8 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.51 1.485 ;
+        RECT 5.175 1.095 5.31 1.485 ;
+        RECT 4.415 1.13 4.55 1.485 ;
+        RECT 3.585 1.03 3.72 1.485 ;
+        RECT 3.045 0.865 3.18 1.485 ;
+        RECT 2.665 0.99 2.8 1.485 ;
+        RECT 1.945 0.83 2.015 1.485 ;
+        RECT 1.305 1.105 1.44 1.485 ;
+        RECT 0.925 1.105 1.06 1.485 ;
+        RECT 0.545 1.035 0.68 1.485 ;
+        RECT 0.195 1.18 0.33 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.51 0.085 ;
+        RECT 5.175 -0.085 5.31 0.225 ;
+        RECT 4.415 -0.085 4.55 0.225 ;
+        RECT 3.4 -0.085 3.535 0.285 ;
+        RECT 2.665 -0.085 2.8 0.285 ;
+        RECT 1.755 -0.085 1.825 0.32 ;
+        RECT 0.92 -0.085 1.055 0.285 ;
+        RECT 0.195 -0.085 0.33 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 5.4 0.215 5.47 1.235 ;
+      RECT 4.9 0.625 5.47 0.695 ;
+      RECT 4.9 0.56 4.975 0.695 ;
+      RECT 4.37 0.945 4.93 1.015 ;
+      RECT 4.37 0.41 4.44 1.015 ;
+      RECT 4.37 0.41 4.685 0.48 ;
+      RECT 4.615 0.22 4.685 0.48 ;
+      RECT 4.615 0.22 4.93 0.29 ;
+      RECT 3.94 1.18 4.28 1.25 ;
+      RECT 4.21 0.16 4.28 1.25 ;
+      RECT 3.94 0.76 4.01 1.25 ;
+      RECT 2.18 1.035 2.525 1.105 ;
+      RECT 2.455 0.35 2.525 1.105 ;
+      RECT 3.27 0.76 3.34 1.09 ;
+      RECT 3.27 0.76 4.01 0.83 ;
+      RECT 3.865 0.16 3.935 0.51 ;
+      RECT 3.265 0.35 3.935 0.42 ;
+      RECT 2.455 0.35 2.98 0.42 ;
+      RECT 2.91 0.16 2.98 0.42 ;
+      RECT 3.265 0.16 3.335 0.42 ;
+      RECT 3.865 0.16 4.28 0.23 ;
+      RECT 2.91 0.16 3.335 0.23 ;
+      RECT 4.075 0.295 4.145 1.115 ;
+      RECT 2.75 0.62 4.145 0.69 ;
+      RECT 4 0.295 4.145 0.69 ;
+      RECT 3.805 0.895 3.875 1.115 ;
+      RECT 3.435 0.895 3.505 1.115 ;
+      RECT 3.435 0.895 3.875 0.965 ;
+      RECT 2.615 0.755 2.99 0.825 ;
+      RECT 2.615 0.485 2.685 0.825 ;
+      RECT 2.615 0.485 3.8 0.555 ;
+      RECT 3.045 0.295 3.18 0.555 ;
+      RECT 2.315 0.2 2.385 0.965 ;
+      RECT 1.415 0.555 2.385 0.625 ;
+      RECT 2.125 0.695 2.195 0.965 ;
+      RECT 1.755 0.695 1.825 0.965 ;
+      RECT 1.755 0.695 2.195 0.765 ;
+      RECT 1.145 0.765 1.215 1.105 ;
+      RECT 0.61 0.765 1.215 0.835 ;
+      RECT 0.61 0.39 0.68 0.835 ;
+      RECT 0.61 0.39 1.19 0.46 ;
+      RECT 1.12 0.25 1.19 0.46 ;
+      RECT 1.62 0.385 2.15 0.455 ;
+      RECT 1.62 0.15 1.69 0.455 ;
+      RECT 1.12 0.25 1.4 0.32 ;
+      RECT 1.33 0.15 1.4 0.32 ;
+      RECT 1.33 0.15 1.69 0.22 ;
+      RECT 1.585 1.165 1.815 1.235 ;
+      RECT 1.585 0.905 1.655 1.235 ;
+      RECT 1.28 0.905 1.655 0.975 ;
+      RECT 1.28 0.41 1.35 0.975 ;
+      RECT 1.28 0.41 1.555 0.48 ;
+      RECT 1.485 0.285 1.555 0.48 ;
+      RECT 0.195 0.9 0.865 0.97 ;
+      RECT 0.195 0.225 0.265 0.97 ;
+      RECT 0.195 0.225 0.68 0.295 ;
+  END
+END SDFFRS_X1
+
+MACRO SDFFRS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFRS_X2 0 0 ;
+  SIZE 5.89 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.495 0.42 5.64 0.56 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.545 1.165 0.7 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 5.57 0.675 5.7 0.84 ;
+        RECT 5.135 0.72 5.7 0.79 ;
+        RECT 5.135 0.385 5.205 0.79 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.925 0.56 5.07 0.7 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.365 0.545 1.46 0.7 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.9 0.175 2.065 0.245 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.24 0.15 0.32 1.125 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.6 0.435 0.735 0.9 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.89 1.485 ;
+        RECT 5.54 1.195 5.675 1.485 ;
+        RECT 4.78 1.09 4.915 1.485 ;
+        RECT 3.95 1.09 4.085 1.485 ;
+        RECT 3.42 0.985 3.555 1.485 ;
+        RECT 3.04 0.985 3.175 1.485 ;
+        RECT 2.285 0.965 2.42 1.485 ;
+        RECT 1.64 1.115 1.775 1.485 ;
+        RECT 1.18 1.12 1.315 1.485 ;
+        RECT 0.79 1.1 0.925 1.485 ;
+        RECT 0.41 1.1 0.545 1.485 ;
+        RECT 0.065 0.85 0.135 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.89 0.085 ;
+        RECT 5.54 -0.085 5.675 0.18 ;
+        RECT 4.81 -0.085 4.88 0.27 ;
+        RECT 3.76 -0.085 3.895 0.285 ;
+        RECT 3.04 -0.085 3.175 0.285 ;
+        RECT 2.13 -0.085 2.2 0.32 ;
+        RECT 1.7 -0.085 1.835 0.285 ;
+        RECT 0.79 -0.085 0.925 0.16 ;
+        RECT 0.41 -0.085 0.545 0.16 ;
+        RECT 0.065 -0.085 0.135 0.41 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 5.765 0.15 5.835 1.09 ;
+      RECT 5.27 0.565 5.41 0.635 ;
+      RECT 5.34 0.285 5.41 0.635 ;
+      RECT 5.34 0.285 5.835 0.355 ;
+      RECT 4.74 0.95 5.295 1.02 ;
+      RECT 4.74 0.375 4.81 1.02 ;
+      RECT 4.74 0.375 5.045 0.445 ;
+      RECT 4.975 0.165 5.045 0.445 ;
+      RECT 4.975 0.165 5.295 0.235 ;
+      RECT 4.305 1.155 4.675 1.225 ;
+      RECT 4.605 0.15 4.675 1.225 ;
+      RECT 2.555 1.115 2.915 1.185 ;
+      RECT 2.845 0.35 2.915 1.185 ;
+      RECT 4.305 0.765 4.375 1.225 ;
+      RECT 3.615 0.765 4.375 0.835 ;
+      RECT 4.575 0.69 4.675 0.825 ;
+      RECT 3.61 0.355 4.34 0.425 ;
+      RECT 4.27 0.15 4.34 0.425 ;
+      RECT 2.845 0.35 3.39 0.42 ;
+      RECT 3.32 0.15 3.39 0.42 ;
+      RECT 3.61 0.15 3.68 0.425 ;
+      RECT 4.27 0.15 4.675 0.22 ;
+      RECT 3.32 0.15 3.68 0.22 ;
+      RECT 4.44 0.625 4.51 1.09 ;
+      RECT 3.125 0.625 4.51 0.695 ;
+      RECT 4.405 0.285 4.475 0.695 ;
+      RECT 4.405 0.285 4.54 0.355 ;
+      RECT 4.17 0.955 4.24 1.175 ;
+      RECT 3.8 0.955 3.87 1.175 ;
+      RECT 3.8 0.955 4.24 1.025 ;
+      RECT 2.99 0.765 3.37 0.835 ;
+      RECT 2.99 0.485 3.06 0.835 ;
+      RECT 2.99 0.49 4.17 0.56 ;
+      RECT 2.99 0.485 3.525 0.56 ;
+      RECT 3.455 0.32 3.525 0.56 ;
+      RECT 2.7 0.2 2.77 1.05 ;
+      RECT 1.665 0.485 1.735 0.68 ;
+      RECT 1.665 0.485 2.77 0.555 ;
+      RECT 1.53 0.84 2.04 0.91 ;
+      RECT 1.97 0.685 2.04 0.91 ;
+      RECT 1.53 0.35 1.6 0.91 ;
+      RECT 1.97 0.685 2.635 0.755 ;
+      RECT 2.565 0.62 2.635 0.755 ;
+      RECT 1.53 0.35 2.04 0.42 ;
+      RECT 2.5 0.83 2.57 1.05 ;
+      RECT 2.13 0.83 2.2 1.05 ;
+      RECT 2.13 0.83 2.57 0.9 ;
+      RECT 1.84 1.16 2.22 1.23 ;
+      RECT 1.84 0.975 1.91 1.23 ;
+      RECT 1.395 0.975 1.91 1.045 ;
+      RECT 1.395 0.765 1.465 1.045 ;
+      RECT 0.87 0.765 1.465 0.835 ;
+      RECT 0.87 0.41 0.94 0.835 ;
+      RECT 0.87 0.41 1.46 0.48 ;
+      RECT 0.39 0.965 1.12 1.035 ;
+      RECT 0.39 0.23 0.46 1.035 ;
+      RECT 0.39 0.23 1.305 0.3 ;
+  END
+END SDFFRS_X2
+
+MACRO SDFFR_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFR_X1 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.56 4.365 0.7 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.84 0.925 0.98 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.105 0.77 4.53 0.84 ;
+        RECT 4.43 0.56 4.53 0.84 ;
+        RECT 4.105 0.565 4.175 0.84 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.67 0.655 3.765 0.84 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.77 0.66 1.995 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.435 0.185 0.51 1.015 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.185 0.13 1.065 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.4 1.045 4.47 1.485 ;
+        RECT 3.64 1.08 3.71 1.485 ;
+        RECT 3.27 1.08 3.34 1.485 ;
+        RECT 2.4 0.995 2.47 1.485 ;
+        RECT 1.84 1.06 1.975 1.485 ;
+        RECT 1.15 1.205 1.22 1.485 ;
+        RECT 0.74 1.24 0.875 1.485 ;
+        RECT 0.21 1.24 0.345 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.4 -0.085 4.47 0.32 ;
+        RECT 3.64 -0.085 3.71 0.32 ;
+        RECT 3.11 -0.085 3.18 0.32 ;
+        RECT 2.27 -0.085 2.34 0.425 ;
+        RECT 1.71 -0.085 1.845 0.285 ;
+        RECT 0.77 -0.085 0.84 0.32 ;
+        RECT 0.24 -0.085 0.31 0.46 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.595 0.185 4.665 1.22 ;
+      RECT 3.965 0.905 4.665 0.975 ;
+      RECT 3.965 0.715 4.035 0.975 ;
+      RECT 4.1 0.415 4.665 0.485 ;
+      RECT 3.83 1.04 4.125 1.11 ;
+      RECT 3.83 0.22 3.9 1.11 ;
+      RECT 3.12 0.52 3.9 0.59 ;
+      RECT 3.83 0.22 4.125 0.29 ;
+      RECT 2.54 1.18 3.205 1.25 ;
+      RECT 3.135 0.945 3.205 1.25 ;
+      RECT 3.45 0.945 3.52 1.2 ;
+      RECT 2.54 0.505 2.61 1.25 ;
+      RECT 3.135 0.945 3.585 1.015 ;
+      RECT 3.515 0.655 3.585 1.015 ;
+      RECT 2.985 0.655 3.585 0.725 ;
+      RECT 2.985 0.385 3.055 0.725 ;
+      RECT 2.985 0.385 3.335 0.455 ;
+      RECT 3.265 0.185 3.335 0.455 ;
+      RECT 2.69 1.015 3.065 1.085 ;
+      RECT 2.995 0.81 3.065 1.085 ;
+      RECT 2.69 0.305 2.76 1.085 ;
+      RECT 2.995 0.81 3.45 0.88 ;
+      RECT 2.22 0.855 2.29 1.13 ;
+      RECT 2.22 0.855 2.405 0.925 ;
+      RECT 2.335 0.49 2.405 0.925 ;
+      RECT 2.85 0.17 2.92 0.835 ;
+      RECT 1.43 0.49 1.5 0.7 ;
+      RECT 1.43 0.49 2.475 0.56 ;
+      RECT 2.405 0.17 2.475 0.56 ;
+      RECT 2.09 0.185 2.16 0.56 ;
+      RECT 2.405 0.17 2.92 0.24 ;
+      RECT 1.545 1.18 1.695 1.25 ;
+      RECT 1.625 0.765 1.695 1.25 ;
+      RECT 2.065 0.655 2.135 1.065 ;
+      RECT 1.625 0.905 2.135 0.975 ;
+      RECT 1.28 0.765 1.695 0.835 ;
+      RECT 2.065 0.655 2.26 0.79 ;
+      RECT 1.28 0.35 1.35 0.835 ;
+      RECT 1.28 0.35 2 0.42 ;
+      RECT 1.93 0.185 2 0.42 ;
+      RECT 1.49 0.905 1.56 1.04 ;
+      RECT 1.14 0.905 1.56 0.975 ;
+      RECT 1.14 0.215 1.21 0.975 ;
+      RECT 0.72 0.705 1.21 0.775 ;
+      RECT 0.72 0.525 0.79 0.775 ;
+      RECT 1.14 0.215 1.46 0.285 ;
+      RECT 0.585 0.185 0.655 1.24 ;
+      RECT 0.195 1.08 0.655 1.15 ;
+      RECT 0.195 0.525 0.265 1.15 ;
+      RECT 1.005 0.39 1.075 0.635 ;
+      RECT 0.585 0.39 1.075 0.46 ;
+      RECT 0.935 1.045 1.41 1.115 ;
+  END
+END SDFFR_X1
+
+MACRO SDFFR_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFR_X2 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.565 0.42 4.69 0.625 ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.145 0.84 1.27 0.98 ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.345 0.7 4.765 0.845 ;
+        RECT 4.345 0.565 4.415 0.845 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.86 0.67 4.005 0.84 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.145 0.695 2.28 0.84 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.395 0.51 1.005 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.795 0.56 0.89 1.005 ;
+        RECT 0.795 0.395 0.865 1.005 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.635 1.045 4.705 1.485 ;
+        RECT 3.875 1.08 3.945 1.485 ;
+        RECT 3.46 1.115 3.595 1.485 ;
+        RECT 2.66 0.995 2.73 1.485 ;
+        RECT 2.06 1.06 2.195 1.485 ;
+        RECT 1.37 1.205 1.44 1.485 ;
+        RECT 0.985 1.205 1.055 1.485 ;
+        RECT 0.575 1.24 0.71 1.485 ;
+        RECT 0.225 1.205 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.635 -0.085 4.705 0.195 ;
+        RECT 3.875 -0.085 3.945 0.32 ;
+        RECT 3.295 -0.085 3.365 0.32 ;
+        RECT 2.535 -0.085 2.605 0.42 ;
+        RECT 2.005 -0.085 2.075 0.32 ;
+        RECT 1.065 -0.085 1.135 0.32 ;
+        RECT 0.575 -0.085 0.71 0.16 ;
+        RECT 0.195 -0.085 0.33 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.83 0.195 4.9 1.22 ;
+      RECT 4.205 0.91 4.9 0.98 ;
+      RECT 4.205 0.715 4.275 0.98 ;
+      RECT 4.36 0.415 4.495 0.485 ;
+      RECT 4.425 0.285 4.495 0.485 ;
+      RECT 4.425 0.285 4.9 0.355 ;
+      RECT 4.07 1.045 4.36 1.115 ;
+      RECT 4.07 0.23 4.14 1.115 ;
+      RECT 3.42 0.52 4.14 0.59 ;
+      RECT 4.07 0.23 4.36 0.3 ;
+      RECT 2.805 1.18 3.255 1.25 ;
+      RECT 3.185 0.975 3.255 1.25 ;
+      RECT 3.69 0.655 3.76 1.2 ;
+      RECT 2.805 0.5 2.875 1.25 ;
+      RECT 3.185 0.975 3.76 1.045 ;
+      RECT 3.285 0.655 3.76 0.725 ;
+      RECT 3.285 0.385 3.355 0.725 ;
+      RECT 3.285 0.385 3.57 0.455 ;
+      RECT 3.5 0.2 3.57 0.455 ;
+      RECT 3.04 0.84 3.11 1.115 ;
+      RECT 2.955 0.84 3.11 0.915 ;
+      RECT 2.955 0.84 3.625 0.91 ;
+      RECT 2.955 0.33 3.025 0.915 ;
+      RECT 2.89 0.33 3.025 0.4 ;
+      RECT 2.48 0.815 2.55 1.09 ;
+      RECT 2.48 0.815 2.74 0.885 ;
+      RECT 2.67 0.165 2.74 0.885 ;
+      RECT 3.15 0.165 3.22 0.775 ;
+      RECT 1.715 0.545 1.785 0.685 ;
+      RECT 1.715 0.545 2.74 0.615 ;
+      RECT 2.35 0.285 2.42 0.615 ;
+      RECT 2.67 0.165 3.22 0.235 ;
+      RECT 1.79 1.18 1.95 1.25 ;
+      RECT 1.88 0.75 1.95 1.25 ;
+      RECT 1.88 0.915 2.415 0.985 ;
+      RECT 2.345 0.68 2.415 0.985 ;
+      RECT 1.56 0.75 1.95 0.82 ;
+      RECT 2.345 0.68 2.56 0.75 ;
+      RECT 1.56 0.41 1.63 0.82 ;
+      RECT 1.56 0.41 2.265 0.48 ;
+      RECT 2.195 0.26 2.265 0.48 ;
+      RECT 1.425 0.885 1.815 0.955 ;
+      RECT 1.425 0.265 1.495 0.955 ;
+      RECT 0.29 0.26 0.36 0.66 ;
+      RECT 0.93 0.385 1.495 0.455 ;
+      RECT 0.93 0.26 1 0.455 ;
+      RECT 1.425 0.265 1.73 0.335 ;
+      RECT 0.29 0.26 1 0.33 ;
+      RECT 1.155 1.045 1.29 1.25 ;
+      RECT 1.155 1.045 1.63 1.115 ;
+      RECT 0.045 1.07 1.08 1.14 ;
+      RECT 1.01 0.64 1.08 1.14 ;
+      RECT 0.66 0.525 0.73 1.14 ;
+      RECT 0.045 0.26 0.115 1.14 ;
+      RECT 1.01 0.64 1.36 0.775 ;
+  END
+END SDFFR_X2
+
+MACRO SDFFS_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFS_X1 0 0 ;
+  SIZE 4.75 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.55 0.38 0.7 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.765 0.57 0.835 ;
+        RECT 0.5 0.55 0.57 0.835 ;
+        RECT 0.06 0.55 0.185 0.835 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.91 0.42 1.08 0.56 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.84 0.42 3.93 0.575 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.785 1.115 0.98 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.24 0.98 4.335 1.25 ;
+        RECT 4.265 0.4 4.335 1.25 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.62 0.98 4.705 1.25 ;
+        RECT 4.635 0.15 4.705 1.25 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.75 1.485 ;
+        RECT 4.445 0.975 4.515 1.485 ;
+        RECT 4.105 0.975 4.175 1.485 ;
+        RECT 3.735 1.07 3.805 1.485 ;
+        RECT 2.83 1.07 2.9 1.485 ;
+        RECT 2.3 1.155 2.37 1.485 ;
+        RECT 1.52 1.04 1.59 1.485 ;
+        RECT 0.985 1.045 1.055 1.485 ;
+        RECT 0.225 1.035 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.75 0.085 ;
+        RECT 4.445 -0.085 4.515 0.195 ;
+        RECT 3.735 -0.085 3.805 0.32 ;
+        RECT 2.805 -0.085 2.94 0.285 ;
+        RECT 2.485 -0.085 2.555 0.37 ;
+        RECT 1.49 -0.085 1.625 0.215 ;
+        RECT 0.985 -0.085 1.055 0.285 ;
+        RECT 0.225 -0.085 0.295 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.915 0.775 3.985 1.25 ;
+      RECT 3.69 0.775 3.985 0.915 ;
+      RECT 3.69 0.775 4.2 0.845 ;
+      RECT 4.13 0.265 4.2 0.845 ;
+      RECT 4.495 0.265 4.565 0.66 ;
+      RECT 4.075 0.265 4.565 0.335 ;
+      RECT 3.255 1.1 3.625 1.17 ;
+      RECT 3.555 0.215 3.625 1.17 ;
+      RECT 3.555 0.64 4.065 0.71 ;
+      RECT 3.995 0.525 4.065 0.71 ;
+      RECT 3.25 0.215 3.625 0.285 ;
+      RECT 2.615 0.93 3.49 1 ;
+      RECT 3.42 0.35 3.49 1 ;
+      RECT 2.615 0.805 2.685 1 ;
+      RECT 2.225 0.805 2.685 0.875 ;
+      RECT 2.65 0.35 3.49 0.42 ;
+      RECT 2.65 0.2 2.72 0.42 ;
+      RECT 1.34 0.905 1.41 1.25 ;
+      RECT 1.34 0.905 1.865 0.975 ;
+      RECT 1.795 0.74 1.865 0.975 ;
+      RECT 3.285 0.485 3.355 0.86 ;
+      RECT 1.795 0.74 2.025 0.81 ;
+      RECT 1.955 0.42 2.025 0.81 ;
+      RECT 2.225 0.485 3.355 0.555 ;
+      RECT 1.74 0.42 2.025 0.49 ;
+      RECT 2.225 0.15 2.295 0.555 ;
+      RECT 1.74 0.15 1.81 0.49 ;
+      RECT 1.34 0.28 1.81 0.35 ;
+      RECT 1.34 0.15 1.41 0.35 ;
+      RECT 1.74 0.15 2.295 0.22 ;
+      RECT 1.87 1.17 2.005 1.24 ;
+      RECT 1.935 0.88 2.005 1.24 ;
+      RECT 1.935 0.88 2.16 0.95 ;
+      RECT 2.09 0.285 2.16 0.95 ;
+      RECT 2.09 0.665 2.945 0.735 ;
+      RECT 1.875 0.285 2.16 0.355 ;
+      RECT 2.455 1.17 2.59 1.24 ;
+      RECT 2.07 1.17 2.205 1.24 ;
+      RECT 2.135 1.02 2.205 1.24 ;
+      RECT 2.455 1.02 2.525 1.24 ;
+      RECT 2.135 1.02 2.525 1.09 ;
+      RECT 1.18 0.77 1.25 1.25 ;
+      RECT 1.18 0.77 1.675 0.84 ;
+      RECT 1.605 0.415 1.675 0.84 ;
+      RECT 1.605 0.6 1.89 0.67 ;
+      RECT 1.18 0.415 1.675 0.485 ;
+      RECT 1.18 0.15 1.25 0.485 ;
+      RECT 0.58 1.035 0.715 1.24 ;
+      RECT 0.58 1.035 0.9 1.105 ;
+      RECT 0.83 0.625 0.9 1.105 ;
+      RECT 0.775 0.625 1.54 0.695 ;
+      RECT 0.775 0.15 0.845 0.695 ;
+      RECT 0.615 0.15 0.845 0.285 ;
+      RECT 0.045 0.9 0.115 1.25 ;
+      RECT 0.045 0.9 0.765 0.97 ;
+      RECT 0.635 0.835 0.765 0.97 ;
+      RECT 0.635 0.415 0.705 0.97 ;
+      RECT 0.045 0.415 0.705 0.485 ;
+      RECT 0.045 0.15 0.115 0.485 ;
+  END
+END SDFFS_X1
+
+MACRO SDFFS_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFFS_X2 0 0 ;
+  SIZE 5.13 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.25 0.67 0.375 0.84 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.91 0.595 0.98 ;
+        RECT 0.525 0.67 0.595 0.98 ;
+        RECT 0.06 0.795 0.185 0.98 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.965 0.42 1.08 0.64 ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.34 0.56 4.03 0.63 ;
+        RECT 3.34 0.28 3.41 0.63 ;
+        RECT 2.91 0.28 3.41 0.35 ;
+        RECT 2.42 0.425 2.98 0.495 ;
+        RECT 2.91 0.28 2.98 0.495 ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.84 1.13 0.98 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.43 0.395 4.5 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.81 0.395 4.88 0.785 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 5.13 1.485 ;
+        RECT 4.99 1.125 5.06 1.485 ;
+        RECT 4.58 1.15 4.715 1.485 ;
+        RECT 4.2 1.15 4.335 1.485 ;
+        RECT 3.825 1.15 3.96 1.485 ;
+        RECT 3.51 1.12 3.58 1.485 ;
+        RECT 2.64 1.03 2.71 1.485 ;
+        RECT 2.265 1.165 2.4 1.485 ;
+        RECT 1.505 1.24 1.64 1.485 ;
+        RECT 0.99 1.115 1.06 1.485 ;
+        RECT 0.195 1.24 0.33 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 5.13 0.085 ;
+        RECT 4.99 -0.085 5.06 0.195 ;
+        RECT 4.58 -0.085 4.715 0.18 ;
+        RECT 4.2 -0.085 4.335 0.18 ;
+        RECT 3.475 -0.085 3.61 0.48 ;
+        RECT 2.475 -0.085 2.61 0.345 ;
+        RECT 1.51 -0.085 1.645 0.345 ;
+        RECT 0.96 -0.085 1.095 0.28 ;
+        RECT 0.2 -0.085 0.335 0.465 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 2.91 1.18 3.445 1.25 ;
+      RECT 3.375 0.985 3.445 1.25 ;
+      RECT 2.91 0.83 2.98 1.25 ;
+      RECT 3.375 0.985 5.015 1.055 ;
+      RECT 4.945 0.26 5.015 1.055 ;
+      RECT 2.26 0.83 2.98 0.965 ;
+      RECT 3.69 0.26 3.76 0.495 ;
+      RECT 3.69 0.26 5.015 0.33 ;
+      RECT 3.375 0.85 4.745 0.92 ;
+      RECT 4.675 0.525 4.745 0.92 ;
+      RECT 4.295 0.415 4.365 0.92 ;
+      RECT 3.825 0.415 4.365 0.485 ;
+      RECT 3.045 1.045 3.31 1.115 ;
+      RECT 3.24 0.695 3.31 1.115 ;
+      RECT 3.24 0.695 4.23 0.765 ;
+      RECT 4.095 0.56 4.23 0.765 ;
+      RECT 3.205 0.415 3.275 0.76 ;
+      RECT 3.045 0.415 3.275 0.485 ;
+      RECT 1.355 1.105 1.425 1.25 ;
+      RECT 1.355 1.105 1.855 1.175 ;
+      RECT 1.785 0.76 1.855 1.175 ;
+      RECT 3.07 0.845 3.175 0.98 ;
+      RECT 3.07 0.56 3.14 0.98 ;
+      RECT 1.785 0.76 2.05 0.83 ;
+      RECT 1.98 0.425 2.05 0.83 ;
+      RECT 2.285 0.56 3.14 0.63 ;
+      RECT 1.98 0.425 2.075 0.575 ;
+      RECT 2.285 0.155 2.355 0.63 ;
+      RECT 1.355 0.425 2.075 0.495 ;
+      RECT 1.75 0.155 1.82 0.495 ;
+      RECT 1.355 0.36 1.425 0.495 ;
+      RECT 1.75 0.155 2.355 0.225 ;
+      RECT 1.925 0.895 1.995 1.25 ;
+      RECT 1.925 0.895 2.195 0.965 ;
+      RECT 2.125 0.695 2.195 0.965 ;
+      RECT 2.125 0.695 2.825 0.765 ;
+      RECT 2.15 0.29 2.22 0.765 ;
+      RECT 1.895 0.29 2.22 0.36 ;
+      RECT 2.485 1.03 2.555 1.25 ;
+      RECT 2.115 1.03 2.185 1.25 ;
+      RECT 2.115 1.03 2.555 1.1 ;
+      RECT 1.195 0.87 1.265 1.25 ;
+      RECT 1.195 0.87 1.705 0.94 ;
+      RECT 1.635 0.56 1.705 0.94 ;
+      RECT 1.635 0.625 1.915 0.695 ;
+      RECT 1.195 0.56 1.705 0.63 ;
+      RECT 1.195 0.315 1.265 0.63 ;
+      RECT 0.585 1.18 0.9 1.25 ;
+      RECT 0.83 0.35 0.9 1.25 ;
+      RECT 0.83 0.705 1.57 0.775 ;
+      RECT 0.585 0.35 0.9 0.42 ;
+      RECT 0.045 1.045 0.115 1.25 ;
+      RECT 0.045 1.045 0.765 1.115 ;
+      RECT 0.695 0.535 0.765 1.115 ;
+      RECT 0.045 0.535 0.765 0.605 ;
+      RECT 0.045 0.38 0.115 0.605 ;
+  END
+END SDFFS_X2
+
+MACRO SDFF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFF_X1 0 0 ;
+  SIZE 4.37 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.975 0.42 4.125 0.565 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.05 0.7 4.18 0.84 ;
+        RECT 3.75 0.7 4.18 0.77 ;
+        RECT 3.75 0.59 3.885 0.77 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.415 0.525 3.55 0.7 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.02 0.42 2.225 0.58 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.44 0.15 0.51 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.15 0.135 1.215 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.37 1.485 ;
+        RECT 4.02 0.975 4.155 1.485 ;
+        RECT 3.295 1.04 3.365 1.485 ;
+        RECT 2.935 1.08 3.005 1.485 ;
+        RECT 2.07 0.94 2.14 1.485 ;
+        RECT 1.51 0.975 1.645 1.485 ;
+        RECT 0.75 1.165 0.885 1.485 ;
+        RECT 0.25 1.04 0.32 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.37 0.085 ;
+        RECT 4.02 -0.085 4.155 0.16 ;
+        RECT 3.295 -0.085 3.365 0.195 ;
+        RECT 2.905 -0.085 3.04 0.19 ;
+        RECT 2.04 -0.085 2.175 0.285 ;
+        RECT 1.51 -0.085 1.645 0.285 ;
+        RECT 0.75 -0.085 0.885 0.285 ;
+        RECT 0.25 -0.085 0.32 0.425 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.245 0.15 4.315 1.215 ;
+      RECT 3.615 0.45 3.685 0.84 ;
+      RECT 3.615 0.45 3.88 0.52 ;
+      RECT 3.81 0.28 3.88 0.52 ;
+      RECT 3.81 0.28 4.315 0.35 ;
+      RECT 3.67 0.905 3.74 1.215 ;
+      RECT 3.28 0.905 3.74 0.975 ;
+      RECT 3.28 0.285 3.35 0.975 ;
+      RECT 2.9 0.695 3.35 0.83 ;
+      RECT 3.28 0.285 3.74 0.355 ;
+      RECT 3.67 0.15 3.74 0.355 ;
+      RECT 3.125 0.92 3.195 1.215 ;
+      RECT 2.205 1.14 2.835 1.21 ;
+      RECT 2.765 0.545 2.835 1.21 ;
+      RECT 2.205 0.815 2.275 1.21 ;
+      RECT 2.765 0.92 3.195 0.99 ;
+      RECT 2.765 0.545 3.215 0.615 ;
+      RECT 3.145 0.15 3.215 0.615 ;
+      RECT 2.53 0.975 2.7 1.045 ;
+      RECT 2.63 0.215 2.7 1.045 ;
+      RECT 2.63 0.325 3.08 0.46 ;
+      RECT 2.53 0.215 2.7 0.285 ;
+      RECT 1.885 0.2 1.955 1.09 ;
+      RECT 2.37 0.68 2.44 0.95 ;
+      RECT 1.885 0.68 2.565 0.75 ;
+      RECT 2.495 0.35 2.565 0.75 ;
+      RECT 1.26 0.65 1.955 0.72 ;
+      RECT 1.73 0.84 1.8 1.215 ;
+      RECT 1.125 0.84 1.8 0.91 ;
+      RECT 1.125 0.475 1.195 0.91 ;
+      RECT 1.125 0.475 1.8 0.545 ;
+      RECT 1.73 0.32 1.8 0.545 ;
+      RECT 0.99 1.15 1.265 1.22 ;
+      RECT 0.99 0.23 1.06 1.22 ;
+      RECT 0.73 0.525 1.06 0.66 ;
+      RECT 0.99 0.23 1.265 0.3 ;
+      RECT 0.595 0.15 0.665 1.215 ;
+      RECT 0.2 0.885 0.665 0.955 ;
+      RECT 0.2 0.51 0.27 0.955 ;
+      RECT 0.595 0.73 0.925 0.865 ;
+  END
+END SDFF_X1
+
+MACRO SDFF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN SDFF_X2 0 0 ;
+  SIZE 4.56 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.165 0.42 4.33 0.56 ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.95 0.7 4.355 0.84 ;
+        RECT 3.95 0.595 4.02 0.84 ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 3.48 0.42 3.58 0.56 ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.225 0.42 2.41 0.58 ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.425 0.4 0.51 0.785 ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.805 0.185 0.89 0.84 ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.56 1.485 ;
+        RECT 4.24 0.965 4.31 1.485 ;
+        RECT 3.455 1.24 3.59 1.485 ;
+        RECT 3.135 1.08 3.205 1.485 ;
+        RECT 2.275 0.91 2.345 1.485 ;
+        RECT 1.745 0.94 1.815 1.485 ;
+        RECT 0.985 1.04 1.055 1.485 ;
+        RECT 0.605 1.04 0.675 1.485 ;
+        RECT 0.225 1.04 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.56 0.085 ;
+        RECT 4.21 -0.085 4.345 0.16 ;
+        RECT 3.485 -0.085 3.555 0.255 ;
+        RECT 3.065 -0.085 3.2 0.165 ;
+        RECT 2.275 -0.085 2.345 0.32 ;
+        RECT 1.745 -0.085 1.815 0.32 ;
+        RECT 0.985 -0.085 1.055 0.32 ;
+        RECT 0.605 -0.085 0.675 0.195 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.43 0.195 4.5 1.24 ;
+      RECT 3.78 0.42 3.85 0.895 ;
+      RECT 3.78 0.42 4.05 0.49 ;
+      RECT 3.98 0.285 4.05 0.49 ;
+      RECT 3.98 0.285 4.5 0.355 ;
+      RECT 3.86 0.96 3.93 1.24 ;
+      RECT 3.645 0.96 3.93 1.03 ;
+      RECT 3.645 0.15 3.715 1.03 ;
+      RECT 3.105 0.64 3.715 0.775 ;
+      RECT 3.645 0.15 3.965 0.22 ;
+      RECT 3.33 0.89 3.4 1.185 ;
+      RECT 2.41 1.11 3.04 1.18 ;
+      RECT 2.97 0.505 3.04 1.18 ;
+      RECT 2.41 0.785 2.48 1.18 ;
+      RECT 2.97 0.89 3.4 0.96 ;
+      RECT 2.97 0.505 3.405 0.575 ;
+      RECT 3.335 0.185 3.405 0.575 ;
+      RECT 2.63 0.945 2.905 1.015 ;
+      RECT 2.835 0.215 2.905 1.015 ;
+      RECT 2.835 0.37 3.27 0.44 ;
+      RECT 2.635 0.215 2.905 0.285 ;
+      RECT 2.09 0.185 2.16 1.185 ;
+      RECT 2.575 0.65 2.645 0.88 ;
+      RECT 2.09 0.65 2.77 0.72 ;
+      RECT 2.7 0.35 2.77 0.72 ;
+      RECT 1.42 0.63 2.16 0.7 ;
+      RECT 1.935 0.79 2.005 1.185 ;
+      RECT 1.265 0.475 1.335 0.985 ;
+      RECT 1.265 0.79 2.005 0.86 ;
+      RECT 1.265 0.475 2.005 0.545 ;
+      RECT 1.935 0.185 2.005 0.545 ;
+      RECT 1.13 1.055 1.47 1.125 ;
+      RECT 1.13 0.22 1.2 1.125 ;
+      RECT 0.29 0.905 1.2 0.975 ;
+      RECT 0.29 0.525 0.36 0.975 ;
+      RECT 1.13 0.22 1.47 0.29 ;
+      RECT 0.045 0.185 0.115 1.185 ;
+      RECT 0.67 0.265 0.74 0.66 ;
+      RECT 0.045 0.265 0.74 0.335 ;
+  END
+END SDFF_X2
+
+MACRO TBUF_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X1 0 0 ;
+  SIZE 1.52 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.495 0.89 0.73 ;
+        RECT 0.51 0.495 0.89 0.565 ;
+        RECT 0.51 0.495 0.58 0.63 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.695 1.33 0.92 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.035 0.97 0.14 1.245 ;
+        RECT 0.035 0.15 0.14 0.425 ;
+        RECT 0.035 0.15 0.105 1.245 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.52 1.485 ;
+        RECT 1.19 1.24 1.325 1.485 ;
+        RECT 0.69 1.145 0.76 1.485 ;
+        RECT 0.225 1.145 0.36 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.52 0.085 ;
+        RECT 1.15 -0.085 1.285 0.295 ;
+        RECT 0.77 -0.085 0.905 0.295 ;
+        RECT 0.225 -0.085 0.36 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.41 0.365 1.48 1.245 ;
+      RECT 0.875 1.105 1.48 1.175 ;
+      RECT 0.875 0.94 0.945 1.175 ;
+      RECT 0.65 0.94 0.945 1.01 ;
+      RECT 0.65 0.645 0.72 1.01 ;
+      RECT 1.345 0.365 1.48 0.435 ;
+      RECT 1.065 0.36 1.135 1.04 ;
+      RECT 0.17 0.495 0.305 0.565 ;
+      RECT 0.235 0.225 0.305 0.565 ;
+      RECT 0.615 0.36 1.135 0.43 ;
+      RECT 0.615 0.225 0.685 0.43 ;
+      RECT 0.235 0.225 0.685 0.295 ;
+      RECT 0.495 0.835 0.565 1.115 ;
+      RECT 0.37 0.835 0.565 0.905 ;
+      RECT 0.37 0.36 0.44 0.905 ;
+      RECT 0.17 0.645 0.44 0.715 ;
+      RECT 0.37 0.36 0.53 0.43 ;
+  END
+END TBUF_X1
+
+MACRO TBUF_X16
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X16 0 0 ;
+  SIZE 4.94 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.265 0.39 4.335 0.66 ;
+        RECT 3.67 0.39 4.335 0.46 ;
+        RECT 3.475 0.555 3.74 0.625 ;
+        RECT 3.67 0.39 3.74 0.625 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 4.05 0.725 4.6 0.795 ;
+        RECT 4.53 0.525 4.6 0.795 ;
+        RECT 4.05 0.56 4.12 0.795 ;
+        RECT 3.955 0.56 4.12 0.63 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.895 0.36 3.03 1.005 ;
+        RECT 0.36 0.56 3.03 0.7 ;
+        RECT 2.515 0.36 2.65 1.005 ;
+        RECT 2.14 0.56 2.275 1.005 ;
+        RECT 2.135 0.36 2.27 0.7 ;
+        RECT 1.76 0.36 1.895 0.7 ;
+        RECT 1.755 0.56 1.89 1.005 ;
+        RECT 1.38 0.56 1.515 1.005 ;
+        RECT 1.375 0.36 1.51 0.7 ;
+        RECT 1 0.36 1.135 0.7 ;
+        RECT 0.995 0.56 1.13 1.005 ;
+        RECT 0.62 0.36 0.755 1.005 ;
+        RECT 0.24 0.86 0.43 0.93 ;
+        RECT 0.36 0.36 0.43 0.93 ;
+        RECT 0.24 0.36 0.43 0.43 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 4.94 1.485 ;
+        RECT 4.605 1.24 4.74 1.485 ;
+        RECT 3.845 1.24 3.98 1.485 ;
+        RECT 3.465 1.24 3.6 1.485 ;
+        RECT 3.085 1.24 3.22 1.485 ;
+        RECT 2.705 1.24 2.84 1.485 ;
+        RECT 2.325 1.24 2.46 1.485 ;
+        RECT 1.945 1.24 2.08 1.485 ;
+        RECT 1.565 1.24 1.7 1.485 ;
+        RECT 1.185 1.24 1.32 1.485 ;
+        RECT 0.805 1.24 0.94 1.485 ;
+        RECT 0.425 1.24 0.56 1.485 ;
+        RECT 0.05 1.24 0.185 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 4.94 0.085 ;
+        RECT 4.605 -0.085 4.74 0.16 ;
+        RECT 4.225 -0.085 4.36 0.16 ;
+        RECT 3.845 -0.085 3.98 0.16 ;
+        RECT 3.085 -0.085 3.22 0.16 ;
+        RECT 2.705 -0.085 2.84 0.16 ;
+        RECT 2.325 -0.085 2.46 0.16 ;
+        RECT 1.945 -0.085 2.08 0.16 ;
+        RECT 1.565 -0.085 1.7 0.16 ;
+        RECT 1.185 -0.085 1.32 0.16 ;
+        RECT 0.805 -0.085 0.94 0.16 ;
+        RECT 0.425 -0.085 0.56 0.16 ;
+        RECT 0.05 -0.085 0.185 0.16 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 4.825 0.26 4.895 1.25 ;
+      RECT 3.86 0.995 4.895 1.065 ;
+      RECT 3.86 0.83 3.93 1.065 ;
+      RECT 3.23 0.83 3.93 0.9 ;
+      RECT 3.805 0.525 3.875 0.9 ;
+      RECT 3.23 0.525 3.3 0.9 ;
+      RECT 4.23 0.86 4.735 0.93 ;
+      RECT 4.665 0.225 4.735 0.93 ;
+      RECT 0.105 0.495 0.29 0.565 ;
+      RECT 0.105 0.225 0.175 0.565 ;
+      RECT 0.105 0.225 4.735 0.295 ;
+      RECT 0.105 1.085 3.79 1.155 ;
+      RECT 3.095 0.36 3.165 1.155 ;
+      RECT 0.105 0.65 0.175 1.155 ;
+      RECT 0.105 0.65 0.295 0.72 ;
+      RECT 3.095 0.36 3.6 0.43 ;
+  END
+END TBUF_X16
+
+MACRO TBUF_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.56 0.965 0.7 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.2 0.7 1.535 0.84 ;
+        RECT 1.2 0.285 1.27 0.84 ;
+        RECT 0.685 0.285 1.27 0.355 ;
+        RECT 0.685 0.285 0.755 0.66 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.06 0.8 0.335 0.87 ;
+        RECT 0.06 0.35 0.33 0.42 ;
+        RECT 0.06 0.35 0.13 0.87 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.39 1.065 1.46 1.485 ;
+        RECT 0.975 1.065 1.045 1.485 ;
+        RECT 0.415 1.135 0.485 1.485 ;
+        RECT 0.04 0.995 0.11 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.405 -0.085 1.475 0.25 ;
+        RECT 0.91 -0.085 0.98 0.2 ;
+        RECT 0.415 -0.085 0.485 0.39 ;
+        RECT 0.04 -0.085 0.11 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.6 0.15 1.67 1.25 ;
+      RECT 1.335 0.56 1.67 0.63 ;
+      RECT 0.4 0.925 1.27 0.995 ;
+      RECT 1.065 0.43 1.135 0.995 ;
+      RECT 0.4 0.65 0.47 0.995 ;
+      RECT 0.235 0.65 0.47 0.72 ;
+      RECT 1 0.43 1.135 0.5 ;
+      RECT 0.55 0.725 0.705 0.795 ;
+      RECT 0.55 0.15 0.62 0.795 ;
+      RECT 0.235 0.495 0.62 0.565 ;
+      RECT 0.55 0.15 0.825 0.22 ;
+  END
+END TBUF_X2
+
+MACRO TBUF_X4
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X4 0 0 ;
+  SIZE 2.09 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.35 0.525 1.46 0.7 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.75 0.525 1.84 0.7 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.235 1.065 0.745 1.135 ;
+        RECT 0.235 0.33 0.745 0.4 ;
+        RECT 0.235 0.33 0.32 1.135 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.09 1.485 ;
+        RECT 1.745 0.86 1.815 1.485 ;
+        RECT 1.21 1.205 1.28 1.485 ;
+        RECT 0.83 1.205 0.9 1.485 ;
+        RECT 0.45 1.205 0.52 1.485 ;
+        RECT 0.075 1.205 0.145 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.09 0.085 ;
+        RECT 1.74 -0.085 1.81 0.195 ;
+        RECT 1.365 -0.085 1.435 0.195 ;
+        RECT 0.83 -0.085 0.9 0.195 ;
+        RECT 0.45 -0.085 0.52 0.195 ;
+        RECT 0.075 -0.085 0.145 0.335 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.935 0.15 2.005 0.995 ;
+      RECT 0.945 0.265 1.015 0.66 ;
+      RECT 0.945 0.265 2.005 0.335 ;
+      RECT 1.365 0.895 1.435 1.14 ;
+      RECT 0.59 0.895 1.63 0.965 ;
+      RECT 1.56 0.4 1.63 0.965 ;
+      RECT 0.59 0.465 0.66 0.965 ;
+      RECT 0.73 0.725 1.28 0.795 ;
+      RECT 1.21 0.4 1.28 0.795 ;
+      RECT 0.73 0.615 0.8 0.795 ;
+  END
+END TBUF_X4
+
+MACRO TBUF_X8
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TBUF_X8 0 0 ;
+  SIZE 3.42 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.72 0.39 2.79 0.66 ;
+        RECT 2.14 0.39 2.79 0.46 ;
+        RECT 1.95 0.56 2.21 0.63 ;
+        RECT 2.14 0.39 2.21 0.63 ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.465 0.725 3.08 0.795 ;
+        RECT 3.01 0.525 3.08 0.795 ;
+        RECT 2.465 0.525 2.6 0.795 ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.36 1.01 1.505 1.08 ;
+        RECT 1.355 0.375 1.505 0.445 ;
+        RECT 1.36 0.775 1.43 1.08 ;
+        RECT 0.265 0.7 1.425 0.84 ;
+        RECT 1.355 0.375 1.425 0.84 ;
+        RECT 1.02 0.2 1.095 0.84 ;
+        RECT 1.02 0.2 1.09 1.25 ;
+        RECT 0.645 0.2 0.715 1.25 ;
+        RECT 0.265 0.2 0.335 1.25 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 3.42 1.485 ;
+        RECT 3.085 1.13 3.22 1.485 ;
+        RECT 2.32 1.15 2.455 1.485 ;
+        RECT 1.97 0.995 2.04 1.485 ;
+        RECT 1.59 0.995 1.66 1.485 ;
+        RECT 1.21 0.975 1.28 1.485 ;
+        RECT 0.83 0.975 0.9 1.485 ;
+        RECT 0.415 1.01 0.55 1.485 ;
+        RECT 0.07 0.975 0.14 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 3.42 0.085 ;
+        RECT 3.09 -0.085 3.225 0.16 ;
+        RECT 2.7 -0.085 2.835 0.16 ;
+        RECT 2.32 -0.085 2.455 0.16 ;
+        RECT 1.56 -0.085 1.695 0.16 ;
+        RECT 1.18 -0.085 1.315 0.16 ;
+        RECT 0.8 -0.085 0.935 0.16 ;
+        RECT 0.415 -0.085 0.55 0.375 ;
+        RECT 0.07 -0.085 0.14 0.41 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 3.305 0.2 3.375 1.25 ;
+      RECT 2.295 0.995 3.375 1.065 ;
+      RECT 2.295 0.525 2.365 1.065 ;
+      RECT 1.705 0.725 2.365 0.795 ;
+      RECT 2.275 0.525 2.365 0.795 ;
+      RECT 1.705 0.525 1.775 0.795 ;
+      RECT 2.705 0.86 3.215 0.93 ;
+      RECT 3.145 0.225 3.215 0.93 ;
+      RECT 1.205 0.225 1.275 0.6 ;
+      RECT 1.205 0.225 3.215 0.295 ;
+      RECT 2.16 0.86 2.23 1.25 ;
+      RECT 1.78 0.86 1.85 1.25 ;
+      RECT 1.57 0.86 2.23 0.93 ;
+      RECT 1.57 0.39 1.64 0.93 ;
+      RECT 1.49 0.615 1.64 0.75 ;
+      RECT 1.57 0.39 2.075 0.46 ;
+  END
+END TBUF_X8
+
+MACRO TINV_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TINV_X1 0 0 ;
+  SIZE 0.76 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN EN
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.45 0.65 0.585 0.72 ;
+        RECT 0.175 0.84 0.52 0.98 ;
+        RECT 0.45 0.65 0.52 0.98 ;
+        RECT 0.175 0.625 0.245 0.98 ;
+    END
+  END EN
+  PIN I
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.31 0.42 0.38 0.6 ;
+        RECT 0.25 0.42 0.38 0.56 ;
+    END
+  END I
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.84 0.72 1.24 ;
+        RECT 0.65 0.155 0.72 1.24 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 0.76 1.485 ;
+        RECT 0.225 1.065 0.295 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 0.76 0.085 ;
+        RECT 0.225 -0.085 0.295 0.195 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 0.195 0.11 1.24 ;
+      RECT 0.45 0.495 0.585 0.565 ;
+      RECT 0.45 0.275 0.52 0.565 ;
+      RECT 0.04 0.275 0.52 0.345 ;
+  END
+END TINV_X1
+
+MACRO TLAT_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN TLAT_X1 0 0 ;
+  SIZE 2.47 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN D
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.585 0.73 0.84 ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.185 0.745 0.32 0.98 ;
+    END
+  END G
+  PIN OE
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.815 0.5 2.275 0.57 ;
+        RECT 1.815 0.5 2.03 0.7 ;
+    END
+  END OE
+  PIN Q
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 2.265 1.01 2.41 1.215 ;
+        RECT 2.34 0.22 2.41 1.215 ;
+        RECT 2.265 0.22 2.41 0.425 ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 2.47 1.485 ;
+        RECT 1.87 0.975 1.94 1.485 ;
+        RECT 1.305 1.08 1.44 1.485 ;
+        RECT 0.585 1.04 0.655 1.485 ;
+        RECT 0.235 1.045 0.305 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 2.47 0.085 ;
+        RECT 1.87 -0.085 1.94 0.32 ;
+        RECT 1.335 -0.085 1.405 0.32 ;
+        RECT 0.585 -0.085 0.655 0.46 ;
+        RECT 0.235 -0.085 0.305 0.32 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 1.68 0.185 1.75 1.245 ;
+      RECT 1.68 0.775 2.275 0.855 ;
+      RECT 2.14 0.65 2.275 0.855 ;
+      RECT 1.53 0.185 1.6 1.185 ;
+      RECT 1.26 0.515 1.6 0.65 ;
+      RECT 0.93 1.07 1.09 1.14 ;
+      RECT 1.02 0.22 1.09 1.14 ;
+      RECT 1.02 0.745 1.465 0.88 ;
+      RECT 0.93 0.22 1.09 0.29 ;
+      RECT 0.43 0.185 0.5 1.25 ;
+      RECT 0.43 0.905 0.945 0.975 ;
+      RECT 0.875 0.51 0.945 0.975 ;
+      RECT 0.05 0.185 0.12 1.25 ;
+      RECT 0.05 0.46 0.365 0.595 ;
+  END
+END TLAT_X1
+
+MACRO XNOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XNOR2_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.65 0.555 0.81 0.625 ;
+        RECT 0.65 0.39 0.72 0.625 ;
+        RECT 0.185 0.39 0.72 0.46 ;
+        RECT 0.185 0.39 0.32 0.56 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.35 0.84 0.965 0.91 ;
+        RECT 0.895 0.525 0.965 0.91 ;
+        RECT 0.35 0.84 0.51 0.98 ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.98 1.1 1.05 ;
+        RECT 1.03 0.295 1.1 1.05 ;
+        RECT 0.785 0.295 1.1 0.365 ;
+        RECT 0.63 0.98 0.7 1.25 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 1 1.115 1.07 1.485 ;
+        RECT 0.43 1.115 0.5 1.485 ;
+        RECT 0.05 1.115 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.395 -0.085 0.53 0.25 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.21 1.145 0.345 1.215 ;
+      RECT 0.21 0.67 0.28 1.215 ;
+      RECT 0.05 0.67 0.585 0.74 ;
+      RECT 0.515 0.525 0.585 0.74 ;
+      RECT 0.05 0.15 0.12 0.74 ;
+      RECT 0.595 0.16 1.105 0.23 ;
+  END
+END XNOR2_X1
+
+MACRO XNOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XNOR2_X2 0 0 ;
+  SIZE 1.9 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.01 0.525 1.08 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.77 1.65 0.84 ;
+        RECT 1.58 0.525 1.65 0.84 ;
+        RECT 0.82 0.56 0.89 0.84 ;
+        RECT 0.505 0.56 0.89 0.63 ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.21 0.905 1.84 0.975 ;
+        RECT 1.77 0.19 1.84 0.975 ;
+        RECT 0.975 0.36 1.84 0.43 ;
+        RECT 1.765 0.19 1.84 0.43 ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.9 1.485 ;
+        RECT 1.54 1.24 1.675 1.485 ;
+        RECT 0.805 1.065 0.875 1.485 ;
+        RECT 0.425 1.065 0.495 1.485 ;
+        RECT 0.05 1.065 0.12 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.9 0.085 ;
+        RECT 0.395 -0.085 0.53 0.16 ;
+        RECT 0.05 -0.085 0.12 0.325 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.245 0.725 0.72 0.795 ;
+      RECT 0.245 0.39 0.315 0.795 ;
+      RECT 0.245 0.39 0.91 0.46 ;
+      RECT 0.975 1.095 1.865 1.165 ;
+      RECT 0.21 0.225 1.675 0.295 ;
+  END
+END XNOR2_X2
+
+MACRO XOR2_X1
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XOR2_X1 0 0 ;
+  SIZE 1.14 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.63 0.525 0.755 0.66 ;
+        RECT 0.175 0.73 0.7 0.8 ;
+        RECT 0.63 0.525 0.7 0.8 ;
+        RECT 0.175 0.665 0.245 0.8 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.82 0.525 0.945 0.66 ;
+        RECT 0.305 0.875 0.89 0.945 ;
+        RECT 0.82 0.525 0.89 0.945 ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.775 1.04 1.08 1.11 ;
+        RECT 1.01 0.35 1.08 1.11 ;
+        RECT 0.62 0.35 1.08 0.42 ;
+        RECT 0.62 0.15 0.69 0.42 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.14 1.485 ;
+        RECT 0.42 1.15 0.49 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.14 0.085 ;
+        RECT 0.99 -0.085 1.06 0.285 ;
+        RECT 0.42 -0.085 0.49 0.285 ;
+        RECT 0.04 -0.085 0.11 0.285 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 0.525 0.11 1.25 ;
+      RECT 0.495 0.525 0.565 0.66 ;
+      RECT 0.04 0.525 0.565 0.595 ;
+      RECT 0.225 0.15 0.295 0.595 ;
+      RECT 0.585 1.175 1.095 1.245 ;
+  END
+END XOR2_X1
+
+MACRO XOR2_X2
+  CLASS CORE ;
+  ORIGIN 0 0 ;
+  FOREIGN XOR2_X2 0 0 ;
+  SIZE 1.71 BY 1.4 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  PIN A
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 1.255 0.395 1.325 0.66 ;
+        RECT 0.745 0.395 1.325 0.465 ;
+        RECT 0.745 0.285 0.82 0.66 ;
+        RECT 0.06 0.285 0.82 0.355 ;
+        RECT 0.06 0.285 0.165 0.7 ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.365 0.77 1.125 0.84 ;
+        RECT 0.99 0.56 1.125 0.84 ;
+        RECT 0.365 0.56 0.5 0.84 ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    PORT
+      LAYER metal1 ;
+        RECT 0.8 0.905 1.465 0.975 ;
+        RECT 1.39 0.26 1.465 0.975 ;
+        RECT 0.885 0.26 1.465 0.33 ;
+        RECT 0.885 0.15 0.955 0.33 ;
+        RECT 0.61 0.15 0.955 0.22 ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 1.315 1.71 1.485 ;
+        RECT 1.585 1.205 1.655 1.485 ;
+        RECT 0.445 1.205 0.515 1.485 ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        RECT 0 -0.085 1.71 0.085 ;
+        RECT 1.585 -0.085 1.655 0.335 ;
+        RECT 1.025 -0.085 1.095 0.195 ;
+        RECT 0.445 -0.085 0.515 0.195 ;
+        RECT 0.07 -0.085 0.14 0.21 ;
+    END
+  END VSS
+  OBS
+    LAYER metal1 ;
+      RECT 0.04 1.04 1.6 1.11 ;
+      RECT 1.53 0.525 1.6 1.11 ;
+      RECT 0.23 0.425 0.3 1.11 ;
+      RECT 0.575 0.425 0.645 0.66 ;
+      RECT 0.23 0.425 0.645 0.495 ;
+      RECT 0.61 1.175 1.5 1.245 ;
+  END
+END XOR2_X2
+
+MACRO LVT_AND2_X1
+  CLASS core ;
+  FOREIGN LVT_AND2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0954 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.299 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.61 0.19 0.7 0.19 0.7 1.25 0.61 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.54 1.315 0.76 1.315 0.76 1.485 0.54 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.485 0.085 0.485 0.325 0.415 0.325 0.415 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.84 0.47 0.84 0.47 0.46 0.045 0.46 0.045 0.19 0.115 0.19 0.115 0.39 0.54 0.39 0.54 0.91 0.305 0.91 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND2_X1
+
+MACRO LVT_AND2_X2
+  CLASS core ;
+  FOREIGN LVT_AND2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.615 0.15 0.7 0.15 0.7 1.25 0.615 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.545 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.95 1.315 0.95 1.485 0.545 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.865 0.085 0.865 0.425 0.795 0.425 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.84 0.475 0.84 0.475 0.46 0.045 0.46 0.045 0.15 0.115 0.15 0.115 0.39 0.545 0.39 0.545 0.91 0.305 0.91 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND2_X2
+
+MACRO LVT_AND2_X4
+  CLASS core ;
+  FOREIGN LVT_AND2_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0312 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0962 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.42 0.38 0.42 0.38 0.66 0.25 0.66  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.101125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3315 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.42 0.185 0.42 0.185 0.725 0.69 0.725 0.69 0.525 0.76 0.525 0.76 0.795 0.06 0.795  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.19045 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6682 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.15 1.08 0.15 1.08 0.68 1.365 0.68 1.365 0.15 1.435 0.15 1.435 1.25 1.365 1.25 1.365 0.75 1.08 0.75 1.08 1.25 0.995 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.995 0.11 0.995 0.11 1.315 0.415 1.315 0.415 0.995 0.485 0.995 0.485 1.315 0.795 1.315 0.795 0.995 0.865 0.995 0.865 1.315 0.92 1.315 1.175 1.315 1.175 0.995 1.245 0.995 1.245 1.315 1.555 1.315 1.555 0.995 1.625 0.995 1.625 1.315 1.71 1.315 1.71 1.485 0.92 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.625 0.085 1.625 0.355 1.555 0.355 1.555 0.085 1.245 0.085 1.245 0.355 1.175 0.355 1.175 0.085 0.865 0.085 0.865 0.215 0.795 0.215 0.795 0.085 0.11 0.085 0.11 0.355 0.04 0.355 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.86 0.85 0.86 0.85 0.355 0.425 0.355 0.425 0.22 0.495 0.22 0.495 0.285 0.92 0.285 0.92 0.93 0.675 0.93 0.675 1.25 0.605 1.25 0.605 0.93 0.305 0.93 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND2_X4
+
+MACRO LVT_AND3_X1
+  CLASS core ;
+  FOREIGN LVT_AND3_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.57 0.525 0.57 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.088 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3146 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.975 0.82 0.975 0.82 0.425 0.8 0.425 0.8 0.15 0.89 0.15 0.89 1.25 0.8 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.04 0.295 1.04 0.295 1.315 0.605 1.315 0.605 1 0.675 1 0.675 1.315 0.755 1.315 0.95 1.315 0.95 1.485 0.755 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.865 0.635 0.865 0.635 0.42 0.045 0.42 0.045 0.15 0.115 0.15 0.115 0.35 0.705 0.35 0.705 0.525 0.755 0.525 0.755 0.66 0.705 0.66 0.705 0.935 0.485 0.935 0.485 1.25 0.415 1.25 0.415 0.935 0.115 0.935 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_AND3_X1
+
+MACRO LVT_AND3_X2
+  CLASS core ;
+  FOREIGN LVT_AND3_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.57 0.525 0.57 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.805 0.15 0.89 0.15 0.89 1.25 0.805 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.975 0.295 0.975 0.295 1.315 0.605 1.315 0.605 0.975 0.675 0.975 0.675 1.315 0.735 1.315 0.99 1.315 0.99 0.975 1.06 0.975 1.06 1.315 1.14 1.315 1.14 1.485 0.735 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 1.06 0.085 1.06 0.425 0.99 0.425 0.99 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.8 0.665 0.8 0.665 0.425 0.045 0.425 0.045 0.15 0.115 0.15 0.115 0.355 0.735 0.355 0.735 0.87 0.485 0.87 0.485 1.25 0.415 1.25 0.415 0.87 0.115 0.87 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_AND3_X2
+
+MACRO LVT_AND3_X4
+  CLASS core ;
+  FOREIGN LVT_AND3_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.019575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.595 0.555 0.73 0.555 0.73 0.7 0.595 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0819 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2756 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.34 0.42 0.95 0.42 0.95 0.7 0.82 0.7 0.82 0.49 0.41 0.49 0.41 0.66 0.34 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1155 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4238 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.19 0.525 0.19 0.765 1.07 0.765 1.07 0.525 1.14 0.525 1.14 0.835 0.12 0.835 0.12 0.7 0.06 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.196 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.65 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.375 0.15 1.445 0.15 1.445 0.56 1.745 0.56 1.745 0.15 1.815 0.15 1.815 1.25 1.745 1.25 1.745 0.7 1.445 0.7 1.445 1.25 1.375 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.035 0.11 1.035 0.11 1.315 0.415 1.315 0.415 1.035 0.485 1.035 0.485 1.315 0.795 1.315 0.795 1.035 0.865 1.035 0.865 1.315 1.175 1.315 1.175 1.035 1.245 1.035 1.245 1.315 1.305 1.315 1.555 1.315 1.555 1.035 1.625 1.035 1.625 1.315 1.935 1.315 1.935 1.035 2.005 1.035 2.005 1.315 2.09 1.315 2.09 1.485 1.305 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 2.005 0.085 2.005 0.425 1.935 0.425 1.935 0.085 1.625 0.085 1.625 0.425 1.555 0.425 1.555 0.085 1.245 0.085 1.245 0.195 1.175 0.195 1.175 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.9 1.235 0.9 1.235 0.33 0.615 0.33 0.615 0.15 0.685 0.15 0.685 0.26 1.305 0.26 1.305 0.97 1.055 0.97 1.055 1.25 0.985 1.25 0.985 0.97 0.675 0.97 0.675 1.25 0.605 1.25 0.605 0.97 0.305 0.97 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND3_X4
+
+MACRO LVT_AND4_X1
+  CLASS core ;
+  FOREIGN LVT_AND4_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.76 0.525 0.76 0.7 0.63 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.099 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3094 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.99 0.15 1.08 0.15 1.08 1.25 0.99 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.925 1.315 1.14 1.315 1.14 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 0.865 0.085 0.865 0.285 0.795 0.285 0.795 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.84 0.855 0.84 0.855 0.42 0.045 0.42 0.045 0.15 0.115 0.15 0.115 0.35 0.925 0.35 0.925 0.91 0.675 0.91 0.675 1.25 0.605 1.25 0.605 0.91 0.305 0.91 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND4_X1
+
+MACRO LVT_AND4_X2
+  CLASS core ;
+  FOREIGN LVT_AND4_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.76 0.525 0.76 0.7 0.63 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.15 1.08 0.15 1.08 1.25 0.995 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.925 1.315 1.18 1.315 1.18 0.975 1.25 0.975 1.25 1.315 1.33 1.315 1.33 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.25 0.085 1.25 0.425 1.18 0.425 1.18 0.085 0.865 0.085 0.865 0.27 0.795 0.27 0.795 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.8 0.855 0.8 0.855 0.425 0.045 0.425 0.045 0.15 0.115 0.15 0.115 0.355 0.925 0.355 0.925 0.87 0.675 0.87 0.675 1.25 0.605 1.25 0.605 0.87 0.305 0.87 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_AND4_X2
+
+MACRO LVT_AND4_X4
+  CLASS core ;
+  FOREIGN LVT_AND4_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.56 0.935 0.56 0.935 0.7 0.8 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.079125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2626 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.565 0.425 1.135 0.425 1.135 0.66 1.065 0.66 1.065 0.495 0.7 0.495 0.7 0.7 0.565 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.121975 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.403 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.355 0.525 0.425 0.525 0.425 0.77 1.2 0.77 1.2 0.525 1.345 0.525 1.345 0.84 0.355 0.84  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.164325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5993 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.205 0.525 0.205 0.905 1.465 0.905 1.465 0.525 1.535 0.525 1.535 0.975 0.135 0.975 0.135 0.7 0.06 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1505 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.481 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.77 0.15 1.84 0.15 1.84 0.56 2.14 0.56 2.14 0.15 2.21 0.15 2.21 0.925 2.14 0.925 2.14 0.7 1.84 0.7 1.84 0.925 1.77 0.925  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 1.065 0.125 1.065 0.125 1.315 0.43 1.315 0.43 1.175 0.5 1.175 0.5 1.315 0.81 1.315 0.81 1.175 0.88 1.175 0.88 1.315 1.19 1.315 1.19 1.175 1.26 1.175 1.26 1.315 1.57 1.315 1.57 1.175 1.64 1.175 1.64 1.315 1.705 1.315 1.95 1.315 1.95 1.065 2.02 1.065 2.02 1.315 2.33 1.315 2.33 1.065 2.4 1.065 2.4 1.315 2.47 1.315 2.47 1.485 1.705 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.4 0.085 2.4 0.425 2.33 0.425 2.33 0.085 2.02 0.085 2.02 0.425 1.95 0.425 1.95 0.085 1.64 0.085 1.64 0.195 1.57 0.195 1.57 0.085 0.125 0.085 0.125 0.425 0.055 0.425 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.215 1.04 1.635 1.04 1.635 0.36 0.785 0.36 0.785 0.29 1.705 0.29 1.705 1.11 0.215 1.11  ;
+  END
+END LVT_AND4_X4
+
+MACRO LVT_ANTENNA_X1
+  CLASS core ;
+  FOREIGN LVT_ANTENNA_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.19 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0231 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.104 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0162 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.42 0.13 0.42 0.13 0.75 0.06 0.75  ;
+    END
+  END A
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.19 1.315 0.19 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.19 -0.085 0.19 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_ANTENNA_X1
+
+MACRO LVT_AOI211_X1
+  CLASS core ;
+  FOREIGN LVT_AOI211_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.89 0.525 0.89 0.7 0.765 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.41 0.525 0.51 0.525 0.51 0.7 0.41 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0845 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.21 0.525 0.21 0.7 0.06 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.124175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.468 LAYER metal1 ;
+    ANTENNADIFFAREA 0.189875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.275 0.355 0.44 0.355 0.44 0.15 0.525 0.15 0.525 0.355 0.835 0.355 0.835 0.15 0.905 0.15 0.905 0.425 0.345 0.425 0.345 1.115 0.275 1.115  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.525 1.315 0.835 1.315 0.835 0.905 0.905 0.905 0.905 1.315 0.95 1.315 0.95 1.485 0.525 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.715 0.085 0.715 0.285 0.645 0.285 0.645 0.085 0.15 0.085 0.15 0.425 0.08 0.425 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.905 0.155 0.905 0.155 1.18 0.455 1.18 0.455 0.905 0.525 0.905 0.525 1.25 0.085 1.25  ;
+  END
+END LVT_AOI211_X1
+
+MACRO LVT_AOI211_X2
+  CLASS core ;
+  FOREIGN LVT_AOI211_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.39 0.56 0.525 0.56 0.525 0.7 0.39 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0951 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3224 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.765 0.68 0.765 0.68 0.525 0.75 0.525 0.75 0.835 0.06 0.835  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.19 0.56 1.325 0.56 1.325 0.7 1.19 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08205 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2925 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.965 0.425 1.65 0.425 1.65 0.7 1.54 0.7 1.54 0.495 1.035 0.495 1.035 0.66 0.965 0.66  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.2202 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7709 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3507 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.89 0.765 1.475 0.765 1.475 1.055 1.405 1.055 1.405 0.835 1.095 0.835 1.095 1.055 1.025 1.055 1.025 0.835 0.82 0.835 0.82 0.355 0.2 0.355 0.2 0.15 0.335 0.15 0.335 0.285 1.185 0.285 1.185 0.15 1.32 0.15 1.32 0.355 0.89 0.355  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.42 1.315 0.42 1.035 0.49 1.035 0.49 1.315 1.665 1.315 1.71 1.315 1.71 1.485 1.665 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.665 0.085 1.665 0.355 1.595 0.355 1.595 0.085 0.895 0.085 0.895 0.215 0.825 0.215 0.825 0.085 0.5 0.085 0.5 0.215 0.43 0.215 0.43 0.085 0.115 0.085 0.115 0.355 0.045 0.355 0.045 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.9 0.885 0.9 0.885 1.18 1.22 1.18 1.22 0.975 1.29 0.975 1.29 1.18 1.595 1.18 1.595 0.975 1.665 0.975 1.665 1.25 0.815 1.25 0.815 0.97 0.12 0.97 0.12 1.25 0.05 1.25  ;
+  END
+END LVT_AOI211_X2
+
+MACRO LVT_AOI211_X4
+  CLASS core ;
+  FOREIGN LVT_AOI211_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.76 0.525 0.76 0.7 0.63 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1862 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6123 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.375 0.15 1.445 0.15 1.445 0.56 1.75 0.56 1.75 0.15 1.82 0.15 1.82 1.175 1.75 1.175 1.75 0.7 1.445 0.7 1.445 1.175 1.375 1.175  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.485 1.315 0.795 1.315 0.795 0.9 0.865 0.9 0.865 1.315 0.93 1.315 1.175 1.315 1.175 0.9 1.245 0.9 1.245 1.315 1.31 1.315 1.555 1.315 1.555 0.9 1.625 0.9 1.625 1.315 1.935 1.315 1.935 0.9 2.005 0.9 2.005 1.315 2.09 1.315 2.09 1.485 1.31 1.485 0.93 1.485 0.485 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 2.005 0.085 2.005 0.425 1.935 0.425 1.935 0.085 1.625 0.085 1.625 0.425 1.555 0.425 1.555 0.085 1.245 0.085 1.245 0.425 1.175 0.425 1.175 0.085 0.865 0.085 0.865 0.285 0.795 0.285 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.9 0.115 0.9 0.115 1.18 0.415 1.18 0.415 0.9 0.485 0.9 0.485 1.25 0.045 1.25  ;
+        POLYGON 0.235 0.765 0.86 0.765 0.86 0.46 0.045 0.46 0.045 0.15 0.115 0.15 0.115 0.39 0.605 0.39 0.605 0.15 0.675 0.15 0.675 0.39 0.93 0.39 0.93 0.835 0.305 0.835 0.305 1.115 0.235 1.115  ;
+        POLYGON 0.995 0.15 1.065 0.15 1.065 0.525 1.31 0.525 1.31 0.66 1.065 0.66 1.065 1.175 0.995 1.175  ;
+  END
+END LVT_AOI211_X4
+
+MACRO LVT_AOI21_X1
+  CLASS core ;
+  FOREIGN LVT_AOI21_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.4 0.525 0.51 0.525 0.51 0.7 0.4 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0245 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0819 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.2 0.525 0.2 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.083925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3185 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.265 0.355 0.44 0.355 0.44 0.15 0.525 0.15 0.525 0.425 0.335 0.425 0.335 1.115 0.265 1.115  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.525 1.315 0.645 1.315 0.645 0.905 0.715 0.905 0.715 1.315 0.76 1.315 0.76 1.485 0.525 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.715 0.085 0.715 0.355 0.645 0.355 0.645 0.085 0.15 0.085 0.15 0.425 0.08 0.425 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.905 0.155 0.905 0.155 1.18 0.455 1.18 0.455 0.905 0.525 0.905 0.525 1.25 0.085 1.25  ;
+  END
+END LVT_AOI21_X1
+
+MACRO LVT_AOI21_X2
+  CLASS core ;
+  FOREIGN LVT_AOI21_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.215 0.56 0.35 0.56 0.35 0.7 0.215 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.56 0.9 0.56 0.9 0.7 0.765 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0833 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3042 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.57 0.525 0.7 0.525 0.7 0.77 1.11 0.77 1.11 0.525 1.18 0.525 1.18 0.84 0.63 0.84 0.63 0.7 0.57 0.7  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.159875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6006 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.505 0.905 1.13 0.905 1.13 0.975 0.435 0.975 0.435 0.425 0.25 0.425 0.25 0.15 0.335 0.15 0.335 0.355 0.835 0.355 0.835 0.15 0.905 0.15 0.905 0.425 0.505 0.425  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.265 1.315 0.265 1.205 0.335 1.205 0.335 1.315 1.285 1.315 1.33 1.315 1.33 1.485 1.285 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.285 0.085 1.285 0.425 1.215 0.425 1.215 0.085 0.525 0.085 0.525 0.285 0.455 0.285 0.455 0.085 0.15 0.085 0.15 0.425 0.08 0.425 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.975 0.155 0.975 0.155 1.07 1.215 1.07 1.215 0.975 1.285 0.975 1.285 1.25 1.215 1.25 1.215 1.14 0.155 1.14 0.155 1.25 0.085 1.25  ;
+  END
+END LVT_AOI21_X2
+
+MACRO LVT_AOI21_X4
+  CLASS core ;
+  FOREIGN LVT_AOI21_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.023625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.4 0.525 0.535 0.525 0.535 0.7 0.4 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09775 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3185 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.165 0.56 1.3 0.56 1.3 0.69 1.925 0.69 1.925 0.56 2.06 0.56 2.06 0.76 1.165 0.76  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.139675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5044 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.925 0.42 2.32 0.42 2.32 0.66 2.25 0.66 2.25 0.49 1.66 0.49 1.66 0.625 1.525 0.625 1.525 0.49 0.995 0.49 0.995 0.66 0.925 0.66  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.35525 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3377 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.7 0.825 2.21 0.825 2.21 1.115 2.14 1.115 2.14 0.895 1.83 0.895 1.83 1.115 1.76 1.115 1.76 0.895 1.45 0.895 1.45 1.115 1.38 1.115 1.38 0.895 1.07 0.895 1.07 1.115 1 1.115 1 0.895 0.63 0.895 0.63 0.425 0.25 0.425 0.25 0.15 0.32 0.15 0.32 0.355 0.63 0.355 0.63 0.15 0.7 0.15 0.7 0.26 2.055 0.26 2.055 0.33 0.7 0.33  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 1.205 0.31 1.205 0.31 1.315 0.62 1.315 0.62 1.205 0.69 1.205 0.69 1.315 2.4 1.315 2.47 1.315 2.47 1.485 2.4 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.4 0.085 2.4 0.35 2.33 0.35 2.33 0.085 1.64 0.085 1.64 0.195 1.57 0.195 1.57 0.085 0.88 0.085 0.88 0.195 0.81 0.195 0.81 0.085 0.5 0.085 0.5 0.195 0.43 0.195 0.43 0.085 0.125 0.085 0.125 0.425 0.055 0.425 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.965 0.88 0.965 0.88 1.18 1.19 1.18 1.19 0.96 1.26 0.96 1.26 1.18 1.57 1.18 1.57 0.96 1.64 0.96 1.64 1.18 1.95 1.18 1.95 0.96 2.02 0.96 2.02 1.18 2.33 1.18 2.33 0.84 2.4 0.84 2.4 1.25 0.81 1.25 0.81 1.035 0.5 1.035 0.5 1.24 0.43 1.24 0.43 1.035 0.13 1.035 0.13 1.24 0.06 1.24  ;
+  END
+END LVT_AOI21_X4
+
+MACRO LVT_AOI221_X1
+  CLASS core ;
+  FOREIGN LVT_AOI221_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.525 1.08 0.525 1.08 0.7 0.955 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.74 0.525 0.74 0.7 0.63 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.13145 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.468 LAYER metal1 ;
+    ANTENNADIFFAREA 0.189875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.15 0.495 0.15 0.495 0.355 0.985 0.355 0.985 0.15 1.055 0.15 1.055 0.425 0.89 0.425 0.89 1.115 0.805 1.115 0.805 0.425 0.425 0.425  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.905 0.295 0.905 0.295 1.315 0.485 1.315 1.055 1.315 1.14 1.315 1.14 1.485 1.055 1.485 0.485 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 0.675 0.085 0.675 0.215 0.605 0.215 0.605 0.085 0.11 0.085 0.11 0.355 0.04 0.355 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.77 0.485 0.77 0.485 1.18 0.415 1.18 0.415 0.84 0.115 0.84 0.115 1.18 0.045 1.18  ;
+        POLYGON 0.615 0.905 0.685 0.905 0.685 1.18 0.985 1.18 0.985 0.905 1.055 0.905 1.055 1.25 0.615 1.25  ;
+  END
+END LVT_AOI221_X1
+
+MACRO LVT_AOI221_X2
+  CLASS core ;
+  FOREIGN LVT_AOI221_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.11795 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4251 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.56 0.25 0.56 0.25 0.79 1.06 0.79 1.06 0.525 1.13 0.525 1.13 0.86 0.18 0.86 0.18 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0805 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2743 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.34 0.42 0.945 0.42 0.945 0.7 0.82 0.7 0.82 0.49 0.41 0.49 0.41 0.66 0.34 0.66  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0196 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.585 0.56 0.725 0.56 0.725 0.7 0.585 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.57 0.525 1.66 0.525 1.66 0.7 1.57 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2912 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.34 0.525 1.41 0.525 1.41 0.765 1.77 0.765 1.77 0.525 1.91 0.525 1.91 0.7 1.84 0.7 1.84 0.835 1.34 0.835  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1938 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.715 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3507 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.275 0.9 1.86 0.9 1.86 0.97 1.195 0.97 1.195 0.35 0.2 0.35 0.2 0.28 1.675 0.28 1.675 0.35 1.275 0.35  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.415 1.315 0.415 1.205 0.485 1.205 0.485 1.315 0.795 1.315 0.795 1.205 0.865 1.205 0.865 1.315 2.015 1.315 2.09 1.315 2.09 1.485 2.015 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 2.015 0.085 2.015 0.425 1.945 0.425 1.945 0.085 1.245 0.085 1.245 0.195 1.175 0.195 1.175 0.085 0.675 0.085 0.675 0.195 0.605 0.195 0.605 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.2 0.93 1.09 0.93 1.09 1 0.2 1  ;
+        POLYGON 0.045 0.865 0.115 0.865 0.115 1.07 1.945 1.07 1.945 0.865 2.015 0.865 2.015 1.14 0.045 1.14  ;
+  END
+END LVT_AOI221_X2
+
+MACRO LVT_AOI221_X4
+  CLASS core ;
+  FOREIGN LVT_AOI221_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.61 0.525 0.7 0.525 0.7 0.7 0.61 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.525 0.89 0.525 0.89 0.7 0.8 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02975 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.18 0.525 1.18 0.7 1.01 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.03675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1001 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.27 0.525 0.27 0.7 0.06 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.42 0.525 0.51 0.525 0.51 0.7 0.42 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.2049 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6513 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.795 0.15 1.885 0.15 1.885 0.56 2.17 0.56 2.17 0.15 2.24 0.15 2.24 1.25 2.17 1.25 2.17 0.7 1.865 0.7 1.865 1.25 1.795 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.565 1.315 0.875 1.315 0.875 1.035 0.945 1.035 0.945 1.315 1.1 1.315 1.215 1.315 1.215 0.975 1.285 0.975 1.285 1.315 1.35 1.315 1.6 1.315 1.6 1.005 1.67 1.005 1.67 1.315 1.73 1.315 1.975 1.315 1.975 0.975 2.045 0.975 2.045 1.315 2.355 1.315 2.355 0.975 2.425 0.975 2.425 1.315 2.47 1.315 2.47 1.485 1.73 1.485 1.35 1.485 1.1 1.485 0.565 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.425 0.085 2.425 0.425 2.355 0.425 2.355 0.085 2.045 0.085 2.045 0.425 1.975 0.425 1.975 0.085 1.675 0.085 1.675 0.425 1.605 0.425 1.605 0.085 1.285 0.085 1.285 0.285 1.215 0.285 1.215 0.085 0.565 0.085 0.565 0.285 0.495 0.285 0.495 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.125 0.975 0.195 0.975 0.195 1.105 0.495 1.105 0.495 0.975 0.565 0.975 0.565 1.25 0.495 1.25 0.495 1.175 0.195 1.175 0.195 1.25 0.125 1.25  ;
+        POLYGON 0.695 0.9 1.1 0.9 1.1 1.25 1.03 1.25 1.03 0.97 0.765 0.97 0.765 1.25 0.695 1.25  ;
+        POLYGON 0.315 0.765 1.28 0.765 1.28 0.425 0.125 0.425 0.125 0.15 0.195 0.15 0.195 0.355 0.71 0.355 0.71 0.15 0.78 0.15 0.78 0.355 1.35 0.355 1.35 0.835 0.385 0.835 0.385 1.04 0.315 1.04  ;
+        POLYGON 1.415 0.15 1.485 0.15 1.485 0.525 1.73 0.525 1.73 0.66 1.485 0.66 1.485 1.25 1.415 1.25  ;
+  END
+END LVT_AOI221_X4
+
+MACRO LVT_AOI222_X1
+  CLASS core ;
+  FOREIGN LVT_AOI222_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.52 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.025375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0832 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.315 0.525 1.46 0.525 1.46 0.7 1.315 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.525 1.08 0.525 1.08 0.7 0.995 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.62 0.525 0.72 0.525 0.72 0.7 0.62 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.525 0.91 0.525 0.91 0.7 0.82 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.525 0.51 0.525 0.51 0.7 0.385 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.027125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0858 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.215 0.525 0.215 0.7 0.06 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.15955 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.546 LAYER metal1 ;
+    ANTENNADIFFAREA 0.252125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.5 0.175 0.57 0.175 0.57 0.375 1.325 0.375 1.325 0.175 1.46 0.175 1.46 0.45 1.215 0.45 1.215 1.115 1.145 1.115 1.145 0.45 0.5 0.45  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.905 0.11 0.905 0.11 1.315 0.415 1.315 0.415 0.905 0.485 0.905 0.485 1.315 1.395 1.315 1.52 1.315 1.52 1.485 1.395 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.52 -0.085 1.52 0.085 1.015 0.085 1.015 0.31 0.945 0.31 0.945 0.085 0.11 0.085 0.11 0.45 0.04 0.45 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.77 0.825 0.77 0.825 1.115 0.755 1.115 0.755 0.84 0.305 0.84 0.305 1.18 0.235 1.18  ;
+        POLYGON 0.575 0.905 0.645 0.905 0.645 1.18 0.945 1.18 0.945 0.905 1.015 0.905 1.015 1.18 1.325 1.18 1.325 0.905 1.395 0.905 1.395 1.25 0.575 1.25  ;
+  END
+END LVT_AOI222_X1
+
+MACRO LVT_AOI222_X2
+  CLASS core ;
+  FOREIGN LVT_AOI222_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.91 0.56 2.045 0.56 2.045 0.7 1.91 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.285 0.56 2.42 0.56 2.42 0.7 2.285 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.145 0.56 1.28 0.56 1.28 0.7 1.145 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08525 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2717 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.91 0.42 1.545 0.42 1.545 0.66 1.475 0.66 1.475 0.49 1.08 0.49 1.08 0.66 0.91 0.66  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.56 0.52 0.56 0.52 0.7 0.385 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0872 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2964 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.425 0.76 0.425 0.76 0.66 0.69 0.66 0.69 0.495 0.19 0.495 0.19 0.7 0.06 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.26185 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.9256 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3507 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.84 0.77 2.38 0.77 2.38 1.115 2.31 1.115 2.31 0.84 2.01 0.84 2.01 1.115 1.94 1.115 1.94 0.84 1.77 0.84 1.77 0.355 0.39 0.355 0.39 0.15 0.525 0.15 0.525 0.285 1.145 0.285 1.145 0.15 1.28 0.15 1.28 0.285 2.035 0.285 2.035 0.355 1.84 0.355  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.905 0.295 0.905 0.295 1.315 0.605 1.315 0.605 0.905 0.675 0.905 0.675 1.315 2.57 1.315 2.66 1.315 2.66 1.485 2.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 2.38 0.085 2.38 0.25 2.31 0.25 2.31 0.085 1.625 0.085 1.625 0.195 1.555 0.195 1.555 0.085 0.9 0.085 0.9 0.215 0.765 0.215 0.765 0.085 0.11 0.085 0.11 0.25 0.04 0.25 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.77 1.625 0.77 1.625 1.115 1.555 1.115 1.555 0.84 1.245 0.84 1.245 1.115 1.175 1.115 1.175 0.84 0.865 0.84 0.865 1.18 0.795 1.18 0.795 0.84 0.485 0.84 0.485 1.18 0.415 1.18 0.415 0.84 0.115 0.84 0.115 1.18 0.045 1.18  ;
+        POLYGON 1.715 0.15 2.17 0.15 2.17 0.355 2.5 0.355 2.5 0.15 2.57 0.15 2.57 0.425 2.1 0.425 2.1 0.22 1.715 0.22  ;
+        POLYGON 0.995 0.905 1.065 0.905 1.065 1.18 1.365 1.18 1.365 0.905 1.435 0.905 1.435 1.18 1.745 1.18 1.745 0.905 1.815 0.905 1.815 1.18 2.12 1.18 2.12 0.905 2.19 0.905 2.19 1.18 2.5 1.18 2.5 0.905 2.57 0.905 2.57 1.25 0.995 1.25  ;
+  END
+END LVT_AOI222_X2
+
+MACRO LVT_AOI222_X4
+  CLASS core ;
+  FOREIGN LVT_AOI222_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.030625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.091 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.235 0.525 0.235 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.525 0.51 0.525 0.51 0.7 0.385 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.89 0.525 0.89 0.7 0.765 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.135 0.525 1.135 0.7 1.01 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.023625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.525 1.335 0.525 1.335 0.7 1.2 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.2037 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6318 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.95 0.15 2.02 0.15 2.02 0.56 2.325 0.56 2.325 0.15 2.41 0.15 2.41 1.205 2.33 1.205 2.33 0.7 2.02 0.7 2.02 1.205 1.95 1.205  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.91 1.315 0.995 1.315 0.995 1.065 1.065 1.065 1.065 1.315 1.25 1.315 1.37 1.315 1.37 0.93 1.44 0.93 1.44 1.315 1.505 1.315 1.75 1.315 1.75 0.93 1.82 0.93 1.82 1.315 1.885 1.315 2.13 1.315 2.13 0.93 2.2 0.93 2.2 1.315 2.51 1.315 2.51 0.93 2.58 0.93 2.58 1.315 2.66 1.315 2.66 1.485 1.885 1.485 1.505 1.485 1.25 1.485 0.91 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 2.58 0.085 2.58 0.425 2.51 0.425 2.51 0.085 2.21 0.085 2.21 0.425 2.14 0.425 2.14 0.085 1.82 0.085 1.82 0.425 1.75 0.425 1.75 0.085 1.44 0.085 1.44 0.285 1.37 0.285 1.37 0.085 0.53 0.085 0.53 0.285 0.46 0.285 0.46 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.09 0.93 0.16 0.93 0.16 1.135 0.46 1.135 0.46 0.93 0.53 0.93 0.53 1.135 0.84 1.135 0.84 1.07 0.91 1.07 0.91 1.205 0.09 1.205  ;
+        POLYGON 0.66 0.93 1.25 0.93 1.25 1.205 1.18 1.205 1.18 1 0.73 1 0.73 1.065 0.66 1.065  ;
+        POLYGON 0.28 0.765 1.435 0.765 1.435 0.425 0.09 0.425 0.09 0.15 0.16 0.15 0.16 0.355 0.84 0.355 0.84 0.15 0.91 0.15 0.91 0.355 1.505 0.355 1.505 0.835 0.35 0.835 0.35 1.04 0.28 1.04  ;
+        POLYGON 1.57 0.15 1.64 0.15 1.64 0.525 1.885 0.525 1.885 0.66 1.64 0.66 1.64 1.205 1.57 1.205  ;
+  END
+END LVT_AOI222_X4
+
+MACRO LVT_AOI22_X1
+  CLASS core ;
+  FOREIGN LVT_AOI22_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.03 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0949 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.42 0.7 0.42 0.7 0.66 0.575 0.66  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.03 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0949 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.42 0.89 0.42 0.89 0.66 0.765 0.66  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.07245 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2873 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.15 0.51 0.15 0.51 0.725 0.69 0.725 0.69 1.005 0.62 1.005 0.62 0.795 0.44 0.795  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 1.205 0.31 1.205 0.31 1.315 0.88 1.315 0.95 1.315 0.95 1.485 0.88 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.88 0.085 0.88 0.355 0.81 0.355 0.81 0.085 0.125 0.085 0.125 0.355 0.055 0.355 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.865 0.13 0.865 0.13 1.07 0.435 1.07 0.435 0.865 0.505 0.865 0.505 1.07 0.81 1.07 0.81 0.865 0.88 0.865 0.88 1.14 0.06 1.14  ;
+  END
+END LVT_AOI22_X1
+
+MACRO LVT_AOI22_X2
+  CLASS core ;
+  FOREIGN LVT_AOI22_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.155 0.56 1.29 0.56 1.29 0.7 1.155 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.078825 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2691 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.425 1.55 0.425 1.55 0.66 1.48 0.66 1.48 0.495 1.08 0.495 1.08 0.7 0.955 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.395 0.56 0.53 0.56 0.53 0.7 0.395 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09785 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3237 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.195 0.525 0.195 0.765 0.685 0.765 0.685 0.525 0.755 0.525 0.755 0.835 0.06 0.835  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.2065 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7072 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.89 0.765 1.445 0.765 1.445 1.065 1.375 1.065 1.375 0.835 1.06 0.835 1.06 1.065 0.99 1.065 0.99 0.835 0.82 0.835 0.82 0.355 0.395 0.355 0.395 0.15 0.53 0.15 0.53 0.28 1.15 0.28 1.15 0.15 1.285 0.15 1.285 0.355 0.89 0.355  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.23 1.315 0.23 1.035 0.3 1.035 0.3 1.315 0.61 1.315 0.61 1.035 0.68 1.035 0.68 1.315 1.63 1.315 1.71 1.315 1.71 1.485 1.63 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.63 0.085 1.63 0.36 1.56 0.36 1.56 0.085 0.905 0.085 0.905 0.205 0.77 0.205 0.77 0.085 0.115 0.085 0.115 0.39 0.045 0.39 0.045 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.9 0.87 0.9 0.87 1.18 1.18 1.18 1.18 0.975 1.25 0.975 1.25 1.18 1.56 1.18 1.56 0.975 1.63 0.975 1.63 1.25 0.8 1.25 0.8 0.97 0.49 0.97 0.49 1.25 0.42 1.25 0.42 0.97 0.12 0.97 0.12 1.25 0.05 1.25  ;
+  END
+END LVT_AOI22_X2
+
+MACRO LVT_AOI22_X4
+  CLASS core ;
+  FOREIGN LVT_AOI22_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09635 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3133 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.915 0.56 2.05 0.56 2.05 0.69 2.655 0.69 2.655 0.56 2.79 0.56 2.79 0.76 1.915 0.76  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.146175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4875 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.715 0.42 3.045 0.42 3.045 0.66 2.91 0.66 2.91 0.49 2.43 0.49 2.43 0.625 2.295 0.625 2.295 0.49 1.785 0.49 1.785 0.66 1.715 0.66  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09775 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3185 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.395 0.56 0.53 0.56 0.53 0.69 1.155 0.69 1.155 0.56 1.29 0.56 1.29 0.76 0.395 0.76  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.139325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5031 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.125 0.42 1.515 0.42 1.515 0.66 1.445 0.66 1.445 0.49 0.89 0.49 0.89 0.625 0.755 0.625 0.755 0.49 0.195 0.49 0.195 0.66 0.125 0.66  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.36155 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3611 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.65 0.725 1.82 0.725 1.82 0.825 2.96 0.825 2.96 1.115 2.89 1.115 2.89 0.895 2.58 0.895 2.58 1.115 2.51 1.115 2.51 0.895 2.2 0.895 2.2 1.115 2.13 1.115 2.13 0.895 1.82 0.895 1.82 1.115 1.75 1.115 1.75 0.795 1.58 0.795 1.58 0.33 0.395 0.33 0.395 0.26 2.805 0.26 2.805 0.33 1.65 0.33  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.23 1.315 0.23 1.065 0.3 1.065 0.3 1.315 0.61 1.315 0.61 1.065 0.68 1.065 0.68 1.315 0.99 1.315 0.99 1.065 1.06 1.065 1.06 1.315 1.37 1.315 1.37 1.065 1.44 1.065 1.44 1.315 3.15 1.315 3.23 1.315 3.23 1.485 3.15 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 3.15 0.085 3.15 0.335 3.08 0.335 3.08 0.085 2.425 0.085 2.425 0.16 2.29 0.16 2.29 0.085 1.665 0.085 1.665 0.16 1.53 0.16 1.53 0.085 0.905 0.085 0.905 0.16 0.77 0.16 0.77 0.085 0.115 0.085 0.115 0.335 0.045 0.335 0.045 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.87 1.63 0.87 1.63 1.18 1.94 1.18 1.94 0.96 2.01 0.96 2.01 1.18 2.32 1.18 2.32 0.96 2.39 0.96 2.39 1.18 2.7 1.18 2.7 0.96 2.77 0.96 2.77 1.18 3.08 1.18 3.08 0.84 3.15 0.84 3.15 1.25 1.56 1.25 1.56 0.94 1.25 0.94 1.25 1.16 1.18 1.16 1.18 0.94 0.87 0.94 0.87 1.16 0.8 1.16 0.8 0.94 0.49 0.94 0.49 1.16 0.42 1.16 0.42 0.94 0.12 0.94 0.12 1.16 0.05 1.16  ;
+  END
+END LVT_AOI22_X4
+
+MACRO LVT_BUF_X1
+  CLASS core ;
+  FOREIGN LVT_BUF_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.57 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.19 0.525 0.19 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0945 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2964 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.42 0.19 0.51 0.19 0.51 1.24 0.42 1.24  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.965 0.295 0.965 0.295 1.315 0.355 1.315 0.57 1.315 0.57 1.485 0.355 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.57 -0.085 0.57 0.085 0.295 0.085 0.295 0.325 0.225 0.325 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.83 0.285 0.83 0.285 0.46 0.045 0.46 0.045 0.19 0.115 0.19 0.115 0.39 0.355 0.39 0.355 0.9 0.115 0.9 0.115 1.24 0.045 1.24  ;
+  END
+END LVT_BUF_X1
+
+MACRO LVT_BUF_X16
+  CLASS core ;
+  FOREIGN LVT_BUF_X16 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.75 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0819 LAYER metal1 ;
+    ANTENNAGATEAREA 0.418 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.715 0.06 0.715  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.7364 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 2.0644 LAYER metal1 ;
+    ANTENNADIFFAREA 1.1704 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.77 0.15 1.84 0.15 1.84 0.28 2.14 0.28 2.14 0.15 2.21 0.15 2.21 0.28 2.52 0.28 2.52 0.15 2.59 0.15 2.59 0.28 2.9 0.28 2.9 0.15 2.97 0.15 2.97 0.28 3.28 0.28 3.28 0.15 3.35 0.15 3.35 0.28 3.66 0.28 3.66 0.15 3.73 0.15 3.73 0.28 4.04 0.28 4.04 0.15 4.11 0.15 4.11 0.28 4.42 0.28 4.42 0.15 4.49 0.15 4.49 0.925 4.42 0.925 4.42 0.42 4.12 0.42 4.12 0.925 4.05 0.925 4.05 0.42 3.73 0.42 3.73 0.925 3.66 0.925 3.66 0.42 3.35 0.42 3.35 0.925 3.28 0.925 3.28 0.42 2.97 0.42 2.97 0.925 2.9 0.925 2.9 0.42 2.59 0.42 2.59 0.925 2.52 0.925 2.52 0.42 2.21 0.42 2.21 0.925 2.14 0.925 2.14 0.42 1.84 0.42 1.84 0.925 1.77 0.925  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 0.43 1.315 0.43 0.975 0.5 0.975 0.5 1.315 0.81 1.315 0.81 0.975 0.88 0.975 0.88 1.315 1.19 1.315 1.19 0.975 1.26 0.975 1.26 1.315 1.57 1.315 1.57 1.205 1.64 1.205 1.64 1.315 1.95 1.315 1.95 1.205 2.02 1.205 2.02 1.315 2.33 1.315 2.33 1.205 2.4 1.205 2.4 1.315 2.71 1.315 2.71 1.205 2.78 1.205 2.78 1.315 3.09 1.315 3.09 1.205 3.16 1.205 3.16 1.315 3.47 1.315 3.47 1.205 3.54 1.205 3.54 1.315 3.85 1.315 3.85 1.205 3.92 1.205 3.92 1.315 4.23 1.315 4.23 1.205 4.3 1.205 4.3 1.315 4.61 1.315 4.61 1.205 4.63 1.205 4.68 1.205 4.68 1.315 4.75 1.315 4.75 1.485 4.63 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.75 -0.085 4.75 0.085 4.68 0.085 4.68 0.2 4.61 0.2 4.61 0.085 4.3 0.085 4.3 0.2 4.23 0.2 4.23 0.085 3.92 0.085 3.92 0.2 3.85 0.2 3.85 0.085 3.54 0.085 3.54 0.2 3.47 0.2 3.47 0.085 3.16 0.085 3.16 0.2 3.09 0.2 3.09 0.085 2.78 0.085 2.78 0.2 2.71 0.2 2.71 0.085 2.4 0.085 2.4 0.2 2.33 0.2 2.33 0.085 2.02 0.085 2.02 0.2 1.95 0.2 1.95 0.085 1.64 0.085 1.64 0.34 1.57 0.34 1.57 0.085 1.26 0.085 1.26 0.34 1.19 0.34 1.19 0.085 0.88 0.085 0.88 0.34 0.81 0.34 0.81 0.085 0.5 0.085 0.5 0.34 0.43 0.34 0.43 0.085 0.125 0.085 0.125 0.34 0.055 0.34 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.25 0.15 0.32 0.15 0.32 0.525 0.62 0.525 0.62 0.15 0.69 0.15 0.69 0.525 1 0.525 1 0.15 1.07 0.15 1.07 0.525 1.38 0.525 1.38 0.15 1.45 0.15 1.45 0.525 1.705 0.525 1.705 1.05 2.69 1.05 2.69 0.525 2.76 0.525 2.76 1.05 3.45 1.05 3.45 0.525 3.52 0.525 3.52 1.05 4.56 1.05 4.56 0.525 4.63 0.525 4.63 1.12 1.635 1.12 1.635 0.66 1.45 0.66 1.45 1.25 1.38 1.25 1.38 0.66 1.07 0.66 1.07 1.25 1 1.25 1 0.66 0.69 0.66 0.69 1.25 0.62 1.25 0.62 0.66 0.32 0.66 0.32 1.25 0.25 1.25  ;
+  END
+END LVT_BUF_X16
+
+MACRO LVT_BUF_X2
+  CLASS core ;
+  FOREIGN LVT_BUF_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02975 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.23 0.525 0.23 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1001 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3471 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.465 0.15 0.535 0.15 0.535 0.56 0.7 0.56 0.7 0.7 0.535 0.7 0.535 1.25 0.465 1.25  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.265 1.315 0.265 1.04 0.335 1.04 0.335 1.315 0.395 1.315 0.645 1.315 0.645 0.975 0.715 0.975 0.715 1.315 0.76 1.315 0.76 1.485 0.395 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.715 0.085 0.715 0.425 0.645 0.425 0.645 0.085 0.335 0.085 0.335 0.285 0.265 0.285 0.265 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.82 0.325 0.82 0.325 0.46 0.085 0.46 0.085 0.15 0.155 0.15 0.155 0.39 0.395 0.39 0.395 0.89 0.155 0.89 0.155 1.25 0.085 1.25  ;
+  END
+END LVT_BUF_X2
+
+MACRO LVT_BUF_X32
+  CLASS core ;
+  FOREIGN LVT_BUF_X32 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 9.31 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.3672 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.1141 LAYER metal1 ;
+    ANTENNAGATEAREA 0.836 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.1 0.525 0.17 0.525 0.17 0.93 1.12 0.93 1.12 0.56 1.255 0.56 1.255 0.93 1.905 0.93 1.905 0.56 2.04 0.56 2.04 0.93 2.665 0.93 2.665 0.56 2.8 0.56 2.8 1 0.1 1  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 1.39335 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 3.7141 LAYER metal1 ;
+    ANTENNADIFFAREA 2.3617 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.3 0.15 3.37 0.15 3.37 0.28 3.67 0.28 3.67 0.15 3.74 0.15 3.74 0.28 4.05 0.28 4.05 0.15 4.12 0.15 4.12 0.28 4.43 0.28 4.43 0.15 4.5 0.15 4.5 0.28 4.81 0.28 4.81 0.15 4.88 0.15 4.88 0.28 5.19 0.28 5.19 0.15 5.26 0.15 5.26 0.28 5.57 0.28 5.57 0.15 5.64 0.15 5.64 0.28 5.95 0.28 5.95 0.15 6.02 0.15 6.02 0.28 6.33 0.28 6.33 0.15 6.4 0.15 6.4 0.28 6.71 0.28 6.71 0.15 6.78 0.15 6.78 0.28 7.09 0.28 7.09 0.15 7.16 0.15 7.16 0.28 7.47 0.28 7.47 0.15 7.54 0.15 7.54 0.28 7.85 0.28 7.85 0.15 7.92 0.15 7.92 0.28 8.23 0.28 8.23 0.15 8.3 0.15 8.3 0.28 8.61 0.28 8.61 0.15 8.68 0.15 8.68 0.28 8.99 0.28 8.99 0.15 9.06 0.15 9.06 1.25 8.99 1.25 8.99 0.42 8.68 0.42 8.68 0.785 8.61 0.785 8.61 0.42 8.3 0.42 8.3 0.785 8.23 0.785 8.23 0.42 7.92 0.42 7.92 0.785 7.85 0.785 7.85 0.42 7.54 0.42 7.54 0.785 7.47 0.785 7.47 0.42 7.16 0.42 7.16 0.785 7.09 0.785 7.09 0.42 6.78 0.42 6.78 0.785 6.71 0.785 6.71 0.42 6.4 0.42 6.4 0.785 6.33 0.785 6.33 0.42 6.02 0.42 6.02 0.785 5.95 0.785 5.95 0.42 5.64 0.42 5.64 0.785 5.57 0.785 5.57 0.42 5.26 0.42 5.26 0.785 5.19 0.785 5.19 0.42 4.88 0.42 4.88 0.785 4.81 0.785 4.81 0.42 4.5 0.42 4.5 0.785 4.43 0.785 4.43 0.42 4.12 0.42 4.12 0.785 4.05 0.785 4.05 0.42 3.74 0.42 3.74 0.785 3.67 0.785 3.67 0.42 3.37 0.42 3.37 0.785 3.3 0.785  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.065 0.11 1.065 0.11 1.315 0.415 1.315 0.415 1.065 0.485 1.065 0.485 1.315 0.795 1.315 0.795 1.065 0.865 1.065 0.865 1.315 1.175 1.315 1.175 1.065 1.245 1.065 1.245 1.315 1.555 1.315 1.555 1.065 1.625 1.065 1.625 1.315 1.935 1.315 1.935 1.065 2.005 1.065 2.005 1.315 2.315 1.315 2.315 1.065 2.385 1.065 2.385 1.315 2.695 1.315 2.695 1.065 2.765 1.065 2.765 1.315 3.08 1.315 3.08 1.065 3.15 1.065 3.15 1.315 3.48 1.315 3.48 1.065 3.55 1.065 3.55 1.315 3.86 1.315 3.86 1.065 3.93 1.065 3.93 1.315 4.24 1.315 4.24 1.065 4.31 1.065 4.31 1.315 4.62 1.315 4.62 1.065 4.69 1.065 4.69 1.315 5 1.315 5 1.065 5.07 1.065 5.07 1.315 5.38 1.315 5.38 1.065 5.45 1.065 5.45 1.315 5.76 1.315 5.76 1.065 5.83 1.065 5.83 1.315 6.14 1.315 6.14 1.065 6.21 1.065 6.21 1.315 6.52 1.315 6.52 1.065 6.59 1.065 6.59 1.315 6.9 1.315 6.9 1.065 6.97 1.065 6.97 1.315 7.28 1.315 7.28 1.065 7.35 1.065 7.35 1.315 7.66 1.315 7.66 1.065 7.73 1.065 7.73 1.315 8.04 1.315 8.04 1.065 8.11 1.065 8.11 1.315 8.42 1.315 8.42 1.065 8.49 1.065 8.49 1.315 8.8 1.315 8.8 1.065 8.87 1.065 8.87 1.315 8.88 1.315 9.18 1.315 9.18 1.065 9.25 1.065 9.25 1.315 9.31 1.315 9.31 1.485 8.88 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 9.31 -0.085 9.31 0.085 9.25 0.085 9.25 0.2 9.18 0.2 9.18 0.085 8.87 0.085 8.87 0.2 8.8 0.2 8.8 0.085 8.49 0.085 8.49 0.2 8.42 0.2 8.42 0.085 8.11 0.085 8.11 0.2 8.04 0.2 8.04 0.085 7.73 0.085 7.73 0.2 7.66 0.2 7.66 0.085 7.35 0.085 7.35 0.2 7.28 0.2 7.28 0.085 6.97 0.085 6.97 0.2 6.9 0.2 6.9 0.085 6.59 0.085 6.59 0.2 6.52 0.2 6.52 0.085 6.21 0.085 6.21 0.2 6.14 0.2 6.14 0.085 5.83 0.085 5.83 0.2 5.76 0.2 5.76 0.085 5.45 0.085 5.45 0.2 5.38 0.2 5.38 0.085 5.07 0.085 5.07 0.2 5 0.2 5 0.085 4.69 0.085 4.69 0.2 4.62 0.2 4.62 0.085 4.31 0.085 4.31 0.2 4.24 0.2 4.24 0.085 3.93 0.085 3.93 0.2 3.86 0.2 3.86 0.085 3.55 0.085 3.55 0.2 3.48 0.2 3.48 0.085 3.15 0.085 3.15 0.22 3.08 0.22 3.08 0.085 2.765 0.085 2.765 0.34 2.695 0.34 2.695 0.085 2.385 0.085 2.385 0.34 2.315 0.34 2.315 0.085 2.005 0.085 2.005 0.34 1.935 0.34 1.935 0.085 1.625 0.085 1.625 0.34 1.555 0.34 1.555 0.085 1.245 0.085 1.245 0.34 1.175 0.34 1.175 0.085 0.865 0.085 0.865 0.34 0.795 0.34 0.795 0.085 0.485 0.085 0.485 0.34 0.415 0.34 0.415 0.085 0.11 0.085 0.11 0.36 0.04 0.36 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.405 0.605 0.405 0.605 0.15 0.675 0.15 0.675 0.405 0.985 0.405 0.985 0.15 1.055 0.15 1.055 0.405 1.365 0.405 1.365 0.15 1.435 0.15 1.435 0.405 1.75 0.405 1.75 0.15 1.82 0.15 1.82 0.405 2.13 0.405 2.13 0.15 2.2 0.15 2.2 0.405 2.505 0.405 2.505 0.15 2.575 0.15 2.575 0.405 2.89 0.405 2.89 0.15 2.96 0.15 2.96 0.405 3.235 0.405 3.235 0.85 4.185 0.85 4.185 0.56 4.32 0.56 4.32 0.85 5.325 0.85 5.325 0.56 5.46 0.56 5.46 0.85 6.465 0.85 6.465 0.56 6.6 0.56 6.6 0.85 7.605 0.85 7.605 0.56 7.74 0.56 7.74 0.85 8.745 0.85 8.745 0.56 8.88 0.56 8.88 0.92 3.165 0.92 3.165 0.495 2.955 0.495 2.955 0.865 2.885 0.865 2.885 0.495 2.575 0.495 2.575 0.865 2.505 0.865 2.505 0.495 2.2 0.495 2.2 0.865 2.13 0.865 2.13 0.495 1.815 0.495 1.815 0.865 1.745 0.865 1.745 0.495 1.435 0.495 1.435 0.865 1.365 0.865 1.365 0.495 1.055 0.495 1.055 0.865 0.985 0.865 0.985 0.495 0.685 0.495 0.685 0.865 0.615 0.865 0.615 0.495 0.305 0.495 0.305 0.865 0.235 0.865  ;
+  END
+END LVT_BUF_X32
+
+MACRO LVT_BUF_X4
+  CLASS core ;
+  FOREIGN LVT_BUF_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.17 0.525 0.17 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1974 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6526 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.615 0.15 0.685 0.15 0.685 0.56 0.995 0.56 0.995 0.15 1.065 0.15 1.065 1.25 0.995 1.25 0.995 0.7 0.685 0.7 0.685 1.25 0.615 1.25  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.55 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 1.175 1.315 1.175 0.975 1.245 0.975 1.245 1.315 1.33 1.315 1.33 1.485 0.55 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.245 0.085 1.245 0.37 1.175 0.37 1.175 0.085 0.865 0.085 0.865 0.37 0.795 0.37 0.795 0.085 0.485 0.085 0.485 0.37 0.415 0.37 0.415 0.085 0.11 0.085 0.11 0.37 0.04 0.37 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.525 0.55 0.525 0.55 0.66 0.305 0.66 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_BUF_X4
+
+MACRO LVT_BUF_X8
+  CLASS core ;
+  FOREIGN LVT_BUF_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.17 0.525 0.17 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.4368 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3468 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.15 1.065 0.15 1.065 0.56 1.365 0.56 1.365 0.15 1.435 0.15 1.435 0.56 1.745 0.56 1.745 0.15 1.815 0.15 1.815 0.56 2.125 0.56 2.125 0.15 2.195 0.15 2.195 1.25 2.125 1.25 2.125 0.7 1.825 0.7 1.825 1.25 1.755 1.25 1.755 0.7 1.435 0.7 1.435 1.25 1.365 1.25 1.365 0.7 1.065 0.7 1.065 1.25 0.995 1.25  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.925 1.315 1.175 1.315 1.175 0.975 1.245 0.975 1.245 1.315 1.555 1.315 1.555 0.975 1.625 0.975 1.625 1.315 1.935 1.315 1.935 0.975 2.005 0.975 2.005 1.315 2.315 1.315 2.315 0.975 2.385 0.975 2.385 1.315 2.47 1.315 2.47 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.385 0.085 2.385 0.425 2.315 0.425 2.315 0.085 2.005 0.085 2.005 0.425 1.935 0.425 1.935 0.085 1.625 0.085 1.625 0.425 1.555 0.425 1.555 0.085 1.255 0.085 1.255 0.425 1.185 0.425 1.185 0.085 0.865 0.085 0.865 0.425 0.795 0.425 0.795 0.085 0.485 0.085 0.485 0.425 0.415 0.425 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.525 0.605 0.525 0.605 0.15 0.675 0.15 0.675 0.525 0.925 0.525 0.925 0.66 0.675 0.66 0.675 1.25 0.605 1.25 0.605 0.66 0.305 0.66 0.305 1.25 0.235 1.25  ;
+  END
+END LVT_BUF_X8
+
+MACRO LVT_CLKBUF_X1
+  CLASS core ;
+  FOREIGN LVT_CLKBUF_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.57 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0845 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0205 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.21 0.525 0.21 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0763 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3016 LAYER metal1 ;
+    ANTENNADIFFAREA 0.086625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.15 0.51 0.15 0.51 1.24 0.44 1.24  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.245 1.315 0.245 0.965 0.315 0.965 0.315 1.315 0.37 1.315 0.57 1.315 0.57 1.485 0.37 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.57 -0.085 0.57 0.085 0.315 0.085 0.315 0.285 0.245 0.285 0.245 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.065 0.83 0.3 0.83 0.3 0.42 0.065 0.42 0.065 0.15 0.135 0.15 0.135 0.35 0.37 0.35 0.37 0.9 0.135 0.9 0.135 1.24 0.065 1.24  ;
+  END
+END LVT_CLKBUF_X1
+
+MACRO LVT_CLKBUF_X2
+  CLASS core ;
+  FOREIGN LVT_CLKBUF_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.04125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.19 0.525 0.19 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1155 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.15 0.51 0.15 0.51 1.25 0.425 1.25  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.04 0.295 1.04 0.295 1.315 0.36 1.315 0.605 1.315 0.605 0.975 0.675 0.975 0.675 1.315 0.76 1.315 0.76 1.485 0.36 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.905 0.29 0.905 0.29 0.42 0.045 0.42 0.045 0.15 0.115 0.15 0.115 0.35 0.36 0.35 0.36 0.975 0.115 0.975 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_CLKBUF_X2
+
+MACRO LVT_CLKBUF_X3
+  CLASS core ;
+  FOREIGN LVT_CLKBUF_X3 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.04125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.19 0.525 0.19 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1813 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5954 LAYER metal1 ;
+    ANTENNADIFFAREA 0.202125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.18 0.495 0.18 0.495 0.42 0.795 0.42 0.795 0.18 0.865 0.18 0.865 1.175 0.795 1.175 0.795 0.56 0.495 0.56 0.495 1.175 0.425 1.175  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.9 0.295 0.9 0.295 1.315 0.355 1.315 0.605 1.315 0.605 0.9 0.675 0.9 0.675 1.315 0.95 1.315 0.95 1.485 0.355 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.675 0.085 0.675 0.235 0.605 0.235 0.605 0.085 0.295 0.085 0.295 0.235 0.225 0.235 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.765 0.285 0.765 0.285 0.45 0.045 0.45 0.045 0.18 0.115 0.18 0.115 0.38 0.355 0.38 0.355 0.835 0.115 0.835 0.115 1.175 0.045 1.175  ;
+  END
+END LVT_CLKBUF_X3
+
+MACRO LVT_CLKGATETST_X1
+  CLASS core ;
+  FOREIGN LVT_CLKGATETST_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.85 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.075 0.7 2.22 0.7 2.22 0.84 2.075 0.84  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0182 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0702 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.7 0.38 0.7 0.38 0.84 0.25 0.84  ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.7 0.185 0.7 0.185 0.84 0.06 0.84  ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.075225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2522 LAYER metal1 ;
+    ANTENNADIFFAREA 0.086625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.705 0.35 2.79 0.35 2.79 1.235 2.705 1.235  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.385 1.315 0.385 1.04 0.52 1.04 0.52 1.315 0.57 1.315 1.185 1.315 1.185 1.01 1.32 1.01 1.32 1.315 1.475 1.315 1.555 1.315 1.69 1.315 1.755 1.315 1.755 0.94 1.825 0.94 1.825 1.315 2.07 1.315 2.135 1.315 2.135 0.94 2.205 0.94 2.205 1.315 2.48 1.315 2.48 1.045 2.615 1.045 2.615 1.315 2.64 1.315 2.85 1.315 2.85 1.485 2.64 1.485 2.07 1.485 1.69 1.485 1.555 1.485 1.475 1.485 0.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.85 -0.085 2.85 0.085 2.62 0.085 2.62 0.385 2.485 0.385 2.485 0.085 1.82 0.085 1.82 0.42 1.75 0.42 1.75 0.085 1.32 0.085 1.32 0.38 1.185 0.38 1.185 0.085 0.52 0.085 0.52 0.385 0.385 0.385 0.385 0.085 0.11 0.085 0.11 0.42 0.04 0.42 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.905 0.5 0.905 0.5 0.52 0.235 0.52 0.235 0.285 0.305 0.285 0.305 0.45 0.57 0.45 0.57 0.975 0.115 0.975 0.115 1.235 0.045 1.235  ;
+        POLYGON 0.74 1.16 1.05 1.16 1.05 0.875 1.475 0.875 1.475 1.235 1.405 1.235 1.405 0.945 1.12 0.945 1.12 1.23 0.67 1.23 0.67 0.15 1.015 0.15 1.015 0.445 1.405 0.445 1.405 0.285 1.475 0.285 1.475 0.515 0.945 0.515 0.945 0.22 0.74 0.22  ;
+        POLYGON 0.805 0.285 0.875 0.285 0.875 0.735 1.555 0.735 1.555 0.805 0.875 0.805 0.875 1.095 0.805 1.095  ;
+        POLYGON 1.565 0.93 1.62 0.93 1.62 0.655 1.105 0.655 1.105 0.585 1.565 0.585 1.565 0.285 1.635 0.285 1.635 0.585 1.69 0.585 1.69 1.205 1.565 1.205  ;
+        POLYGON 1.935 0.15 2.07 0.15 2.07 0.22 2.005 0.22 2.005 1.21 1.935 1.21  ;
+        POLYGON 2.14 0.285 2.21 0.285 2.21 0.525 2.64 0.525 2.64 0.66 2.4 0.66 2.4 1.005 2.33 1.005 2.33 0.595 2.14 0.595  ;
+  END
+END LVT_CLKGATETST_X1
+
+MACRO LVT_CLKGATETST_X2
+  CLASS core ;
+  FOREIGN LVT_CLKGATETST_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.04 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.102025 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3549 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.18 0.525 2.25 0.525 2.25 0.85 2.45 0.85 2.72 0.85 2.72 0.525 2.825 0.525 2.825 0.92 2.45 0.92 2.18 0.92  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.020625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0754 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.56 0.375 0.56 0.375 0.725 0.25 0.725  ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.017325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0702 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.56 0.545 0.56 0.545 0.725 0.44 0.725  ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0508 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1859 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1155 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.52 0.15 2.6 0.15 2.6 0.785 2.52 0.785  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.94 0.295 0.94 0.295 1.315 0.73 1.315 0.73 1.115 0.865 1.115 0.865 1.315 1.515 1.315 1.515 0.91 1.585 0.91 1.585 1.315 1.83 1.315 1.83 1.24 1.965 1.24 1.965 1.315 2.275 1.315 2.275 1.24 2.41 1.24 2.41 1.315 2.675 1.315 2.675 1.24 2.81 1.24 2.81 1.315 2.965 1.315 3.04 1.315 3.04 1.485 2.965 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.04 -0.085 3.04 0.085 2.77 0.085 2.77 0.195 2.7 0.195 2.7 0.085 2.395 0.085 2.395 0.195 2.325 0.195 2.325 0.085 1.9 0.085 1.9 0.185 1.765 0.185 1.765 0.085 1.52 0.085 1.52 0.405 1.45 0.405 1.45 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.425 0.15 0.495 0.15 0.495 0.41 0.87 0.41 0.87 0.545 0.68 0.545 0.68 0.885 0.61 0.885 0.61 0.48 0.425 0.48  ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.805 0.48 0.805 0.48 0.95 0.945 0.95 0.945 0.15 1.285 0.15 1.285 0.22 1.015 0.22 1.015 0.61 1.08 0.61 1.08 0.745 1.015 0.745 1.015 1.02 0.41 1.02 0.41 0.875 0.115 0.875 0.115 1.125 0.045 1.125  ;
+        POLYGON 1.08 0.285 1.215 0.285 1.215 0.525 1.63 0.525 1.63 0.66 1.215 0.66 1.215 1.03 1.145 1.03 1.145 0.42 1.08 0.42  ;
+        POLYGON 1.38 0.76 1.705 0.76 1.705 0.35 1.61 0.35 1.61 0.28 1.775 0.28 1.775 0.83 1.38 0.83  ;
+        POLYGON 2.045 0.39 2.17 0.39 2.17 0.15 2.24 0.15 2.24 0.325 2.45 0.325 2.45 0.46 2.115 0.46 2.115 0.925 2.045 0.925  ;
+        POLYGON 1.68 1.08 2.895 1.08 2.895 0.15 2.965 0.15 2.965 1.24 2.895 1.24 2.895 1.15 1.75 1.15 1.75 1.245 1.68 1.245  ;
+  END
+END LVT_CLKGATETST_X2
+
+MACRO LVT_CLKGATETST_X4
+  CLASS core ;
+  FOREIGN LVT_CLKGATETST_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.8 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1002 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3146 LAYER metal1 ;
+    ANTENNAGATEAREA 0.13075 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.21 0.525 2.28 0.525 2.28 0.77 2.495 0.77 2.72 0.77 2.72 0.525 2.85 0.525 2.85 0.85 2.495 0.85 2.21 0.85  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02795 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.56 0.38 0.56 0.38 0.775 0.25 0.775  ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.026875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0884 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.56 0.185 0.56 0.185 0.775 0.06 0.775  ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1463 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4654 LAYER metal1 ;
+    ANTENNADIFFAREA 0.231 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.085 0.18 3.155 0.18 3.155 0.42 3.455 0.42 3.455 0.18 3.525 0.18 3.525 0.925 3.455 0.925 3.455 0.56 3.155 0.56 3.155 0.925 3.085 0.925  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.755 1.315 0.755 1.13 0.825 1.13 0.825 1.315 1.49 1.315 1.49 1.165 1.625 1.165 1.625 1.315 2.13 1.315 2.13 1.205 2.2 1.205 2.2 1.315 2.505 1.315 2.505 1.2 2.575 1.2 2.575 1.315 2.885 1.315 2.885 1.2 2.955 1.2 2.955 1.315 3.015 1.315 3.265 1.315 3.265 0.975 3.335 0.975 3.335 1.315 3.645 1.315 3.645 0.975 3.715 0.975 3.715 1.315 3.8 1.315 3.8 1.485 3.015 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.8 -0.085 3.8 0.085 3.715 0.085 3.715 0.2 3.645 0.2 3.645 0.085 3.335 0.085 3.335 0.2 3.265 0.2 3.265 0.085 2.955 0.085 2.955 0.2 2.885 0.2 2.885 0.085 2.195 0.085 2.195 0.285 2.125 0.285 2.125 0.085 1.6 0.085 1.6 0.285 1.53 0.285 1.53 0.085 0.825 0.085 0.825 0.195 0.755 0.195 0.755 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.285 0.04 0.285 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.84 0.84 0.84 0.84 0.485 0.235 0.485 0.235 0.15 0.335 0.15 0.335 0.415 0.91 0.415 0.91 0.91 0.115 0.91 0.115 1.25 0.045 1.25  ;
+        POLYGON 0.575 0.975 0.975 0.975 0.975 0.33 0.575 0.33 0.575 0.15 0.645 0.15 0.645 0.26 1.045 0.26 1.045 0.39 1.325 0.39 1.325 0.46 1.065 0.46 1.065 1.045 0.645 1.045 0.645 1.25 0.575 1.25  ;
+        POLYGON 1.405 0.725 1.71 0.725 1.71 0.15 1.78 0.15 1.78 0.795 1.405 0.795  ;
+        POLYGON 1.265 0.795 1.335 0.795 1.335 0.865 1.92 0.865 1.92 0.15 1.99 0.15 1.99 0.935 1.265 0.935  ;
+        POLYGON 1.2 1.03 2.055 1.03 2.055 0.39 2.495 0.39 2.495 0.66 2.425 0.66 2.425 0.46 2.125 0.46 2.125 1.1 1.205 1.1 1.205 1.25 1.13 1.25 1.13 0.525 1.39 0.525 1.39 0.255 1.11 0.255 1.11 0.185 1.46 0.185 1.46 0.525 1.645 0.525 1.645 0.66 1.2 0.66  ;
+        POLYGON 2.29 0.93 2.945 0.93 2.945 0.42 2.655 0.42 2.655 0.255 2.48 0.255 2.48 0.185 2.725 0.185 2.725 0.35 3.015 0.35 3.015 1 2.29 1  ;
+  END
+END LVT_CLKGATETST_X4
+
+MACRO LVT_CLKGATETST_X8
+  CLASS core ;
+  FOREIGN LVT_CLKGATETST_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 5.51 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.18095 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6903 LAYER metal1 ;
+    ANTENNAGATEAREA 0.23525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.385 0.525 2.455 0.525 2.455 0.845 3.1 0.845 3.1 0.63 3.035 0.63 3.035 0.56 3.17 0.56 3.17 0.845 3.855 0.845 3.855 0.63 3.765 0.63 3.765 0.56 3.925 0.56 3.925 0.915 2.385 0.915  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0252 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0832 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.33 0.7 0.51 0.7 0.51 0.84 0.33 0.84  ;
+    END
+  END E
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0266 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0858 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.7 0.25 0.7 0.25 0.84 0.06 0.84  ;
+    END
+  END SE
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.44895 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3585 LAYER metal1 ;
+    ANTENNADIFFAREA 0.462 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.075 0.975 4.12 0.975 4.12 0.285 4.075 0.285 4.075 0.15 4.19 0.15 4.19 0.56 4.445 0.56 4.445 0.15 4.515 0.15 4.515 0.56 4.825 0.56 4.825 0.15 4.895 0.15 4.895 0.56 5.205 0.56 5.205 0.15 5.275 0.15 5.275 1.25 5.205 1.25 5.205 0.7 4.895 0.7 4.895 1.25 4.825 1.25 4.825 0.7 4.515 0.7 4.515 1.25 4.445 1.25 4.445 0.7 4.19 0.7 4.19 1.25 4.075 1.25  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.41 1.315 0.41 1.215 0.545 1.215 0.545 1.315 0.75 1.315 0.75 1.24 0.885 1.24 0.885 1.315 1.535 1.315 1.535 1.1 1.67 1.1 1.67 1.315 1.915 1.315 1.915 1.1 2.05 1.1 2.05 1.315 2.365 1.315 2.365 1.06 2.435 1.06 2.435 1.315 2.705 1.315 2.705 1.01 2.84 1.01 2.84 1.315 3.085 1.315 3.085 1.01 3.22 1.01 3.22 1.315 3.465 1.315 3.465 1.01 3.6 1.01 3.6 1.315 3.845 1.315 3.845 1.01 3.98 1.01 3.98 1.315 4.055 1.315 4.26 1.315 4.26 0.975 4.33 0.975 4.33 1.315 4.635 1.315 4.635 0.975 4.705 0.975 4.705 1.315 5.015 1.315 5.015 0.975 5.085 0.975 5.085 1.315 5.395 1.315 5.395 0.975 5.465 0.975 5.465 1.315 5.51 1.315 5.51 1.485 4.055 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 5.51 -0.085 5.51 0.085 5.465 0.085 5.465 0.285 5.395 0.285 5.395 0.085 5.085 0.085 5.085 0.285 5.015 0.285 5.015 0.085 4.705 0.085 4.705 0.285 4.635 0.285 4.635 0.085 4.325 0.085 4.325 0.285 4.255 0.285 4.255 0.085 3.98 0.085 3.98 0.25 3.845 0.25 3.845 0.085 3.22 0.085 3.22 0.16 3.085 0.16 3.085 0.085 2.465 0.085 2.465 0.16 2.33 0.16 2.33 0.085 2.02 0.085 2.02 0.425 1.95 0.425 1.95 0.085 1.645 0.085 1.645 0.265 1.575 0.265 1.575 0.085 0.885 0.085 0.885 0.175 0.75 0.175 0.75 0.085 0.51 0.085 0.51 0.285 0.44 0.285 0.44 0.085 0.135 0.085 0.135 0.285 0.065 0.285 0.065 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.07 0.905 0.87 0.905 0.87 0.49 0.26 0.49 0.26 0.15 0.33 0.15 0.33 0.42 0.95 0.42 0.95 0.975 0.14 0.975 0.14 1.25 0.07 1.25  ;
+        POLYGON 0.565 1.065 1.015 1.065 1.015 0.32 0.6 0.32 0.6 0.15 0.67 0.15 0.67 0.25 1.085 0.25 1.085 0.425 1.37 0.425 1.37 0.495 1.085 0.495 1.085 1.135 0.565 1.135  ;
+        POLYGON 1.45 0.695 1.815 0.695 1.815 0.39 1.73 0.39 1.73 0.185 1.885 0.185 1.885 0.765 1.45 0.765  ;
+        POLYGON 1.315 0.715 1.385 0.715 1.385 0.83 2.1 0.83 2.1 0.195 2.17 0.195 2.17 0.9 1.315 0.9  ;
+        POLYGON 1.23 0.965 2.235 0.965 2.235 0.29 3.44 0.29 3.44 0.555 3.52 0.555 3.52 0.625 3.37 0.625 3.37 0.36 2.645 0.36 2.645 0.56 2.735 0.56 2.735 0.63 2.575 0.63 2.575 0.36 2.305 0.36 2.305 1.035 1.23 1.035 1.23 1.185 1.16 1.185 1.16 0.56 1.435 0.56 1.435 0.25 1.155 0.25 1.155 0.18 1.505 0.18 1.505 0.56 1.75 0.56 1.75 0.63 1.23 0.63  ;
+        POLYGON 2.52 0.71 2.9 0.71 2.9 0.495 2.71 0.495 2.71 0.425 3.305 0.425 3.305 0.705 3.63 0.705 3.63 0.23 3.47 0.23 3.47 0.16 3.7 0.16 3.7 0.35 4.055 0.35 4.055 0.485 3.7 0.485 3.7 0.71 3.79 0.71 3.79 0.78 3.235 0.78 3.235 0.495 2.97 0.495 2.97 0.71 3.03 0.71 3.03 0.78 2.52 0.78  ;
+  END
+END LVT_CLKGATETST_X8
+
+MACRO LVT_CLKGATE_X1
+  CLASS core ;
+  FOREIGN LVT_CLKGATE_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0497 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1287 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.54 0.42 1.895 0.42 1.895 0.56 1.54 0.56  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02975 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.91 0.525 1.08 0.525 1.08 0.7 0.91 0.7  ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0915 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2639 LAYER metal1 ;
+    ANTENNADIFFAREA 0.086625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.31 0.175 2.41 0.175 2.41 1.09 2.31 1.09  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.955 0.295 0.955 0.295 1.315 0.715 1.315 0.955 1.315 0.955 0.9 1.09 0.9 1.09 1.315 1.245 1.315 1.475 1.315 1.585 1.315 1.585 0.89 1.655 0.89 1.655 1.315 2.03 1.315 2.03 0.915 2.1 0.915 2.1 1.315 2.245 1.315 2.47 1.315 2.47 1.485 2.245 1.485 1.475 1.485 1.245 1.485 0.715 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.19 0.085 2.19 0.225 2.12 0.225 2.12 0.085 1.655 0.085 1.655 0.195 1.585 0.195 1.585 0.085 1.055 0.085 1.055 0.32 0.985 0.32 0.985 0.085 0.295 0.085 0.295 0.32 0.225 0.32 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.04 0.265 0.11 0.265 0.11 0.45 0.44 0.45 0.44 0.52 0.11 0.52 0.11 1.04 0.04 1.04  ;
+        POLYGON 0.58 0.98 0.715 0.98 0.715 1.05 0.51 1.05 0.51 0.725 0.175 0.725 0.175 0.59 0.51 0.59 0.51 0.22 0.71 0.22 0.71 0.29 0.58 0.29  ;
+        POLYGON 0.765 0.765 1.245 0.765 1.245 1.05 1.175 1.05 1.175 0.835 0.695 0.835 0.695 0.39 1.175 0.39 1.175 0.27 1.245 0.27 1.245 0.46 0.765 0.46  ;
+        POLYGON 1.145 0.525 1.405 0.525 1.405 0.195 1.475 0.195 1.475 1.09 1.405 1.09 1.405 0.66 1.145 0.66  ;
+        POLYGON 1.785 0.765 2.175 0.765 2.175 0.42 1.97 0.42 1.97 0.185 2.04 0.185 2.04 0.35 2.245 0.35 2.245 0.835 1.855 0.835 1.855 1.09 1.785 1.09  ;
+  END
+END LVT_CLKGATE_X1
+
+MACRO LVT_CLKGATE_X2
+  CLASS core ;
+  FOREIGN LVT_CLKGATE_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0168 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.58 0.42 1.65 0.42 1.65 0.66 1.58 0.66  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0289 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0884 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.34 0.42 0.51 0.42 0.51 0.59 0.34 0.59  ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0927 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2912 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1155 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.32 0.185 2.41 0.185 2.41 1.215 2.32 1.215  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.94 0.295 0.94 0.295 1.315 0.985 1.315 0.985 0.98 1.055 0.98 1.055 1.315 1.725 1.315 1.725 0.89 1.795 0.89 1.795 1.315 2.095 1.315 2.095 0.94 2.165 0.94 2.165 1.315 2.255 1.315 2.505 1.315 2.505 0.94 2.575 0.94 2.575 1.315 2.66 1.315 2.66 1.485 2.255 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 2.575 0.085 2.575 0.22 2.505 0.22 2.505 0.085 2.165 0.085 2.165 0.22 2.095 0.22 2.095 0.085 1.635 0.085 1.635 0.235 1.565 0.235 1.565 0.085 1.09 0.085 1.09 0.285 0.955 0.285 0.955 0.085 0.295 0.085 0.295 0.32 0.225 0.32 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.175 0.525 0.245 0.525 0.245 0.655 0.605 0.655 0.605 0.2 0.675 0.2 0.675 1.115 0.605 1.115 0.605 0.725 0.175 0.725  ;
+        POLYGON 0.99 0.65 1.325 0.65 1.325 1.115 1.255 1.115 1.255 0.72 0.74 0.72 0.74 0.585 0.92 0.585 0.92 0.35 1.28 0.35 1.28 0.42 0.99 0.42  ;
+        POLYGON 1.065 0.49 1.385 0.49 1.385 0.185 1.455 0.185 1.455 0.49 1.49 0.49 1.49 0.975 1.42 0.975 1.42 0.56 1.065 0.56  ;
+        POLYGON 0.04 0.295 0.11 0.295 0.11 0.805 0.43 0.805 0.43 1.18 0.85 1.18 0.85 0.79 1.19 0.79 1.19 1.18 1.57 1.18 1.57 0.755 1.715 0.755 1.715 0.56 2.095 0.56 2.095 0.63 1.785 0.63 1.785 0.825 1.64 0.825 1.64 1.25 1.12 1.25 1.12 0.86 0.92 0.86 0.92 1.25 0.36 1.25 0.36 0.875 0.11 0.875 0.11 1.17 0.04 1.17  ;
+        POLYGON 1.915 0.805 2.185 0.805 2.185 0.46 1.725 0.46 1.725 0.185 1.795 0.185 1.795 0.39 2.255 0.39 2.255 0.875 1.985 0.875 1.985 1.215 1.915 1.215  ;
+  END
+END LVT_CLKGATE_X2
+
+MACRO LVT_CLKGATE_X4
+  CLASS core ;
+  FOREIGN LVT_CLKGATE_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0717 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2444 LAYER metal1 ;
+    ANTENNAGATEAREA 0.13075 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.535 0.39 1.965 0.39 1.965 0.66 1.895 0.66 1.895 0.46 1.65 0.46 1.65 0.7 1.535 0.7  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0336 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0962 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.35 0.42 0.51 0.42 0.51 0.63 0.35 0.63  ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1946 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6448 LAYER metal1 ;
+    ANTENNADIFFAREA 0.231 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.555 0.15 2.625 0.15 2.625 0.42 2.925 0.42 2.925 0.15 2.995 0.15 2.995 1.24 2.925 1.24 2.925 0.56 2.625 0.56 2.625 1.24 2.555 1.24  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.235 1.315 0.235 0.965 0.305 0.965 0.305 1.315 0.995 1.315 0.995 0.965 1.065 0.965 1.065 1.315 1.57 1.315 1.57 1.24 1.705 1.24 1.705 1.315 1.975 1.315 1.975 1.065 2.045 1.065 2.045 1.315 2.355 1.315 2.355 1.065 2.425 1.065 2.425 1.315 2.49 1.315 2.735 1.315 2.735 0.965 2.805 0.965 2.805 1.315 3.115 1.315 3.115 0.965 3.185 0.965 3.185 1.315 3.23 1.315 3.23 1.485 2.49 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 3.185 0.085 3.185 0.215 3.115 0.215 3.115 0.085 2.805 0.085 2.805 0.215 2.735 0.215 2.735 0.085 2.46 0.085 2.46 0.185 2.325 0.185 2.325 0.085 1.65 0.085 1.65 0.285 1.58 0.285 1.58 0.085 1.065 0.085 1.065 0.32 0.995 0.32 0.995 0.085 0.305 0.085 0.305 0.32 0.235 0.32 0.235 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.185 0.525 0.255 0.525 0.255 0.695 0.615 0.695 0.615 0.2 0.685 0.2 0.685 1.095 0.615 1.095 0.615 0.765 0.185 0.765  ;
+        POLYGON 1.125 0.695 1.335 0.695 1.335 0.87 1.265 0.87 1.265 0.765 1.055 0.765 1.055 0.46 0.82 0.46 0.82 0.66 0.75 0.66 0.75 0.39 1.185 0.39 1.185 0.3 1.255 0.3 1.255 0.46 1.125 0.46  ;
+        POLYGON 1.19 0.56 1.4 0.56 1.4 0.15 1.47 0.15 1.47 1.04 1.4 1.04 1.4 0.63 1.19 0.63  ;
+        POLYGON 0.05 0.15 0.12 0.15 0.12 0.83 0.44 0.83 0.44 1.165 0.815 1.165 0.815 0.83 0.92 0.83 0.92 0.56 0.99 0.56 0.99 0.83 1.2 0.83 1.2 1.105 1.57 1.105 1.57 0.765 1.715 0.765 1.715 0.525 1.785 0.525 1.785 0.765 2.25 0.765 2.25 0.525 2.32 0.525 2.32 0.835 1.64 0.835 1.64 1.175 1.13 1.175 1.13 0.9 0.885 0.9 0.885 1.235 0.37 1.235 0.37 0.9 0.12 0.9 0.12 1.24 0.05 1.24  ;
+        POLYGON 1.79 0.905 2.42 0.905 2.42 0.325 1.95 0.325 1.95 0.255 2.49 0.255 2.49 0.975 2.235 0.975 2.235 1.24 2.165 1.24 2.165 0.975 1.86 0.975 1.86 1.24 1.79 1.24  ;
+  END
+END LVT_CLKGATE_X4
+
+MACRO LVT_CLKGATE_X8
+  CLASS core ;
+  FOREIGN LVT_CLKGATE_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.94 BY 1.4 ;
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1453 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.533 LAYER metal1 ;
+    ANTENNAGATEAREA 0.23525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.625 0.86 2.13 0.86 2.13 0.525 2.22 0.525 2.22 0.86 2.865 0.86 2.865 0.525 2.935 0.525 2.935 0.93 1.625 0.93  ;
+    END
+  END CK
+  PIN E
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0231 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.345 0.56 0.51 0.56 0.51 0.7 0.345 0.7  ;
+    END
+  END E
+  PIN GCK
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.4326 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3312 LAYER metal1 ;
+    ANTENNADIFFAREA 0.462 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.485 0.15 3.555 0.15 3.555 0.42 3.855 0.42 3.855 0.15 3.925 0.15 3.925 0.42 4.235 0.42 4.235 0.15 4.305 0.15 4.305 0.42 4.615 0.42 4.615 0.15 4.685 0.15 4.685 1.235 4.615 1.235 4.615 0.56 4.305 0.56 4.305 1.235 4.235 1.235 4.235 0.56 3.925 0.56 3.925 1.235 3.855 1.235 3.855 0.56 3.555 0.56 3.555 1.235 3.485 1.235  ;
+    END
+  END GCK
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.23 1.315 0.23 0.96 0.3 0.96 0.3 1.315 1.005 1.315 1.005 0.995 1.075 0.995 1.075 1.315 1.355 1.315 1.355 1.175 1.49 1.175 1.49 1.315 1.645 1.315 1.725 1.315 1.725 1.065 1.795 1.065 1.795 1.315 2.12 1.315 2.12 1.205 2.19 1.205 2.19 1.315 2.5 1.315 2.5 1.205 2.57 1.205 2.57 1.315 2.88 1.315 2.88 1.205 2.95 1.205 2.95 1.315 3.275 1.315 3.275 0.96 3.345 0.96 3.345 1.315 3.42 1.315 3.665 1.315 3.665 0.96 3.735 0.96 3.735 1.315 4.045 1.315 4.045 0.96 4.115 0.96 4.115 1.315 4.425 1.315 4.425 0.96 4.495 0.96 4.495 1.315 4.805 1.315 4.805 0.96 4.875 0.96 4.875 1.315 4.94 1.315 4.94 1.485 3.42 1.485 1.645 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.94 -0.085 4.94 0.085 4.875 0.085 4.875 0.285 4.805 0.285 4.805 0.085 4.495 0.085 4.495 0.285 4.425 0.285 4.425 0.085 4.115 0.085 4.115 0.285 4.045 0.285 4.045 0.085 3.74 0.085 3.74 0.285 3.67 0.285 3.67 0.085 3.38 0.085 3.38 0.16 3.245 0.16 3.245 0.085 2.605 0.085 2.605 0.16 2.47 0.16 2.47 0.085 1.85 0.085 1.85 0.16 1.715 0.16 1.715 0.085 1.49 0.085 1.49 0.16 1.355 0.16 1.355 0.085 1.075 0.085 1.075 0.285 1.005 0.285 1.005 0.085 0.335 0.085 0.335 0.25 0.2 0.25 0.2 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.39 0.8 0.39 0.8 0.46 0.645 0.46 0.645 0.87 0.575 0.87 0.575 0.46 0.115 0.46 0.115 1.235 0.045 1.235  ;
+        POLYGON 0.585 1.01 0.735 1.01 0.735 0.525 0.865 0.525 0.865 0.25 0.585 0.25 0.585 0.18 0.935 0.18 0.935 0.525 1.14 0.525 1.14 0.66 0.805 0.66 0.805 1.08 0.585 1.08  ;
+        POLYGON 1.56 1.005 1.645 1.005 1.645 1.075 1.49 1.075 1.49 0.93 0.94 0.93 0.94 1.22 0.44 1.22 0.44 0.835 0.18 0.835 0.18 0.605 0.25 0.605 0.25 0.765 0.51 0.765 0.51 1.15 0.87 1.15 0.87 0.86 1.49 0.86 1.49 0.43 1.645 0.43 1.645 0.5 1.56 0.5  ;
+        POLYGON 0.87 0.725 1.205 0.725 1.205 0.15 1.275 0.15 1.275 0.255 3.225 0.255 3.225 0.66 3.155 0.66 3.155 0.325 2.57 0.325 2.57 0.66 2.5 0.66 2.5 0.325 1.895 0.325 1.895 0.66 1.825 0.66 1.825 0.325 1.275 0.325 1.275 0.795 0.87 0.795  ;
+        POLYGON 1.905 0.995 3.07 0.995 3.07 0.795 3.005 0.795 3.005 0.46 2.74 0.46 2.74 0.795 2.31 0.795 2.31 0.46 2.095 0.46 2.095 0.39 2.38 0.39 2.38 0.725 2.67 0.725 2.67 0.39 3.075 0.39 3.075 0.725 3.35 0.725 3.35 0.525 3.42 0.525 3.42 0.795 3.14 0.795 3.14 1.235 3.07 1.235 3.07 1.065 2.795 1.065 2.795 1.2 2.66 1.2 2.66 1.065 2.415 1.065 2.415 1.2 2.28 1.2 2.28 1.065 2.04 1.065 2.04 1.2 1.905 1.2  ;
+  END
+END LVT_CLKGATE_X8
+
+MACRO LVT_DFFRS_X1
+  CLASS core ;
+  FOREIGN LVT_DFFRS_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.56 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.04845 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1157 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.12 0.585 4.31 0.585 4.31 0.84 4.12 0.84  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.7 1.345 0.7 1.345 0.84 1.2 0.84  ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0126 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0598 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0615 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.7 0.89 0.7 0.89 0.84 0.8 0.84  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.031175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0936 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.24 0.28 4.385 0.28 4.385 0.495 4.24 0.495  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.03325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1417 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.4 0.51 0.4 0.51 0.875 0.44 0.875  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0623 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2496 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.185 0.13 0.185 0.13 1.075 0.06 1.075  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.215 1.315 0.215 1.1 0.35 1.1 0.35 1.315 0.56 1.315 0.56 1.095 0.695 1.095 0.695 1.315 0.88 1.315 0.965 1.315 0.965 1.065 1.035 1.065 1.035 1.315 1.345 1.315 1.345 0.925 1.415 0.925 1.415 1.315 1.655 1.315 1.655 0.99 1.79 0.99 1.79 1.315 1.945 1.315 2.415 1.315 2.415 0.89 2.55 0.89 2.55 1.315 2.795 1.315 2.795 0.835 2.93 0.835 2.93 1.315 3.325 1.315 3.325 1.03 3.46 1.03 3.46 1.315 3.615 1.315 4.055 1.315 4.255 1.315 4.255 0.915 4.325 0.915 4.325 1.315 4.52 1.315 4.56 1.315 4.56 1.485 4.52 1.485 4.055 1.485 3.615 1.485 1.945 1.485 0.88 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.56 -0.085 4.56 0.085 4.36 0.085 4.36 0.16 4.225 0.16 4.225 0.085 3.27 0.085 3.27 0.285 3.135 0.285 3.135 0.085 2.55 0.085 2.55 0.285 2.415 0.285 2.415 0.085 1.605 0.085 1.605 0.285 1.47 0.285 1.47 0.085 1.07 0.085 1.07 0.285 0.935 0.285 0.935 0.085 0.35 0.085 0.35 0.2 0.215 0.2 0.215 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.27 0.96 0.88 0.96 0.88 1.03 0.2 1.03 0.2 0.265 0.695 0.265 0.695 0.335 0.27 0.335  ;
+        POLYGON 0.595 0.555 0.95 0.555 0.95 0.35 1.9 0.35 1.9 0.425 1.025 0.425 1.025 0.925 1.26 0.925 1.26 0.995 0.955 0.995 0.955 0.625 0.595 0.625  ;
+        POLYGON 1.505 0.855 1.945 0.855 1.945 1.075 1.875 1.075 1.875 0.925 1.575 0.925 1.575 1.075 1.505 1.075  ;
+        POLYGON 1.09 0.495 2.065 0.495 2.065 0.185 2.135 0.185 2.135 1.085 2.065 1.085 2.065 0.63 1.09 0.63  ;
+        POLYGON 2.345 0.485 2.825 0.485 2.825 0.3 2.895 0.3 2.895 0.485 3.545 0.485 3.545 0.555 2.415 0.555 2.415 0.755 2.705 0.755 2.705 1.07 2.635 1.07 2.635 0.825 2.345 0.825  ;
+        POLYGON 3.175 0.895 3.615 0.895 3.615 1.115 3.545 1.115 3.545 0.965 3.245 0.965 3.245 1.115 3.175 1.115  ;
+        POLYGON 2.5 0.62 3.76 0.62 3.76 0.285 3.83 0.285 3.83 0.62 3.92 0.62 3.92 1.115 3.85 1.115 3.85 0.69 2.5 0.69  ;
+        POLYGON 3.02 0.76 3.75 0.76 3.75 1.18 3.985 1.18 3.985 0.22 3.69 0.22 3.69 0.46 3.62 0.46 3.62 0.42 2.98 0.42 2.98 0.235 2.76 0.235 2.76 0.42 2.275 0.42 2.275 1.235 1.955 1.235 1.955 1.165 2.205 1.165 2.205 0.35 2.69 0.35 2.69 0.165 3.05 0.165 3.05 0.35 3.62 0.35 3.62 0.15 4.055 0.15 4.055 1.25 3.68 1.25 3.68 0.83 3.09 0.83 3.09 1.07 3.02 1.07  ;
+        POLYGON 4.45 0.185 4.52 0.185 4.52 1.25 4.45 1.25  ;
+  END
+END LVT_DFFRS_X1
+
+MACRO LVT_DFFRS_X2
+  CLASS core ;
+  FOREIGN LVT_DFFRS_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.94 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.04495 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.13 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.485 0.28 4.69 0.28 4.69 0.46 4.555 0.46 4.555 0.575 4.485 0.575  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0585 LAYER metal1 ;
+    ANTENNAGATEAREA 0.04875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.39 0.545 1.46 0.545 1.46 0.7 1.39 0.7  ;
+    END
+  END RN
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0585 LAYER metal1 ;
+    ANTENNAGATEAREA 0.075 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.545 1.27 0.545 1.27 0.7 1.2 0.7  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.016 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.62 0.54 4.72 0.54 4.72 0.7 4.62 0.7  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.042375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1664 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.625 0.4 0.7 0.4 0.7 0.965 0.625 0.965  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0612 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2197 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.24 0.2 0.32 0.2 0.32 0.965 0.24 0.965  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.05 1.315 0.05 0.925 0.12 0.925 0.12 1.315 0.425 1.315 0.425 1.205 0.495 1.205 0.495 1.315 0.875 1.315 0.875 1.205 0.945 1.205 0.945 1.315 1.225 1.315 1.335 1.315 1.335 1.08 1.405 1.08 1.405 1.315 1.715 1.315 1.715 0.895 1.785 0.895 1.785 1.315 2.055 1.315 2.055 0.955 2.125 0.955 2.125 1.315 2.315 1.315 2.815 1.315 2.815 0.955 2.885 0.955 2.885 1.315 3.195 1.315 3.195 0.765 3.265 0.765 3.265 1.315 3.695 1.315 3.695 1.03 3.83 1.03 3.83 1.315 3.985 1.315 4.39 1.315 4.59 1.315 4.59 0.765 4.66 0.765 4.66 1.315 4.855 1.315 4.94 1.315 4.94 1.485 4.855 1.485 4.39 1.485 3.985 1.485 2.315 1.485 1.225 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.94 -0.085 4.94 0.085 4.695 0.085 4.695 0.215 4.56 0.215 4.56 0.085 3.64 0.085 3.64 0.285 3.505 0.285 3.505 0.085 2.92 0.085 2.92 0.285 2.785 0.285 2.785 0.085 1.94 0.085 1.94 0.32 1.87 0.32 1.87 0.085 1.405 0.085 1.405 0.32 1.335 0.32 1.335 0.085 0.875 0.085 0.875 0.2 0.805 0.2 0.805 0.085 0.495 0.085 0.495 0.2 0.425 0.2 0.425 0.085 0.12 0.085 0.12 0.415 0.05 0.415 0.05 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.56 1.035 1.225 1.035 1.225 1.105 0.49 1.105 0.49 0.66 0.385 0.66 0.385 0.525 0.49 0.525 0.49 0.265 1.065 0.265 1.065 0.335 0.56 0.335  ;
+        POLYGON 0.84 0.525 1.065 0.525 1.065 0.41 1.715 0.41 1.715 0.205 1.785 0.205 1.785 0.41 2.27 0.41 2.27 0.48 1.135 0.48 1.135 0.845 1.63 0.845 1.63 0.915 1.065 0.915 1.065 0.66 0.84 0.66  ;
+        POLYGON 1.875 0.82 2.315 0.82 2.315 1.075 2.245 1.075 2.245 0.89 1.945 0.89 1.945 1.075 1.875 1.075  ;
+        POLYGON 1.58 0.58 2.425 0.58 2.425 0.2 2.505 0.2 2.505 1.075 2.425 1.075 2.425 0.65 1.58 0.65  ;
+        POLYGON 2.76 0.485 3.195 0.485 3.195 0.32 3.265 0.32 3.265 0.485 3.915 0.485 3.915 0.555 2.83 0.555 2.83 0.755 3.075 0.755 3.075 1.04 3.005 1.04 3.005 0.825 2.76 0.825  ;
+        POLYGON 3.545 0.895 3.985 0.895 3.985 1.115 3.915 1.115 3.915 0.965 3.615 0.965 3.615 1.115 3.545 1.115  ;
+        POLYGON 2.895 0.62 4.13 0.62 4.13 0.285 4.2 0.285 4.2 0.62 4.255 0.62 4.255 1.115 4.185 1.115 4.185 0.69 2.895 0.69  ;
+        POLYGON 3.39 0.76 4.12 0.76 4.12 1.18 4.32 1.18 4.32 0.22 4.055 0.22 4.055 0.46 3.985 0.46 3.985 0.42 3.35 0.42 3.35 0.255 3.13 0.255 3.13 0.42 2.64 0.42 2.64 1.21 2.325 1.21 2.325 1.14 2.57 1.14 2.57 0.35 3.06 0.35 3.06 0.185 3.42 0.185 3.42 0.35 3.985 0.35 3.985 0.15 4.39 0.15 4.39 1.25 4.05 1.25 4.05 0.83 3.46 0.83 3.46 1.04 3.39 1.04  ;
+        POLYGON 4.785 0.25 4.855 0.25 4.855 1.24 4.785 1.24  ;
+  END
+END LVT_DFFRS_X2
+
+MACRO LVT_DFFR_X1
+  CLASS core ;
+  FOREIGN LVT_DFFR_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.8 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0222 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.6 0.56 0.72 0.56 0.72 0.745 0.6 0.745  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.181 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6682 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.495 1.165 1.63 1.165 1.815 1.165 1.815 0.93 2.175 0.93 2.175 1.18 2.255 1.18 2.455 1.18 2.455 0.56 2.6 0.56 2.6 0.64 2.89 0.64 2.89 0.71 2.525 0.71 2.525 1.25 2.255 1.25 2.105 1.25 2.105 1 1.885 1 1.885 1.235 1.63 1.235 1.495 1.235  ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.175 0.42 0.32 0.42 0.32 0.56 0.175 0.56  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0852 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2977 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.66 0.185 3.74 0.185 3.74 1.25 3.66 1.25  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2405 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.285 0.4 3.36 0.4 3.36 1.25 3.285 1.25  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.23 1.315 0.23 1.065 0.3 1.065 0.3 1.315 0.355 1.315 0.575 1.315 0.575 1.015 0.645 1.015 0.645 1.315 1.295 1.315 1.295 1.03 1.43 1.03 1.43 1.315 1.63 1.315 1.95 1.315 1.95 1.065 2.02 1.065 2.02 1.315 2.255 1.315 2.7 1.315 2.7 0.98 2.77 0.98 2.77 1.315 3.08 1.315 3.08 1.065 3.15 1.065 3.15 1.315 3.465 1.315 3.465 0.975 3.535 0.975 3.535 1.315 3.595 1.315 3.8 1.315 3.8 1.485 3.595 1.485 2.255 1.485 1.63 1.485 0.355 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.8 -0.085 3.8 0.085 3.535 0.085 3.535 0.195 3.465 0.195 3.465 0.085 2.77 0.085 2.77 0.32 2.7 0.32 2.7 0.085 2.03 0.085 2.03 0.285 1.895 0.285 1.895 0.085 1.585 0.085 1.585 0.41 1.515 0.41 1.515 0.085 0.645 0.085 0.645 0.32 0.575 0.32 0.575 0.085 0.3 0.085 0.3 0.32 0.23 0.32 0.23 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.04 0.185 0.11 0.185 0.11 0.7 0.355 0.7 0.355 0.835 0.11 0.835 0.11 1.25 0.04 1.25  ;
+        POLYGON 1.135 0.895 1.565 0.895 1.565 1.025 1.63 1.025 1.63 1.095 1.495 1.095 1.495 0.965 1.205 0.965 1.205 1.125 1.135 1.125  ;
+        POLYGON 0.955 0.29 1.025 0.29 1.025 0.625 1.895 0.625 1.895 0.695 1.025 0.695 1.025 1.125 0.955 1.125  ;
+        POLYGON 0.42 0.185 0.49 0.185 0.49 0.425 0.82 0.425 0.82 0.15 1.16 0.15 1.16 0.485 2.12 0.485 2.12 0.67 1.985 0.67 1.985 0.555 1.09 0.555 1.09 0.22 0.89 0.22 0.89 0.785 0.82 0.785 0.82 0.495 0.49 0.495 0.49 1.25 0.42 1.25  ;
+        POLYGON 1.19 0.76 2.185 0.76 2.185 0.42 1.69 0.42 1.69 0.185 1.76 0.185 1.76 0.35 2.255 0.35 2.255 0.83 1.75 0.83 1.75 0.96 1.68 0.96 1.68 0.83 1.19 0.83  ;
+        POLYGON 2.32 0.185 2.39 0.185 2.39 0.425 3.05 0.425 3.05 0.66 2.98 0.66 2.98 0.495 2.39 0.495 2.39 1.115 2.32 1.115  ;
+        POLYGON 2.59 0.81 3.115 0.81 3.115 0.335 3.05 0.335 3.05 0.265 3.595 0.265 3.595 0.66 3.525 0.66 3.525 0.335 3.185 0.335 3.185 0.88 2.96 0.88 2.96 1.25 2.89 1.25 2.89 0.88 2.59 0.88  ;
+  END
+END LVT_DFFR_X1
+
+MACRO LVT_DFFR_X2
+  CLASS core ;
+  FOREIGN LVT_DFFR_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.18 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0198 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0754 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.52 0.74 0.52 0.74 0.7 0.63 0.7  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1876 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6331 LAYER metal1 ;
+    ANTENNAGATEAREA 0.06125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.515 1.165 1.65 1.165 1.835 1.165 1.835 0.965 2.24 0.965 2.24 1.15 2.26 1.15 2.52 1.15 2.52 0.56 2.905 0.56 2.905 0.7 2.59 0.7 2.59 1.22 2.26 1.22 2.17 1.22 2.17 1.035 1.905 1.035 1.905 1.235 1.65 1.235 1.515 1.235  ;
+    END
+  END RN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.42 0.32 0.42 0.32 0.56 0.195 0.56  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.067125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2522 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.86 0.185 3.935 0.185 3.935 1.08 3.86 1.08  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0518 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1924 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1904 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.41 0.645 3.48 0.645 3.48 0.185 3.55 0.185 3.55 0.785 3.41 0.785  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.245 1.315 0.245 0.945 0.315 0.945 0.315 1.315 0.375 1.315 0.59 1.315 0.59 1.015 0.66 1.015 0.66 1.315 1.315 1.315 1.315 1.03 1.45 1.03 1.45 1.315 1.65 1.315 1.97 1.315 1.97 1.1 2.105 1.1 2.105 1.315 2.26 1.315 2.725 1.315 2.725 1 2.86 1 2.86 1.315 3.19 1.315 3.19 1.065 3.26 1.065 3.26 1.315 3.67 1.315 3.67 1.065 3.74 1.065 3.74 1.315 3.79 1.315 4.05 1.315 4.05 1.065 4.12 1.065 4.12 1.315 4.18 1.315 4.18 1.485 3.79 1.485 2.26 1.485 1.65 1.485 0.375 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.18 -0.085 4.18 0.085 4.12 0.085 4.12 0.335 4.05 0.335 4.05 0.085 3.74 0.085 3.74 0.335 3.67 0.335 3.67 0.085 3.365 0.085 3.365 0.195 3.295 0.195 3.295 0.085 2.76 0.085 2.76 0.32 2.69 0.32 2.69 0.085 2.035 0.085 2.035 0.285 1.9 0.285 1.9 0.085 1.605 0.085 1.605 0.41 1.535 0.41 1.535 0.085 0.66 0.085 0.66 0.32 0.59 0.32 0.59 0.085 0.315 0.085 0.315 0.32 0.245 0.32 0.245 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.185 0.13 0.185 0.13 0.655 0.375 0.655 0.375 0.79 0.13 0.79 0.13 1.22 0.06 1.22  ;
+        POLYGON 1.155 0.895 1.585 0.895 1.585 1.025 1.65 1.025 1.65 1.095 1.515 1.095 1.515 0.965 1.225 0.965 1.225 1.125 1.155 1.125  ;
+        POLYGON 0.97 0.29 1.04 0.29 1.04 0.625 1.925 0.625 1.925 0.765 1.85 0.765 1.85 0.695 1.04 0.695 1.04 1.125 0.97 1.125  ;
+        POLYGON 0.44 0.185 0.51 0.185 0.51 0.385 0.83 0.385 0.83 0.15 1.175 0.15 1.175 0.485 2.125 0.485 2.125 0.705 2.055 0.705 2.055 0.555 1.105 0.555 1.105 0.22 0.9 0.22 0.9 0.82 0.83 0.82 0.83 0.455 0.51 0.455 0.51 0.98 0.44 0.98  ;
+        POLYGON 1.235 0.76 1.77 0.76 1.77 0.83 2.19 0.83 2.19 0.42 1.75 0.42 1.75 0.185 1.82 0.185 1.82 0.35 2.26 0.35 2.26 0.9 1.77 0.9 1.77 0.96 1.7 0.96 1.7 0.83 1.235 0.83  ;
+        POLYGON 2.285 0.215 2.445 0.215 2.445 0.385 2.88 0.385 2.88 0.265 3.31 0.265 3.31 0.66 3.24 0.66 3.24 0.335 2.95 0.335 2.95 0.455 2.445 0.455 2.445 1.085 2.375 1.085 2.375 0.285 2.285 0.285  ;
+        POLYGON 2.655 0.765 2.725 0.765 2.725 0.85 3.07 0.85 3.07 0.4 3.14 0.4 3.14 0.85 3.72 0.85 3.72 0.525 3.79 0.525 3.79 0.92 3.04 0.92 3.04 1.22 2.97 1.22 2.97 0.92 2.655 0.92  ;
+  END
+END LVT_DFFR_X2
+
+MACRO LVT_DFFS_X1
+  CLASS core ;
+  FOREIGN LVT_DFFS_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.8 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0238 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.34 0.56 0.51 0.56 0.51 0.7 0.34 0.7  ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0231 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.625 0.7 2.79 0.7 2.79 0.84 2.625 0.84  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.026275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1001 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.705 0.59 1.84 0.59 1.84 0.84 1.77 0.84 1.77 0.725 1.705 0.725  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.08155 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2964 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.575 0.185 3.645 0.185 3.645 0.56 3.74 0.56 3.74 0.7 3.645 0.7 3.645 1.16 3.575 1.16  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0651 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2353 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.195 0.185 3.265 0.185 3.265 0.56 3.36 0.56 3.36 0.7 3.265 0.7 3.265 0.925 3.195 0.925  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.9 0.295 0.9 0.295 1.315 0.57 1.315 1.015 1.315 1.015 0.94 1.085 0.94 1.085 1.315 1.41 1.315 1.41 0.885 1.48 0.885 1.48 1.315 1.485 1.315 1.755 1.315 1.755 0.905 1.825 0.905 1.825 1.315 2.48 1.315 2.48 1.065 2.615 1.065 2.615 1.315 2.77 1.315 2.855 1.315 2.855 1.005 2.925 1.005 2.925 1.315 3.38 1.315 3.38 1.205 3.45 1.205 3.45 1.315 3.505 1.315 3.8 1.315 3.8 1.485 3.505 1.485 2.925 1.485 2.77 1.485 1.485 1.485 0.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.8 -0.085 3.8 0.085 3.455 0.085 3.455 0.46 3.385 0.46 3.385 0.085 2.805 0.085 2.805 0.34 2.67 0.34 2.67 0.085 1.82 0.085 1.82 0.375 1.75 0.375 1.75 0.085 1.11 0.085 1.11 0.32 1.04 0.32 1.04 0.085 0.295 0.085 0.295 0.32 0.225 0.32 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.04 0.185 0.11 0.185 0.11 0.765 0.57 0.765 0.57 0.835 0.11 0.835 0.11 1.16 0.04 1.16  ;
+        POLYGON 0.59 0.975 0.795 0.975 0.795 0.615 0.77 0.615 0.77 0.355 0.59 0.355 0.59 0.285 0.84 0.285 0.84 0.545 1.35 0.545 1.35 0.685 1.28 0.685 1.28 0.615 0.865 0.615 0.865 1.045 0.59 1.045  ;
+        POLYGON 0.94 0.685 1.01 0.685 1.01 0.75 1.415 0.75 1.415 0.285 1.485 0.285 1.485 0.82 1.29 0.82 1.29 1.09 1.22 1.09 1.22 0.82 0.94 0.82  ;
+        POLYGON 0.175 0.42 0.445 0.42 0.445 0.15 0.975 0.15 0.975 0.385 1.28 0.385 1.28 0.15 1.64 0.15 1.64 0.44 1.97 0.44 1.97 0.15 2.32 0.15 2.32 0.22 2.04 0.22 2.04 0.665 2.095 0.665 2.095 0.8 1.97 0.8 1.97 0.51 1.64 0.51 1.64 0.815 1.67 0.815 1.67 1.09 1.57 1.09 1.57 0.22 1.35 0.22 1.35 0.455 0.905 0.455 0.905 0.22 0.515 0.22 0.515 0.42 0.705 0.42 0.705 0.72 0.73 0.72 0.73 0.855 0.635 0.855 0.635 0.49 0.245 0.49 0.245 0.685 0.175 0.685  ;
+        POLYGON 2.33 0.93 2.77 0.93 2.77 1.15 2.7 1.15 2.7 1 2.4 1 2.4 1.15 2.33 1.15  ;
+        POLYGON 2.105 1.045 2.17 1.045 2.17 0.36 2.105 0.36 2.105 0.29 2.24 0.29 2.24 0.56 2.925 0.56 2.925 0.63 2.24 0.63 2.24 1.115 2.105 1.115  ;
+        POLYGON 2.375 0.42 2.905 0.42 2.905 0.185 2.975 0.185 2.975 0.42 3.08 0.42 3.08 0.995 3.435 0.995 3.435 0.525 3.505 0.525 3.505 1.065 3.01 1.065 3.01 0.49 2.375 0.49  ;
+  END
+END LVT_DFFS_X1
+
+MACRO LVT_DFFS_X2
+  CLASS core ;
+  FOREIGN LVT_DFFS_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.99 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0224 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.35 0.56 0.51 0.56 0.51 0.7 0.35 0.7  ;
+    END
+  END D
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0161 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0663 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.675 0.56 2.79 0.56 2.79 0.7 2.675 0.7  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0884 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.75 0.59 1.84 0.59 1.84 0.84 1.75 0.84  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.03675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1547 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.1 0.4 3.17 0.4 3.17 0.925 3.1 0.925  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.03675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1547 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.48 0.4 3.55 0.4 3.55 0.925 3.48 0.925  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.235 1.315 0.235 0.94 0.305 0.94 0.305 1.315 0.585 1.315 1.08 1.315 1.08 0.94 1.15 0.94 1.15 1.315 1.46 1.315 1.46 0.94 1.53 0.94 1.53 1.315 1.535 1.315 1.805 1.315 1.805 0.94 1.875 0.94 1.875 1.315 2.53 1.315 2.53 1.065 2.665 1.065 2.665 1.315 2.82 1.315 2.91 1.315 2.91 1.205 2.98 1.205 2.98 1.315 3.285 1.315 3.285 1.205 3.355 1.205 3.355 1.315 3.66 1.315 3.66 1.205 3.73 1.205 3.73 1.315 3.92 1.315 3.99 1.315 3.99 1.485 3.92 1.485 2.82 1.485 1.535 1.485 0.585 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.99 -0.085 3.99 0.085 3.73 0.085 3.73 0.195 3.66 0.195 3.66 0.085 3.35 0.085 3.35 0.195 3.28 0.195 3.28 0.085 2.855 0.085 2.855 0.34 2.72 0.34 2.72 0.085 1.87 0.085 1.87 0.32 1.8 0.32 1.8 0.085 1.16 0.085 1.16 0.37 1.09 0.37 1.09 0.085 0.305 0.085 0.305 0.32 0.235 0.32 0.235 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.185 0.12 0.185 0.12 0.765 0.585 0.765 0.585 0.835 0.12 0.835 0.12 1.215 0.05 1.215  ;
+        POLYGON 0.585 0.975 0.82 0.975 0.82 0.355 0.59 0.355 0.59 0.285 0.89 0.285 0.89 0.57 1.4 0.57 1.4 0.705 0.89 0.705 0.89 1.045 0.585 1.045  ;
+        POLYGON 0.965 0.77 1.465 0.77 1.465 0.285 1.535 0.285 1.535 0.84 0.965 0.84  ;
+        POLYGON 0.19 0.425 0.455 0.425 0.455 0.15 1.025 0.15 1.025 0.435 1.225 0.435 1.225 0.15 1.685 0.15 1.685 0.455 2.02 0.455 2.02 0.15 2.395 0.15 2.395 0.22 2.09 0.22 2.09 0.665 2.145 0.665 2.145 0.8 2.02 0.8 2.02 0.525 1.685 0.525 1.685 0.94 1.72 0.94 1.72 1.075 1.615 1.075 1.615 0.22 1.295 0.22 1.295 0.505 0.955 0.505 0.955 0.22 0.525 0.22 0.525 0.425 0.72 0.425 0.72 0.735 0.755 0.735 0.755 0.87 0.65 0.87 0.65 0.495 0.26 0.495 0.26 0.695 0.19 0.695  ;
+        POLYGON 2.38 0.93 2.82 0.93 2.82 1.15 2.75 1.15 2.75 1 2.45 1 2.45 1.15 2.38 1.15  ;
+        POLYGON 2.155 1.045 2.22 1.045 2.22 0.36 2.155 0.36 2.155 0.29 2.29 0.29 2.29 0.405 2.965 0.405 2.965 0.265 3.685 0.265 3.685 0.66 3.615 0.66 3.615 0.335 3.035 0.335 3.035 0.475 2.29 0.475 2.29 1.115 2.155 1.115  ;
+        POLYGON 2.45 0.795 2.99 0.795 2.99 0.99 3.235 0.99 3.235 0.525 3.305 0.525 3.305 0.99 3.85 0.99 3.85 0.26 3.92 0.26 3.92 1.215 3.85 1.215 3.85 1.06 2.92 1.06 2.92 0.865 2.45 0.865  ;
+  END
+END LVT_DFFS_X2
+
+MACRO LVT_DFF_X1
+  CLASS core ;
+  FOREIGN LVT_DFF_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0272 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0858 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.81 0.53 0.97 0.53 0.97 0.7 0.81 0.7  ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0187 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.56 0.53 1.67 0.53 1.67 0.7 1.56 0.7  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0609 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2444 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.1 0.26 3.17 0.26 3.17 1.13 3.1 1.13  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.03675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1547 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.72 0.26 2.79 0.26 2.79 0.785 2.72 0.785  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 0.98 0.31 0.98 0.31 1.315 1.005 1.315 1.005 1.08 1.075 1.08 1.075 1.315 1.61 1.315 1.61 0.9 1.68 0.9 1.68 1.315 2.345 1.315 2.345 1.1 2.48 1.1 2.48 1.315 2.905 1.315 2.905 0.985 2.975 0.985 2.975 1.315 3.035 1.315 3.23 1.315 3.23 1.485 3.035 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 2.975 0.085 2.975 0.46 2.905 0.46 2.905 0.085 2.48 0.085 2.48 0.37 2.345 0.37 2.345 0.085 1.68 0.085 1.68 0.36 1.61 0.36 1.61 0.085 1.11 0.085 1.11 0.3 0.975 0.3 0.975 0.085 0.31 0.085 0.31 0.405 0.24 0.405 0.24 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.27 0.13 0.27 0.13 0.61 0.57 0.61 0.57 0.745 0.13 0.745 0.13 1.13 0.06 1.13  ;
+        POLYGON 0.635 0.285 0.705 0.285 0.705 0.765 1.12 0.765 1.12 0.53 1.19 0.53 1.19 0.835 0.705 0.835 0.705 1.115 0.635 1.115  ;
+        POLYGON 0.38 0.15 0.855 0.15 0.855 0.37 1.2 0.37 1.2 0.27 1.27 0.27 1.27 0.37 1.345 0.37 1.345 0.995 1.275 0.995 1.275 0.44 0.785 0.44 0.785 0.22 0.45 0.22 0.45 0.545 0.38 0.545  ;
+        POLYGON 0.485 1.18 0.87 1.18 0.87 0.945 1.21 0.945 1.21 1.18 1.425 1.18 1.425 0.225 1.495 0.225 1.495 0.765 1.855 0.765 1.855 0.15 2.205 0.15 2.205 0.22 1.925 0.22 1.925 0.835 1.495 0.835 1.495 1.25 1.14 1.25 1.14 1.015 0.94 1.015 0.94 1.25 0.485 1.25  ;
+        POLYGON 2 0.285 2.07 0.285 2.07 0.525 2.505 0.525 2.505 0.66 2.07 0.66 2.07 1.2 2 1.2  ;
+        POLYGON 2.265 0.73 2.57 0.73 2.57 0.225 2.64 0.225 2.64 0.85 2.965 0.85 2.965 0.525 3.035 0.525 3.035 0.92 2.64 0.92 2.64 1.115 2.57 1.115 2.57 0.8 2.265 0.8  ;
+  END
+END LVT_DFF_X1
+
+MACRO LVT_DFF_X2
+  CLASS core ;
+  FOREIGN LVT_DFF_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.61 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0196 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.94 0.56 1.08 0.56 1.08 0.7 0.94 0.7  ;
+    END
+  END D
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0112 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0572 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.57 0.56 1.65 0.56 1.65 0.7 1.57 0.7  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06055 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2431 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.29 0.25 3.36 0.25 3.36 1.115 3.29 1.115  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.04725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1937 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.91 0.25 2.98 0.25 2.98 0.925 2.91 0.925  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.255 1.315 0.255 0.965 0.325 0.965 0.325 1.315 1.015 1.315 1.015 1.08 1.085 1.08 1.085 1.315 1.62 1.315 1.62 0.9 1.69 0.9 1.69 1.315 2.35 1.315 2.35 0.875 2.485 0.875 2.485 1.315 2.73 1.315 2.73 1.205 2.8 1.205 2.8 1.315 3.105 1.315 3.105 1.205 3.175 1.205 3.175 1.315 3.215 1.315 3.485 1.315 3.485 0.84 3.555 0.84 3.555 1.315 3.61 1.315 3.61 1.485 3.215 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.61 -0.085 3.61 0.085 3.555 0.085 3.555 0.46 3.485 0.46 3.485 0.085 3.175 0.085 3.175 0.46 3.105 0.46 3.105 0.085 2.8 0.085 2.8 0.46 2.73 0.46 2.73 0.085 2.485 0.085 2.485 0.45 2.35 0.45 2.35 0.085 1.69 0.085 1.69 0.385 1.62 0.385 1.62 0.085 1.12 0.085 1.12 0.215 0.985 0.215 0.985 0.085 0.325 0.085 0.325 0.385 0.255 0.385 0.255 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.075 0.325 0.145 0.325 0.145 0.765 0.555 0.765 0.555 0.565 0.625 0.565 0.625 0.835 0.145 0.835 0.145 1.055 0.075 1.055  ;
+        POLYGON 0.61 1 0.69 1 0.69 0.355 0.61 0.355 0.61 0.285 0.76 0.285 0.76 0.765 1.145 0.765 1.145 0.565 1.215 0.565 1.215 0.835 0.76 0.835 0.76 1.07 0.61 1.07  ;
+        POLYGON 0.39 0.15 0.895 0.15 0.895 0.285 1.355 0.285 1.355 1.115 1.285 1.115 1.285 0.355 0.825 0.355 0.825 0.22 0.46 0.22 0.46 0.7 0.39 0.7  ;
+        POLYGON 0.5 1.18 0.865 1.18 0.865 0.945 1.22 0.945 1.22 1.18 1.435 1.18 1.435 0.25 1.505 0.25 1.505 0.765 1.875 0.765 1.875 0.215 2.215 0.215 2.215 0.285 1.945 0.285 1.945 0.835 1.505 0.835 1.505 1.25 1.15 1.25 1.15 1.015 0.935 1.015 0.935 1.25 0.5 1.25  ;
+        POLYGON 2.01 0.35 2.08 0.35 2.08 0.525 2.51 0.525 2.51 0.66 2.08 0.66 2.08 0.975 2.01 0.975  ;
+        POLYGON 2.245 0.735 2.575 0.735 2.575 0.2 2.645 0.2 2.645 1.045 3.145 1.045 3.145 0.525 3.215 0.525 3.215 1.115 2.575 1.115 2.575 0.805 2.245 0.805  ;
+  END
+END LVT_DFF_X2
+
+MACRO LVT_DLH_X1
+  CLASS core ;
+  FOREIGN LVT_DLH_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.9 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.95 0.525 1.08 0.525 1.08 0.7 0.95 0.7  ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0767 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.2 0.525 0.32 0.525 0.32 0.7 0.2 0.7  ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.042 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1742 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.185 0.51 0.185 0.51 0.785 0.44 0.785  ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.25 1.315 0.25 0.985 0.32 0.985 0.32 1.315 0.78 1.315 0.845 1.315 0.845 0.965 0.915 0.965 0.915 1.315 1.43 1.315 1.595 1.315 1.595 1.025 1.665 1.025 1.665 1.315 1.725 1.315 1.86 1.315 1.9 1.315 1.9 1.485 1.86 1.485 1.725 1.485 1.43 1.485 0.78 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.9 -0.085 1.9 0.085 1.665 0.085 1.665 0.445 1.595 0.445 1.595 0.085 0.94 0.085 0.94 0.285 0.805 0.285 0.805 0.085 0.32 0.085 0.32 0.32 0.25 0.32 0.25 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.065 0.185 0.135 0.185 0.135 0.85 0.575 0.85 0.575 1.18 0.78 1.18 0.78 1.25 0.505 1.25 0.505 0.92 0.135 0.92 0.135 1.24 0.065 1.24  ;
+        POLYGON 1.095 1.18 1.43 1.18 1.43 1.25 1.025 1.25 1.025 0.835 0.72 0.835 0.72 1.115 0.65 1.115 0.65 0.185 0.72 0.185 0.72 0.765 1.145 0.765 1.145 0.49 1.28 0.49 1.28 0.56 1.215 0.56 1.215 0.835 1.095 0.835  ;
+        POLYGON 1.19 1.045 1.345 1.045 1.345 0.42 0.855 0.42 0.855 0.66 0.785 0.66 0.785 0.35 1.415 0.35 1.415 0.66 1.725 0.66 1.725 0.795 1.415 0.795 1.415 1.115 1.19 1.115  ;
+        POLYGON 1.485 0.525 1.79 0.525 1.79 0.32 1.86 0.32 1.86 1.16 1.79 1.16 1.79 0.595 1.485 0.595  ;
+  END
+END LVT_DLH_X1
+
+MACRO LVT_DLH_X2
+  CLASS core ;
+  FOREIGN LVT_DLH_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.023625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.135 0.525 1.27 0.525 1.27 0.7 1.135 0.7  ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0245 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0819 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.18 0.525 0.32 0.525 0.32 0.7 0.18 0.7  ;
+    END
+  END G
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.042 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1742 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.185 0.51 0.185 0.51 0.785 0.44 0.785  ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 1.055 0.31 1.055 0.31 1.315 0.62 1.315 0.62 1 0.69 1 0.69 1.315 0.78 1.315 1.03 1.315 1.03 1.04 1.1 1.04 1.1 1.315 1.78 1.315 1.78 1.08 1.85 1.08 1.85 1.315 1.91 1.315 2.045 1.315 2.09 1.315 2.09 1.485 2.045 1.485 1.91 1.485 0.78 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 1.85 0.085 1.85 0.32 1.78 0.32 1.78 0.085 1.1 0.085 1.1 0.32 1.03 0.32 1.03 0.085 0.69 0.085 0.69 0.255 0.62 0.255 0.62 0.085 0.31 0.085 0.31 0.255 0.24 0.255 0.24 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.185 0.115 0.185 0.115 0.85 0.71 0.85 0.71 0.375 0.78 0.375 0.78 0.92 0.115 0.92 0.115 1.24 0.045 1.24  ;
+        POLYGON 0.82 0.975 0.85 0.975 0.85 0.31 0.82 0.31 0.82 0.175 0.92 0.175 0.92 0.39 1.475 0.39 1.475 0.67 1.405 0.67 1.405 0.46 0.92 0.46 0.92 1.25 0.82 1.25  ;
+        POLYGON 0.985 0.525 1.055 0.525 1.055 0.78 1.545 0.78 1.545 0.32 1.41 0.32 1.41 0.185 1.615 0.185 1.615 0.74 1.91 0.74 1.91 0.875 1.47 0.875 1.47 1.2 1.4 1.2 1.4 0.85 0.985 0.85  ;
+        POLYGON 1.705 0.495 1.975 0.495 1.975 0.185 2.045 0.185 2.045 1.215 1.975 1.215 1.975 0.63 1.705 0.63  ;
+  END
+END LVT_DLH_X2
+
+MACRO LVT_DLL_X1
+  CLASS core ;
+  FOREIGN LVT_DLL_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.9 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0252 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0832 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.56 0.43 0.56 0.43 0.7 0.25 0.7  ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.58 0.525 1.705 0.525 1.705 0.7 1.58 0.7  ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0406 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.169 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.39 0.26 1.46 0.26 1.46 0.84 1.39 0.84  ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.275 1.315 0.275 0.915 0.345 0.915 0.345 1.315 1.035 1.315 1.035 0.95 1.105 0.95 1.105 1.315 1.575 1.315 1.575 1.04 1.645 1.04 1.645 1.315 1.84 1.315 1.9 1.315 1.9 1.485 1.84 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.9 -0.085 1.9 0.085 1.645 0.085 1.645 0.235 1.575 0.235 1.575 0.085 1.105 0.085 1.105 0.42 1.035 0.42 1.035 0.085 0.345 0.085 0.345 0.415 0.275 0.415 0.275 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.095 0.28 0.165 0.28 0.165 0.78 0.53 0.78 0.53 0.15 0.845 0.15 0.845 0.22 0.6 0.22 0.6 1.25 0.53 1.25 0.53 0.85 0.165 0.85 0.165 1.085 0.095 1.085  ;
+        POLYGON 0.665 0.285 0.735 0.285 0.735 0.525 1.165 0.525 1.165 0.66 0.735 0.66 0.735 1.085 0.665 1.085  ;
+        POLYGON 0.9 0.775 1.23 0.775 1.23 0.285 1.3 0.285 1.3 1.085 1.23 1.085 1.23 0.845 0.9 0.845  ;
+        POLYGON 1.235 1.18 1.44 1.18 1.44 0.905 1.77 0.905 1.77 0.195 1.84 0.195 1.84 1.24 1.77 1.24 1.77 0.975 1.51 0.975 1.51 1.25 1.235 1.25  ;
+  END
+END LVT_DLL_X1
+
+MACRO LVT_DLL_X2
+  CLASS core ;
+  FOREIGN LVT_DLL_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0247 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0832 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.51 0.38 0.51 0.38 0.7 0.25 0.7  ;
+    END
+  END D
+  PIN GN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0767 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.77 0.525 1.89 0.525 1.89 0.7 1.77 0.7  ;
+    END
+  END GN
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.05215 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2119 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.58 0.26 1.65 0.26 1.65 1.005 1.58 1.005  ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 0.9 0.295 0.9 0.295 1.315 0.985 1.315 0.985 0.875 1.055 0.875 1.055 1.315 1.385 1.315 1.385 1.205 1.455 1.205 1.455 1.315 1.76 1.315 1.76 1.205 1.83 1.205 1.83 1.315 2.025 1.315 2.09 1.315 2.09 1.485 2.025 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 1.83 0.085 1.83 0.195 1.76 0.195 1.76 0.085 1.455 0.085 1.455 0.395 1.385 0.395 1.385 0.085 1.055 0.085 1.055 0.46 0.985 0.46 0.985 0.085 0.295 0.085 0.295 0.37 0.225 0.37 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.3 0.115 0.3 0.115 0.765 0.48 0.765 0.48 0.195 0.82 0.195 0.82 0.265 0.55 0.265 0.55 0.835 0.115 0.835 0.115 1.145 0.045 1.145  ;
+        POLYGON 0.615 0.335 0.685 0.335 0.685 0.525 1.125 0.525 1.125 0.66 0.685 0.66 0.685 1.015 0.615 1.015  ;
+        POLYGON 0.85 0.73 1.19 0.73 1.19 0.325 1.26 0.325 1.26 1.005 1.19 1.005 1.19 0.8 0.85 0.8  ;
+        POLYGON 1.185 1.07 1.955 1.07 1.955 0.195 2.025 0.195 2.025 1.24 1.955 1.24 1.955 1.14 1.32 1.14 1.32 1.25 1.185 1.25  ;
+  END
+END LVT_DLL_X2
+
+MACRO LVT_FA_X1
+  CLASS core ;
+  FOREIGN LVT_FA_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.04 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1391 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.507 LAYER metal1 ;
+    ANTENNAGATEAREA 0.105 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.905 0.825 2.115 0.825 2.53 0.825 2.53 0.7 2.66 0.7 2.66 0.895 2.115 0.895 0.905 0.895  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0833 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.312 LAYER metal1 ;
+    ANTENNAGATEAREA 0.105 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.41 0.42 2.03 0.42 2.47 0.42 2.47 0.56 2.34 0.56 2.34 0.49 2.03 0.49 1.41 0.49  ;
+    END
+  END B
+  PIN CI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1246 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.481 LAYER metal1 ;
+    ANTENNAGATEAREA 0.07875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.42 0.7 0.42 0.7 0.555 1.275 0.555 2.03 0.555 2.275 0.555 2.275 0.625 2.03 0.625 1.275 0.625 0.63 0.625  ;
+    END
+  END CI
+  PIN CO
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0765 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2847 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.195 0.135 0.195 0.135 1.215 0.06 1.215  ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0918 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2886 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.89 0.195 2.98 0.195 2.98 1.215 2.89 1.215  ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.25 1.315 0.25 0.94 0.32 0.94 0.32 1.315 1.015 1.315 1.015 1.095 1.085 1.095 1.085 1.315 1.275 1.315 1.36 1.315 1.36 0.965 1.43 0.965 1.43 1.315 1.705 1.315 1.705 1.095 1.84 1.095 1.84 1.315 2 1.315 2.115 1.315 2.695 1.315 2.695 1.205 2.765 1.205 2.765 1.315 2.82 1.315 3.04 1.315 3.04 1.485 2.82 1.485 2.115 1.485 2 1.485 1.275 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.04 -0.085 3.04 0.085 2.8 0.085 2.8 0.16 2.665 0.16 2.665 0.085 1.84 0.085 1.84 0.16 1.705 0.16 1.705 0.085 1.43 0.085 1.43 0.195 1.36 0.195 1.36 0.085 1.095 0.085 1.095 0.33 1.025 0.33 1.025 0.085 0.32 0.085 0.32 0.33 0.25 0.33 0.25 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.835 0.195 0.905 0.195 0.905 0.395 1.205 0.395 1.205 0.195 1.275 0.195 1.275 0.465 0.835 0.465  ;
+        POLYGON 0.8 0.96 1.275 0.96 1.275 1.235 1.205 1.235 1.205 1.03 0.935 1.03 0.935 1.215 0.8 1.215  ;
+        POLYGON 1.555 0.96 2 0.96 2 1.24 1.93 1.24 1.93 1.03 1.625 1.03 1.625 1.24 1.555 1.24  ;
+        POLYGON 1.52 0.225 2.03 0.225 2.03 0.295 1.52 0.295  ;
+        POLYGON 0.565 0.69 2.115 0.69 2.115 0.76 0.7 0.76 0.7 1.215 0.63 1.215 0.63 0.76 0.495 0.76 0.495 0.66 0.205 0.66 0.205 0.525 0.495 0.525 0.495 0.23 0.735 0.23 0.735 0.3 0.565 0.3  ;
+        POLYGON 2.13 0.96 2.75 0.96 2.75 0.295 2.1 0.295 2.1 0.225 2.82 0.225 2.82 1.03 2.2 1.03 2.2 1.24 2.13 1.24  ;
+  END
+END LVT_FA_X1
+
+MACRO LVT_FILLCELL_X1
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.19 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.19 1.315 0.19 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.19 -0.085 0.19 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X1
+
+MACRO LVT_FILLCELL_X16
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X16 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.04 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 3.04 1.315 3.04 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.04 -0.085 3.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X16
+
+MACRO LVT_FILLCELL_X2
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.19 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.19 1.315 0.19 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.19 -0.085 0.19 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X2
+
+MACRO LVT_FILLCELL_X32
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X32 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 6.08 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 6.08 1.315 6.08 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 6.08 -0.085 6.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X32
+
+MACRO LVT_FILLCELL_X4
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.76 1.315 0.76 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X4
+
+MACRO LVT_FILLCELL_X8
+  CLASS core ;
+  FOREIGN LVT_FILLCELL_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.52 BY 1.4 ;
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 1.52 1.315 1.52 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.52 -0.085 1.52 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_FILLCELL_X8
+
+MACRO LVT_HA_X1
+  CLASS core ;
+  FOREIGN LVT_HA_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.9 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0812 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3198 LAYER metal1 ;
+    ANTENNAGATEAREA 0.10475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.355 0.525 0.425 0.525 0.425 0.725 0.67 0.725 0.67 0.56 1.08 0.56 1.08 0.7 1.01 0.7 1.01 0.63 0.74 0.63 0.74 0.795 0.355 0.795  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0857 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3276 LAYER metal1 ;
+    ANTENNAGATEAREA 0.10475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 0.86 0.805 0.86 0.805 0.7 0.89 0.7 0.89 0.93 0.195 0.93  ;
+    END
+  END B
+  PIN CO
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.088 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3068 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.77 0.15 1.85 0.15 1.85 1.25 1.77 1.25  ;
+    END
+  END CO
+  PIN S
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4212 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.29 0.455 0.29 0.455 0.15 0.525 0.15 0.525 0.36 0.13 0.36 0.13 0.995 0.37 0.995 0.37 1.065 0.06 1.065  ;
+    END
+  END S
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.56 1.315 0.645 1.315 0.645 1.08 0.715 1.08 0.715 1.315 1.22 1.315 1.22 0.94 1.25 0.94 1.29 0.94 1.29 1.315 1.59 1.315 1.59 1.08 1.66 1.08 1.66 1.315 1.705 1.315 1.9 1.315 1.9 1.485 1.705 1.485 1.25 1.485 0.56 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.9 -0.085 1.9 0.085 1.66 0.085 1.66 0.285 1.59 0.285 1.59 0.085 1.1 0.085 1.1 0.285 1.03 0.285 1.03 0.085 0.715 0.085 0.715 0.285 0.645 0.285 0.645 0.085 0.15 0.085 0.15 0.225 0.08 0.225 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 1.13 0.56 1.13 0.56 1.2 0.05 1.2  ;
+        POLYGON 1.035 0.765 1.18 0.765 1.18 0.495 0.605 0.495 0.605 0.66 0.535 0.66 0.535 0.425 0.84 0.425 0.84 0.15 0.91 0.15 0.91 0.425 1.25 0.425 1.25 0.835 1.105 0.835 1.105 1.115 1.035 1.115  ;
+        POLYGON 1.22 0.15 1.47 0.15 1.47 0.525 1.705 0.525 1.705 0.66 1.47 0.66 1.47 1.115 1.4 1.115 1.4 0.285 1.22 0.285  ;
+  END
+END LVT_HA_X1
+
+MACRO LVT_INV_X1
+  CLASS core ;
+  FOREIGN LVT_INV_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.38 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.018375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.165 0.525 0.165 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1045 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3107 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.23 0.15 0.325 0.15 0.325 1.25 0.23 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.38 1.315 0.38 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.38 -0.085 0.38 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X1
+
+MACRO LVT_INV_X16
+  CLASS core ;
+  FOREIGN LVT_INV_X16 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.357 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3442 LAYER metal1 ;
+    ANTENNAGATEAREA 0.836 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.095 0.525 0.165 0.525 0.165 1.05 1.2 1.05 1.2 0.525 1.27 0.525 1.27 1.05 2 1.05 2 0.525 2.07 0.525 2.07 1.05 3.025 1.05 3.025 0.525 3.095 0.525 3.095 1.12 0.095 1.12  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.7672 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 2.1788 LAYER metal1 ;
+    ANTENNADIFFAREA 1.1704 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.18 0.305 0.18 0.305 0.28 0.605 0.28 0.605 0.16 0.675 0.16 0.675 0.28 0.985 0.28 0.985 0.15 1.055 0.15 1.055 0.28 1.365 0.28 1.365 0.15 1.435 0.15 1.435 0.28 1.745 0.28 1.745 0.15 1.815 0.15 1.815 0.28 2.125 0.28 2.125 0.15 2.195 0.15 2.195 0.28 2.505 0.28 2.505 0.15 2.575 0.15 2.575 0.28 2.885 0.28 2.885 0.15 2.955 0.15 2.955 0.985 2.885 0.985 2.885 0.42 2.575 0.42 2.575 0.985 2.505 0.985 2.505 0.42 2.205 0.42 2.205 0.985 2.135 0.985 2.135 0.42 1.815 0.42 1.815 0.985 1.745 0.985 1.745 0.42 1.435 0.42 1.435 0.985 1.365 0.985 1.365 0.42 1.055 0.42 1.055 0.985 0.985 0.985 0.985 0.42 0.675 0.42 0.675 0.985 0.605 0.985 0.605 0.42 0.305 0.42 0.305 0.985 0.235 0.985  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.205 0.11 1.205 0.11 1.315 0.415 1.315 0.415 1.205 0.485 1.205 0.485 1.315 0.795 1.315 0.795 1.205 0.865 1.205 0.865 1.315 1.175 1.315 1.175 1.205 1.245 1.205 1.245 1.315 1.555 1.315 1.555 1.205 1.625 1.205 1.625 1.315 1.935 1.315 1.935 1.205 2.005 1.205 2.005 1.315 2.315 1.315 2.315 1.205 2.385 1.205 2.385 1.315 2.695 1.315 2.695 1.205 2.765 1.205 2.765 1.315 3.075 1.315 3.075 1.205 3.145 1.205 3.145 1.315 3.23 1.315 3.23 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 3.145 0.085 3.145 0.365 3.075 0.365 3.075 0.085 2.765 0.085 2.765 0.21 2.695 0.21 2.695 0.085 2.385 0.085 2.385 0.21 2.315 0.21 2.315 0.085 2.005 0.085 2.005 0.21 1.935 0.21 1.935 0.085 1.625 0.085 1.625 0.21 1.555 0.21 1.555 0.085 1.245 0.085 1.245 0.21 1.175 0.21 1.175 0.085 0.865 0.085 0.865 0.21 0.795 0.21 0.795 0.085 0.485 0.085 0.485 0.21 0.415 0.21 0.415 0.085 0.11 0.085 0.11 0.365 0.04 0.365 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X16
+
+MACRO LVT_INV_X2
+  CLASS core ;
+  FOREIGN LVT_INV_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.57 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.077 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3042 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.15 0.32 0.15 0.32 1.25 0.25 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 0.43 1.315 0.43 0.975 0.5 0.975 0.5 1.315 0.57 1.315 0.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.57 -0.085 0.57 0.085 0.5 0.085 0.5 0.425 0.43 0.425 0.43 0.085 0.125 0.085 0.125 0.425 0.055 0.425 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X2
+
+MACRO LVT_INV_X32
+  CLASS core ;
+  FOREIGN LVT_INV_X32 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 6.27 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.57155 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 2.1411 LAYER metal1 ;
+    ANTENNAGATEAREA 1.672 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.115 0.525 0.185 0.525 0.185 0.93 1.2 0.93 1.2 0.525 1.27 0.525 1.27 0.93 2.34 0.93 2.34 0.525 2.41 0.525 2.41 0.93 3.48 0.93 3.48 0.525 3.55 0.525 3.55 0.93 4.62 0.93 4.62 0.525 4.69 0.525 4.69 0.93 5.78 0.93 5.78 0.525 5.85 0.525 5.85 1 0.115 1  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 1.4497 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 3.9221 LAYER metal1 ;
+    ANTENNADIFFAREA 2.3408 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.16 0.32 0.16 0.32 0.28 0.62 0.28 0.62 0.16 0.69 0.16 0.69 0.28 1 0.28 1 0.16 1.07 0.16 1.07 0.28 1.39 0.28 1.39 0.16 1.46 0.16 1.46 0.28 1.76 0.28 1.76 0.16 1.83 0.16 1.83 0.28 2.14 0.28 2.14 0.16 2.21 0.16 2.21 0.28 2.525 0.28 2.525 0.16 2.595 0.16 2.595 0.28 2.9 0.28 2.9 0.16 2.97 0.16 2.97 0.28 3.28 0.28 3.28 0.16 3.35 0.16 3.35 0.28 3.665 0.28 3.665 0.16 3.735 0.16 3.735 0.28 4.04 0.28 4.04 0.16 4.11 0.16 4.11 0.28 4.42 0.28 4.42 0.16 4.49 0.16 4.49 0.28 4.8 0.28 4.8 0.16 4.87 0.16 4.87 0.28 5.18 0.28 5.18 0.16 5.25 0.16 5.25 0.28 5.56 0.28 5.56 0.16 5.63 0.16 5.63 0.28 5.945 0.28 5.945 0.16 6.015 0.16 6.015 1.005 5.945 1.005 5.945 0.42 5.63 0.42 5.63 0.865 5.56 0.865 5.56 0.42 5.25 0.42 5.25 0.865 5.18 0.865 5.18 0.42 4.88 0.42 4.88 0.865 4.81 0.865 4.81 0.42 4.49 0.42 4.49 0.865 4.42 0.865 4.42 0.42 4.11 0.42 4.11 0.865 4.04 0.865 4.04 0.42 3.735 0.42 3.735 0.865 3.665 0.865 3.665 0.42 3.35 0.42 3.35 0.865 3.28 0.865 3.28 0.42 2.97 0.42 2.97 0.865 2.9 0.865 2.9 0.42 2.595 0.42 2.595 0.865 2.525 0.865 2.525 0.42 2.21 0.42 2.21 0.865 2.14 0.865 2.14 0.42 1.83 0.42 1.83 0.865 1.76 0.865 1.76 0.42 1.46 0.42 1.46 0.865 1.39 0.865 1.39 0.42 1.07 0.42 1.07 0.865 1 0.865 1 0.42 0.69 0.42 0.69 0.865 0.62 0.865 0.62 0.42 0.32 0.42 0.32 0.865 0.25 0.865  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 1.065 0.125 1.065 0.125 1.315 0.43 1.315 0.43 1.065 0.5 1.065 0.5 1.315 0.81 1.315 0.81 1.065 0.88 1.065 0.88 1.315 1.19 1.315 1.19 1.065 1.26 1.065 1.26 1.315 1.57 1.315 1.57 1.065 1.64 1.065 1.64 1.315 1.95 1.315 1.95 1.065 2.02 1.065 2.02 1.315 2.33 1.315 2.33 1.065 2.4 1.065 2.4 1.315 2.71 1.315 2.71 1.065 2.78 1.065 2.78 1.315 3.09 1.315 3.09 1.065 3.16 1.065 3.16 1.315 3.47 1.315 3.47 1.065 3.54 1.065 3.54 1.315 3.85 1.315 3.85 1.065 3.92 1.065 3.92 1.315 4.23 1.315 4.23 1.065 4.3 1.065 4.3 1.315 4.61 1.315 4.61 1.065 4.68 1.065 4.68 1.315 4.99 1.315 4.99 1.065 5.06 1.065 5.06 1.315 5.37 1.315 5.37 1.065 5.44 1.065 5.44 1.315 5.75 1.315 5.75 1.065 5.82 1.065 5.82 1.315 6.13 1.315 6.13 1.065 6.2 1.065 6.2 1.315 6.27 1.315 6.27 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 6.27 -0.085 6.27 0.085 6.2 0.085 6.2 0.335 6.13 0.335 6.13 0.085 5.82 0.085 5.82 0.195 5.75 0.195 5.75 0.085 5.44 0.085 5.44 0.195 5.37 0.195 5.37 0.085 5.06 0.085 5.06 0.195 4.99 0.195 4.99 0.085 4.68 0.085 4.68 0.195 4.61 0.195 4.61 0.085 4.3 0.085 4.3 0.195 4.23 0.195 4.23 0.085 3.92 0.085 3.92 0.195 3.85 0.195 3.85 0.085 3.54 0.085 3.54 0.195 3.47 0.195 3.47 0.085 3.16 0.085 3.16 0.195 3.09 0.195 3.09 0.085 2.78 0.085 2.78 0.195 2.71 0.195 2.71 0.085 2.4 0.085 2.4 0.195 2.33 0.195 2.33 0.085 2.02 0.085 2.02 0.195 1.95 0.195 1.95 0.085 1.64 0.085 1.64 0.195 1.57 0.195 1.57 0.085 1.26 0.085 1.26 0.195 1.19 0.195 1.19 0.085 0.88 0.085 0.88 0.195 0.81 0.195 0.81 0.085 0.5 0.085 0.5 0.195 0.43 0.195 0.43 0.085 0.125 0.085 0.125 0.335 0.055 0.335 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X32
+
+MACRO LVT_INV_X4
+  CLASS core ;
+  FOREIGN LVT_INV_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.17 0.525 0.17 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.17005 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5434 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.56 0.61 0.56 0.61 0.15 0.685 0.15 0.685 1.04 0.615 1.04 0.615 0.7 0.305 0.7 0.305 1.04 0.235 1.04  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.98 0.11 0.98 0.11 1.315 0.415 1.315 0.415 0.98 0.485 0.98 0.485 1.315 0.795 1.315 0.795 0.98 0.865 0.98 0.865 1.315 0.95 1.315 0.95 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.865 0.085 0.865 0.425 0.795 0.425 0.795 0.085 0.485 0.085 0.485 0.425 0.415 0.425 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X4
+
+MACRO LVT_INV_X8
+  CLASS core ;
+  FOREIGN LVT_INV_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.418 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.17 0.525 0.17 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.3794 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.131 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.56 0.605 0.56 0.605 0.15 0.675 0.15 0.675 0.56 0.985 0.56 0.985 0.15 1.055 0.15 1.055 0.56 1.375 0.56 1.375 0.15 1.445 0.15 1.445 1.04 1.375 1.04 1.375 0.7 1.055 0.7 1.055 1.04 0.985 1.04 0.985 0.7 0.675 0.7 0.675 1.04 0.605 1.04 0.605 0.7 0.305 0.7 0.305 1.04 0.235 1.04  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.97 0.11 0.97 0.11 1.315 0.415 1.315 0.415 0.97 0.485 0.97 0.485 1.315 0.795 1.315 0.795 0.97 0.865 0.97 0.865 1.315 1.175 1.315 1.175 0.97 1.245 0.97 1.245 1.315 1.555 1.315 1.555 0.97 1.625 0.97 1.625 1.315 1.71 1.315 1.71 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.625 0.085 1.625 0.36 1.555 0.36 1.555 0.085 1.245 0.085 1.245 0.36 1.175 0.36 1.175 0.085 0.865 0.085 0.865 0.36 0.795 0.36 0.795 0.085 0.485 0.085 0.485 0.36 0.415 0.36 0.415 0.085 0.11 0.085 0.11 0.36 0.04 0.36 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_INV_X8
+
+MACRO LVT_LOGIC0_X1
+  CLASS core ;
+  FOREIGN LVT_LOGIC0_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.38 BY 1.4 ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0483 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1976 LAYER metal1 ;
+    ANTENNADIFFAREA 0.00945 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.15 0.13 0.15 0.13 0.84 0.06 0.84  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.18 1.315 0.245 1.315 0.245 1.115 0.315 1.115 0.315 1.315 0.38 1.315 0.38 1.485 0.18 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.38 -0.085 0.38 0.085 0.31 0.085 0.31 0.285 0.24 0.285 0.24 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.975 0.18 0.975 0.18 1.25 0.06 1.25  ;
+  END
+END LVT_LOGIC0_X1
+
+MACRO LVT_LOGIC1_X1
+  CLASS core ;
+  FOREIGN LVT_LOGIC1_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.38 BY 1.4 ;
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0483 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1976 LAYER metal1 ;
+    ANTENNADIFFAREA 0.014175 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.56 0.13 0.56 0.13 1.25 0.06 1.25  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.18 1.315 0.24 1.315 0.24 1.115 0.31 1.115 0.31 1.315 0.38 1.315 0.38 1.485 0.18 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.38 -0.085 0.38 0.085 0.315 0.085 0.315 0.285 0.245 0.285 0.245 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.15 0.18 0.15 0.18 0.425 0.06 0.425  ;
+  END
+END LVT_LOGIC1_X1
+
+MACRO LVT_MUX2_X1
+  CLASS core ;
+  FOREIGN LVT_MUX2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.525 0.95 0.525 0.95 0.7 0.82 0.7  ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08355 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2795 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.765 0.525 0.765 0.525 0.535 0.595 0.535 0.595 0.835 0.06 0.835  ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0936 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2938 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.18 0.19 1.27 0.19 1.27 1.23 1.18 1.23  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.035 0.295 1.035 0.295 1.315 0.985 1.315 0.985 0.975 1.055 0.975 1.055 1.315 1.115 1.315 1.33 1.315 1.33 1.485 1.115 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.055 0.085 1.055 0.24 0.985 0.24 0.985 0.085 0.295 0.085 0.295 0.24 0.225 0.24 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.9 0.685 0.9 0.685 0.46 0.045 0.46 0.045 0.19 0.115 0.19 0.115 0.39 0.755 0.39 0.755 0.97 0.115 0.97 0.115 1.25 0.045 1.25  ;
+        POLYGON 0.58 1.07 0.85 1.07 0.85 0.84 1.045 0.84 1.045 0.46 0.83 0.46 0.83 0.29 0.58 0.29 0.58 0.22 0.9 0.22 0.9 0.39 1.115 0.39 1.115 0.91 0.92 0.91 0.92 1.14 0.58 1.14  ;
+  END
+END LVT_MUX2_X1
+
+MACRO LVT_MUX2_X2
+  CLASS core ;
+  FOREIGN LVT_MUX2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.028875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0884 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.225 0.525 0.225 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END B
+  PIN S
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.115325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3861 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.77 0.525 0.995 0.525 0.995 0.85 1.135 0.85 1.465 0.85 1.465 0.525 1.535 0.525 1.535 0.92 1.135 0.92 0.925 0.92 0.925 0.7 0.77 0.7  ;
+    END
+  END S
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.05715 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1885 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.15 1.29 0.15 1.29 0.785 1.2 0.785  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 1.24 0.375 1.24 0.375 1.315 0.955 1.315 1.035 1.315 1.035 1.205 1.105 1.205 1.105 1.315 1.405 1.315 1.405 1.205 1.475 1.205 1.475 1.315 1.67 1.315 1.71 1.315 1.71 1.485 1.67 1.485 0.955 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.475 0.085 1.475 0.285 1.405 0.285 1.405 0.085 1.1 0.085 1.1 0.285 1.03 0.285 1.03 0.085 0.53 0.085 0.53 0.285 0.46 0.285 0.46 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.09 0.86 0.16 0.86 0.16 1.065 0.53 1.065 0.53 1.175 0.955 1.175 0.955 1.245 0.46 1.245 0.46 1.135 0.09 1.135  ;
+        POLYGON 0.09 0.15 0.16 0.15 0.16 0.385 0.845 0.385 0.845 0.15 0.915 0.15 0.915 0.385 1.135 0.385 1.135 0.66 1.065 0.66 1.065 0.455 0.36 0.455 0.36 0.9 0.725 0.9 0.725 1.075 0.655 1.075 0.655 0.97 0.29 0.97 0.29 0.455 0.09 0.455  ;
+        POLYGON 0.425 0.525 0.495 0.525 0.495 0.765 0.86 0.765 0.86 0.985 1.6 0.985 1.6 0.15 1.67 0.15 1.67 1.25 1.6 1.25 1.6 1.055 0.79 1.055 0.79 0.835 0.425 0.835  ;
+  END
+END LVT_MUX2_X2
+
+MACRO LVT_NAND2_X1
+  CLASS core ;
+  FOREIGN LVT_NAND2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.57 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.525 0.51 0.525 0.51 0.7 0.385 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0896 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.351 LAYER metal1 ;
+    ANTENNADIFFAREA 0.131775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.355 0.43 0.355 0.43 0.15 0.5 0.15 0.5 0.425 0.32 0.425 0.32 1.25 0.25 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 0.43 1.315 0.43 0.975 0.5 0.975 0.5 1.315 0.57 1.315 0.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.57 -0.085 0.57 0.085 0.125 0.085 0.125 0.425 0.055 0.425 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND2_X1
+
+MACRO LVT_NAND2_X2
+  CLASS core ;
+  FOREIGN LVT_NAND2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.51 0.525 0.51 0.7 0.44 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.083625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3107 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.175 0.525 0.32 0.525 0.32 0.77 0.74 0.77 0.74 0.525 0.81 0.525 0.81 0.84 0.25 0.84 0.25 0.66 0.175 0.66  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.16555 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6331 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2345 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.11 0.905 0.7 0.905 0.7 1.25 0.63 1.25 0.63 0.975 0.32 0.975 0.32 1.25 0.25 1.25 0.25 0.975 0.04 0.975 0.04 0.39 0.44 0.39 0.44 0.15 0.51 0.15 0.51 0.46 0.11 0.46  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.065 1.315 0.065 1.04 0.135 1.04 0.135 1.315 0.44 1.315 0.44 1.04 0.51 1.04 0.51 1.315 0.82 1.315 0.82 1.04 0.89 1.04 0.89 1.315 0.95 1.315 0.95 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.89 0.085 0.89 0.425 0.82 0.425 0.82 0.085 0.135 0.085 0.135 0.285 0.065 0.285 0.065 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND2_X2
+
+MACRO LVT_NAND2_X4
+  CLASS core ;
+  FOREIGN LVT_NAND2_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.14 0.525 1.14 0.7 1.01 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.38 0.525 0.51 0.525 0.51 0.7 0.38 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.208475 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7683 LAYER metal1 ;
+    ANTENNADIFFAREA 0.469 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.275 0.785 1.39 0.785 1.39 0.42 1 0.42 1 0.35 1.475 0.35 1.475 1.07 1.405 1.07 1.405 0.855 1.095 0.855 1.095 1.07 1.025 1.07 1.025 0.855 0.715 0.855 0.715 1.07 0.645 1.07 0.645 0.855 0.345 0.855 0.345 1.07 0.275 1.07  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.04 0.15 1.04 0.15 1.315 0.455 1.315 0.455 1.04 0.525 1.04 0.525 1.315 0.835 1.315 0.835 1.04 0.905 1.04 0.905 1.315 1.215 1.315 1.215 1.04 1.285 1.04 1.285 1.315 1.595 1.315 1.595 1.04 1.665 1.04 1.665 1.315 1.71 1.315 1.71 1.485 1.665 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 0.715 0.085 0.715 0.285 0.645 0.285 0.645 0.085 0.335 0.085 0.335 0.285 0.265 0.285 0.265 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.15 0.155 0.15 0.155 0.355 0.455 0.355 0.455 0.15 0.525 0.15 0.525 0.355 0.835 0.355 0.835 0.15 1.665 0.15 1.665 0.425 1.595 0.425 1.595 0.22 0.905 0.22 0.905 0.425 0.085 0.425  ;
+  END
+END LVT_NAND2_X4
+
+MACRO LVT_NAND3_X1
+  CLASS core ;
+  FOREIGN LVT_NAND3_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.54 0.525 0.54 0.7 0.44 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1352 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4992 LAYER metal1 ;
+    ANTENNADIFFAREA 0.197925 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.8 0.605 0.8 0.605 0.15 0.675 0.15 0.675 1.25 0.605 1.25 0.605 0.87 0.32 0.87 0.32 1.25 0.235 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.76 1.315 0.76 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND3_X1
+
+MACRO LVT_NAND3_X2
+  CLASS core ;
+  FOREIGN LVT_NAND3_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.595 0.56 0.73 0.56 0.73 0.7 0.595 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0882 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.299 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.38 0.42 1.08 0.42 1.08 0.7 0.95 0.7 0.95 0.49 0.45 0.49 0.45 0.66 0.38 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.10955 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4108 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 0.7 0.32 0.7 0.32 0.77 1.145 0.77 1.145 0.525 1.215 0.525 1.215 0.84 0.195 0.84  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.2184 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.8294 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3227 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.13 0.905 1.095 0.905 1.095 1.25 1.025 1.25 1.025 0.975 0.715 0.975 0.715 1.25 0.645 1.25 0.645 0.975 0.335 0.975 0.335 1.25 0.265 1.25 0.265 0.975 0.06 0.975 0.06 0.265 0.75 0.265 0.75 0.335 0.13 0.335  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.04 0.15 1.04 0.15 1.315 0.455 1.315 0.455 1.04 0.525 1.04 0.525 1.315 0.835 1.315 0.835 1.04 0.905 1.04 0.905 1.315 1.215 1.315 1.215 1.04 1.285 1.04 1.285 1.315 1.33 1.315 1.33 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.285 0.085 1.285 0.335 1.215 0.335 1.215 0.085 0.15 0.085 0.15 0.195 0.08 0.195 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND3_X2
+
+MACRO LVT_NAND3_X4
+  CLASS core ;
+  FOREIGN LVT_NAND3_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.12565 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4849 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.625 0.555 0.82 0.555 0.82 0.29 1.73 0.29 1.73 0.555 1.89 0.555 1.89 0.625 1.66 0.625 1.66 0.36 0.89 0.36 0.89 0.625 0.625 0.625  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.197275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6968 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.38 0.525 0.45 0.525 0.45 0.69 0.955 0.69 0.955 0.425 1.595 0.425 1.595 0.69 2.06 0.69 2.06 0.525 2.13 0.525 2.13 0.76 1.525 0.76 1.525 0.495 1.08 0.495 1.08 0.76 0.38 0.76  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.225475 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7917 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.19 0.525 0.26 0.525 0.26 0.825 1.19 0.825 1.19 0.56 1.325 0.56 1.325 0.825 2.23 0.825 2.23 0.525 2.3 0.525 2.3 0.895 0.19 0.895  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.5439 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.5444 LAYER metal1 ;
+    ANTENNADIFFAREA 0.6454 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.125 0.98 2.365 0.98 2.365 0.425 1.795 0.425 1.795 0.15 1.865 0.15 1.865 0.355 2.435 0.355 2.435 1.05 2.235 1.05 2.235 1.22 2.165 1.22 2.165 1.12 1.855 1.12 1.855 1.22 1.785 1.22 1.785 1.12 1.475 1.12 1.475 1.22 1.405 1.22 1.405 1.12 1.095 1.12 1.095 1.22 1.025 1.22 1.025 1.12 0.715 1.12 0.715 1.22 0.645 1.22 0.645 1.12 0.335 1.12 0.335 1.22 0.265 1.22 0.265 1.05 0.055 1.05 0.055 0.355 0.645 0.355 0.645 0.15 0.715 0.15 0.715 0.425 0.125 0.425  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.16 0.15 1.16 0.15 1.315 0.425 1.315 0.425 1.195 0.56 1.195 0.56 1.315 0.805 1.315 0.805 1.195 0.94 1.195 0.94 1.315 1.185 1.315 1.185 1.205 1.32 1.205 1.32 1.315 1.565 1.315 1.565 1.205 1.7 1.205 1.7 1.315 1.945 1.315 1.945 1.205 2.08 1.205 2.08 1.315 2.355 1.315 2.355 1.17 2.425 1.17 2.425 1.315 2.47 1.315 2.47 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.425 0.085 2.425 0.195 2.355 0.195 2.355 0.085 1.285 0.085 1.285 0.195 1.215 0.195 1.215 0.085 0.15 0.085 0.15 0.195 0.08 0.195 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND3_X4
+
+MACRO LVT_NAND4_X1
+  CLASS core ;
+  FOREIGN LVT_NAND4_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.89 0.525 0.89 0.7 0.765 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0276 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0923 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.42 0.555 0.42 0.555 0.66 0.44 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.03 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0949 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.42 0.375 0.42 0.375 0.66 0.25 0.66  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.03 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0949 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.42 0.185 0.42 0.185 0.66 0.06 0.66  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1451 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5382 LAYER metal1 ;
+    ANTENNADIFFAREA 0.219975 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.84 0.63 0.84 0.63 0.355 0.795 0.355 0.795 0.15 0.865 0.15 0.865 0.425 0.7 0.425 0.7 1.25 0.615 1.25 0.615 0.91 0.305 0.91 0.305 1.25 0.235 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.415 1.315 0.415 0.975 0.485 0.975 0.485 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.95 1.315 0.95 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.11 0.085 0.11 0.355 0.04 0.355 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND4_X1
+
+MACRO LVT_NAND4_X2
+  CLASS core ;
+  FOREIGN LVT_NAND4_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.027675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0884 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.81 0.42 0.945 0.42 0.945 0.625 0.81 0.625  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.108125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3575 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.285 1.27 0.285 1.27 0.66 1.145 0.66 1.145 0.355 0.645 0.355 0.645 0.66 0.575 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.10905 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3861 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.39 0.525 0.51 0.525 0.51 0.725 1.335 0.725 1.335 0.525 1.405 0.525 1.405 0.795 0.39 0.795  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.162975 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5551 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.32 0.525 0.32 0.86 1.52 0.86 1.52 0.525 1.59 0.525 1.59 0.93 0.195 0.93  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.31725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.0179 LAYER metal1 ;
+    ANTENNADIFFAREA 0.4109 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.13 0.995 1.51 0.995 1.51 1.25 1.375 1.25 1.375 1.065 1.13 1.065 1.13 1.25 0.995 1.25 0.995 1.065 0.75 1.065 0.75 1.25 0.615 1.25 0.615 1.065 0.37 1.065 0.37 1.25 0.235 1.25 0.235 1.065 0.06 1.065 0.06 0.39 0.285 0.39 0.285 0.15 0.94 0.15 0.94 0.22 0.355 0.22 0.355 0.46 0.13 0.46  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.13 0.15 1.13 0.15 1.315 0.455 1.315 0.455 1.13 0.525 1.13 0.525 1.315 0.835 1.315 0.835 1.13 0.905 1.13 0.905 1.315 1.215 1.315 1.215 1.13 1.285 1.13 1.285 1.315 1.595 1.315 1.595 1.065 1.665 1.065 1.665 1.315 1.71 1.315 1.71 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.665 0.085 1.665 0.39 1.595 0.39 1.595 0.085 0.15 0.085 0.15 0.25 0.08 0.25 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NAND4_X2
+
+MACRO LVT_NAND4_X4
+  CLASS core ;
+  FOREIGN LVT_NAND4_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.42 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.018375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.405 0.525 0.51 0.525 0.51 0.7 0.405 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.17 0.525 1.27 0.525 1.27 0.7 1.17 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.15 0.525 2.22 0.525 2.22 0.7 2.15 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.91 0.525 2.98 0.525 2.98 0.7 2.91 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.6363 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.5548 LAYER metal1 ;
+    ANTENNADIFFAREA 0.9604 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.09 0.84 0.685 0.84 0.685 0.355 0.225 0.355 0.225 0.285 0.755 0.285 0.755 0.84 2.425 0.84 3.34 0.84 3.34 1.155 3.27 1.155 3.27 0.98 2.96 0.98 2.96 1.155 2.89 1.155 2.89 0.98 2.58 0.98 2.58 1.155 2.51 1.155 2.51 0.98 2.425 0.98 2.2 0.98 2.2 1.155 2.13 1.155 2.13 0.98 1.75 0.98 1.75 1.155 1.68 1.155 1.68 0.98 1.29 0.98 1.29 1.155 1.22 1.155 1.22 0.98 0.91 0.98 0.91 1.155 0.84 1.155 0.84 0.98 0.53 0.98 0.53 1.155 0.46 1.155 0.46 0.98 0.16 0.98 0.16 1.155 0.09 1.155  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.24 1.315 0.24 1.095 0.375 1.095 0.375 1.315 0.62 1.315 0.62 1.095 0.755 1.095 0.755 1.315 1 1.315 1 1.095 1.135 1.095 1.135 1.315 1.38 1.315 1.38 1.095 1.515 1.095 1.515 1.315 1.91 1.315 1.91 1.095 2.045 1.095 2.045 1.315 2.29 1.315 2.29 1.095 2.425 1.095 2.425 1.315 2.67 1.315 2.67 1.095 2.805 1.095 2.805 1.315 3.05 1.315 3.05 1.095 3.185 1.095 3.185 1.315 3.34 1.315 3.42 1.315 3.42 1.485 3.34 1.485 2.425 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.42 -0.085 3.42 0.085 3.185 0.085 3.185 0.3 3.05 0.3 3.05 0.085 2.805 0.085 2.805 0.3 2.67 0.3 2.67 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.09 0.15 1.67 0.15 1.67 0.46 1.6 0.46 1.6 0.22 0.91 0.22 0.91 0.46 0.84 0.46 0.84 0.22 0.16 0.22 0.16 0.46 0.09 0.46  ;
+        POLYGON 1.005 0.285 1.515 0.285 1.515 0.525 1.91 0.525 1.91 0.285 2.425 0.285 2.425 0.355 2.045 0.355 2.045 0.595 1.38 0.595 1.38 0.355 1.005 0.355  ;
+        POLYGON 1.76 0.15 2.58 0.15 2.58 0.39 2.89 0.39 2.89 0.185 2.96 0.185 2.96 0.39 3.27 0.39 3.27 0.185 3.34 0.185 3.34 0.46 2.51 0.46 2.51 0.22 1.83 0.22 1.83 0.46 1.76 0.46  ;
+  END
+END LVT_NAND4_X4
+
+MACRO LVT_NOR2_X1
+  CLASS core ;
+  FOREIGN LVT_NOR2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.57 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.525 0.51 0.525 0.51 0.7 0.385 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0896 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.351 LAYER metal1 ;
+    ANTENNADIFFAREA 0.12425 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.15 0.32 0.15 0.32 0.975 0.5 0.975 0.5 1.25 0.43 1.25 0.43 1.045 0.25 1.045  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 0.57 1.315 0.57 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.57 -0.085 0.57 0.085 0.5 0.085 0.5 0.425 0.43 0.425 0.43 0.085 0.125 0.085 0.125 0.425 0.055 0.425 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR2_X1
+
+MACRO LVT_NOR2_X2
+  CLASS core ;
+  FOREIGN LVT_NOR2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0168 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.42 0.51 0.42 0.51 0.66 0.44 0.66  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08865 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3029 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 0.725 0.76 0.725 0.76 0.525 0.89 0.525 0.89 0.795 0.195 0.795  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.14035 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5395 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2044 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.26 0.75 0.26 0.75 0.33 0.13 0.33 0.13 0.91 0.525 0.91 0.525 1.25 0.455 1.25 0.455 0.98 0.06 0.98  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.045 0.15 1.045 0.15 1.315 0.835 1.315 0.835 1.045 0.905 1.045 0.905 1.315 0.95 1.315 0.95 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.905 0.085 0.905 0.335 0.835 0.335 0.835 0.085 0.525 0.085 0.525 0.195 0.455 0.195 0.455 0.085 0.15 0.085 0.15 0.195 0.08 0.195 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR2_X2
+
+MACRO LVT_NOR2_X4
+  CLASS core ;
+  FOREIGN LVT_NOR2_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0705 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2548 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.59 0.42 1.16 0.42 1.16 0.66 1.09 0.66 1.09 0.49 0.7 0.49 0.7 0.66 0.59 0.66  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.19355 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6526 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.215 0.525 0.285 0.525 0.285 0.91 0.805 0.91 0.805 0.56 0.94 0.56 0.94 0.91 1.465 0.91 1.465 0.525 1.535 0.525 1.535 0.98 0.215 0.98  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.165625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6058 LAYER metal1 ;
+    ANTENNADIFFAREA 0.4088 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.24 0.28 1.51 0.28 1.51 0.35 1.295 0.35 1.295 0.845 1.225 0.845 1.225 0.35 0.525 0.35 0.525 0.845 0.44 0.845 0.44 0.35 0.24 0.35  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 0.71 0.15 0.71 0.15 1.315 0.835 1.315 0.835 1.045 0.905 1.045 0.905 1.315 1.6 1.315 1.6 0.71 1.67 0.71 1.67 1.315 1.71 1.315 1.71 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.665 0.085 1.665 0.39 1.595 0.39 1.595 0.085 1.285 0.085 1.285 0.195 1.215 0.195 1.215 0.085 0.905 0.085 0.905 0.195 0.835 0.195 0.835 0.085 0.525 0.085 0.525 0.195 0.455 0.195 0.455 0.085 0.15 0.085 0.15 0.39 0.08 0.39 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR2_X4
+
+MACRO LVT_NOR3_X1
+  CLASS core ;
+  FOREIGN LVT_NOR3_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.018375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.545 0.525 0.545 0.7 0.44 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.020125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0754 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.175 0.525 0.175 0.7 0.06 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1171 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3952 LAYER metal1 ;
+    ANTENNADIFFAREA 0.167825 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.355 0.61 0.355 0.61 0.15 0.7 0.15 0.7 1 0.61 1 0.61 0.425 0.235 0.425  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.76 1.315 0.76 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.485 0.085 0.485 0.22 0.415 0.22 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR3_X1
+
+MACRO LVT_NOR3_X2
+  CLASS core ;
+  FOREIGN LVT_NOR3_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.62 0.56 0.755 0.56 0.755 0.7 0.62 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.07815 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2704 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.39 0.425 0.99 0.425 0.99 0.66 0.92 0.66 0.92 0.495 0.51 0.495 0.51 0.7 0.39 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.123025 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4251 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 0.77 1.145 0.77 1.145 0.525 1.27 0.525 1.27 0.84 0.195 0.84  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1736 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.663 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.285 1.13 0.285 1.13 0.355 0.13 0.355 0.13 0.905 0.715 0.905 0.715 1.18 0.645 1.18 0.645 0.975 0.06 0.975  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.065 0.15 1.065 0.15 1.315 1.215 1.315 1.215 1.065 1.285 1.065 1.285 1.315 1.33 1.315 1.33 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.285 0.085 1.285 0.335 1.215 0.335 1.215 0.085 0.905 0.085 0.905 0.195 0.835 0.195 0.835 0.085 0.525 0.085 0.525 0.195 0.455 0.195 0.455 0.085 0.15 0.085 0.15 0.195 0.08 0.195 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR3_X2
+
+MACRO LVT_NOR3_X4
+  CLASS core ;
+  FOREIGN LVT_NOR3_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.525 0.51 0.525 0.51 0.7 0.425 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.185 0.525 1.27 0.525 1.27 0.7 1.185 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.13 0.525 2.23 0.525 2.23 0.7 2.13 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.346875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.2857 LAYER metal1 ;
+    ANTENNADIFFAREA 0.525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.39 0.605 0.39 0.605 0.15 0.675 0.15 0.675 0.39 0.985 0.39 0.985 0.15 1.055 0.15 1.055 0.39 1.365 0.39 1.365 0.15 1.435 0.15 1.435 0.39 1.93 0.39 1.93 0.15 2 0.15 2 0.39 2.31 0.39 2.31 0.15 2.38 0.15 2.38 0.46 0.32 0.46 0.32 0.765 0.675 0.765 0.675 1.115 0.605 1.115 0.605 0.835 0.305 0.835 0.305 1.115 0.235 1.115  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 1.625 1.315 1.745 1.315 1.745 0.9 1.815 0.9 1.815 1.315 2.09 1.315 2.09 0.935 2.225 0.935 2.225 1.315 2.38 1.315 2.5 1.315 2.5 0.9 2.57 0.9 2.57 1.315 2.66 1.315 2.66 1.485 2.38 1.485 1.625 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 2.575 0.085 2.575 0.425 2.505 0.425 2.505 0.085 2.225 0.085 2.225 0.325 2.09 0.325 2.09 0.085 1.85 0.085 1.85 0.325 1.525 0.325 1.525 0.085 1.28 0.085 1.28 0.325 1.145 0.325 1.145 0.085 0.9 0.085 0.9 0.325 0.765 0.325 0.765 0.085 0.52 0.085 0.52 0.325 0.385 0.325 0.385 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.9 0.115 0.9 0.115 1.18 0.415 1.18 0.415 0.9 0.485 0.9 0.485 1.18 0.795 1.18 0.795 0.9 0.865 0.9 0.865 1.18 1.175 1.18 1.175 0.9 1.245 0.9 1.245 1.18 1.555 1.18 1.555 0.9 1.625 0.9 1.625 1.25 0.045 1.25  ;
+        POLYGON 0.995 0.765 2.38 0.765 2.38 1.175 2.31 1.175 2.31 0.835 2 0.835 2 1.175 1.93 1.175 1.93 0.835 1.435 0.835 1.435 1.115 1.365 1.115 1.365 0.835 1.065 0.835 1.065 1.115 0.995 1.115  ;
+  END
+END LVT_NOR3_X4
+
+MACRO LVT_NOR4_X1
+  CLASS core ;
+  FOREIGN LVT_NOR4_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.89 0.525 0.89 0.7 0.765 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.13465 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5031 LAYER metal1 ;
+    ANTENNADIFFAREA 0.18235 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.355 0.61 0.355 0.61 0.15 0.7 0.15 0.7 0.975 0.865 0.975 0.865 1.25 0.795 1.25 0.795 1.045 0.63 1.045 0.63 0.425 0.235 0.425  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.975 0.11 0.975 0.11 1.315 0.95 1.315 0.95 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.865 0.085 0.865 0.425 0.795 0.425 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR4_X1
+
+MACRO LVT_NOR4_X2
+  CLASS core ;
+  FOREIGN LVT_NOR4_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.81 0.56 0.945 0.56 0.945 0.7 0.81 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0819 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2756 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.57 0.42 1.18 0.42 1.18 0.66 1.11 0.66 1.11 0.49 0.7 0.49 0.7 0.7 0.57 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1236 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4238 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.38 0.525 0.45 0.525 0.45 0.765 1.33 0.765 1.33 0.525 1.46 0.525 1.46 0.835 0.38 0.835  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.15925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5954 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.2 0.525 0.27 0.525 0.27 0.91 1.525 0.91 1.525 0.525 1.595 0.525 1.595 0.84 1.65 0.84 1.65 0.98 0.2 0.98  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.230075 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.858 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3206 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.055 0.26 1.405 0.26 1.405 0.15 1.475 0.15 1.475 0.425 1.405 0.425 1.405 0.33 0.13 0.33 0.13 1.055 0.94 1.055 0.94 1.125 0.055 1.125  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.205 0.15 1.205 0.15 1.315 1.595 1.315 1.595 1.065 1.665 1.065 1.665 1.315 1.71 1.315 1.71 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.665 0.085 1.665 0.335 1.595 0.335 1.595 0.085 1.32 0.085 1.32 0.16 1.185 0.16 1.185 0.085 0.94 0.085 0.94 0.16 0.805 0.16 0.805 0.085 0.56 0.085 0.56 0.16 0.425 0.16 0.425 0.085 0.15 0.085 0.15 0.195 0.08 0.195 0.08 0.085 0 0.085  ;
+    END
+  END VSS
+END LVT_NOR4_X2
+
+MACRO LVT_NOR4_X4
+  CLASS core ;
+  FOREIGN LVT_NOR4_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.42 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.525 0.51 0.525 0.51 0.7 0.425 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.18 0.525 1.27 0.525 1.27 0.7 1.18 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.016625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0702 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.15 0.525 2.245 0.525 2.245 0.7 2.15 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.91 0.525 3 0.525 3 0.7 2.91 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.466925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.7316 LAYER metal1 ;
+    ANTENNADIFFAREA 0.67025 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.15 0.305 0.15 0.305 0.39 0.605 0.39 0.605 0.15 0.675 0.15 0.675 0.39 0.985 0.39 0.985 0.15 1.055 0.15 1.055 0.39 1.37 0.39 1.37 0.15 1.44 0.15 1.44 0.39 1.79 0.39 1.79 0.15 1.86 0.15 1.86 0.39 2.165 0.39 2.165 0.15 2.235 0.15 2.235 0.39 2.545 0.39 2.545 0.15 2.615 0.15 2.615 0.39 2.925 0.39 2.925 0.15 2.995 0.15 2.995 0.39 3.305 0.39 3.305 0.15 3.375 0.15 3.375 0.46 0.32 0.46 0.32 0.765 0.675 0.765 0.675 1.115 0.605 1.115 0.605 0.835 0.305 0.835 0.305 1.115 0.235 1.115  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 2.425 1.315 2.705 1.315 2.705 0.935 2.84 0.935 2.84 1.315 3.085 1.315 3.085 0.935 3.22 0.935 3.22 1.315 3.375 1.315 3.42 1.315 3.42 1.485 3.375 1.485 2.425 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.42 -0.085 3.42 0.085 3.22 0.085 3.22 0.325 3.085 0.325 3.085 0.085 2.84 0.085 2.84 0.325 2.705 0.325 2.705 0.085 2.46 0.085 2.46 0.325 2.325 0.325 2.325 0.085 2.08 0.085 2.08 0.325 1.945 0.325 1.945 0.085 1.66 0.085 1.66 0.325 1.525 0.325 1.525 0.085 1.28 0.085 1.28 0.325 1.145 0.325 1.145 0.085 0.9 0.085 0.9 0.325 0.765 0.325 0.765 0.085 0.52 0.085 0.52 0.325 0.385 0.325 0.385 0.085 0.11 0.085 0.11 0.36 0.04 0.36 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.9 0.115 0.9 0.115 1.18 0.415 1.18 0.415 0.9 0.485 0.9 0.485 1.18 0.795 1.18 0.795 0.765 1.625 0.765 1.625 1.115 1.555 1.115 1.555 0.835 1.245 0.835 1.245 1.115 1.175 1.115 1.175 0.835 0.865 0.835 0.865 1.25 0.045 1.25  ;
+        POLYGON 0.995 0.9 1.065 0.9 1.065 1.18 1.365 1.18 1.365 0.9 1.435 0.9 1.435 1.18 1.975 1.18 1.975 0.9 2.045 0.9 2.045 1.18 2.355 1.18 2.355 0.9 2.425 0.9 2.425 1.25 0.995 1.25  ;
+        POLYGON 1.795 0.765 3.375 0.765 3.375 1.175 3.305 1.175 3.305 0.835 2.995 0.835 2.995 1.175 2.925 1.175 2.925 0.835 2.615 0.835 2.615 1.175 2.545 1.175 2.545 0.835 2.235 0.835 2.235 1.115 2.165 1.115 2.165 0.835 1.865 0.835 1.865 1.115 1.795 1.115  ;
+  END
+END LVT_NOR4_X4
+
+MACRO LVT_OAI211_X1
+  CLASS core ;
+  FOREIGN LVT_OAI211_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.79 0.525 0.89 0.525 0.89 0.7 0.79 0.7  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.4 0.525 0.51 0.525 0.51 0.7 0.4 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.11765 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4238 LAYER metal1 ;
+    ANTENNADIFFAREA 0.21245 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.285 0.335 0.285 0.335 0.78 0.525 0.78 0.905 0.78 0.905 1.055 0.835 1.055 0.835 0.85 0.525 0.85 0.525 1.055 0.455 1.055 0.455 0.855 0.25 0.855  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.04 0.15 1.04 0.15 1.315 0.525 1.315 0.645 1.315 0.645 1.04 0.715 1.04 0.715 1.315 0.95 1.315 0.95 1.485 0.525 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.905 0.085 0.905 0.46 0.835 0.46 0.835 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.085 0.15 0.525 0.15 0.525 0.425 0.455 0.425 0.455 0.22 0.155 0.22 0.155 0.425 0.085 0.425  ;
+  END
+END LVT_OAI211_X1
+
+MACRO LVT_OAI211_X2
+  CLASS core ;
+  FOREIGN LVT_OAI211_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0891 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2912 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.185 0.525 0.32 0.525 0.32 0.765 0.685 0.765 0.685 0.525 0.755 0.525 0.755 0.835 0.185 0.835  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.53 0.525 0.53 0.7 0.44 0.7  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.19 0.525 1.29 0.525 1.29 0.7 1.19 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.096075 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.325 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.96 0.525 1.03 0.525 1.03 0.77 1.525 0.77 1.525 0.525 1.65 0.525 1.65 0.84 0.96 0.84  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.20825 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7917 LAYER metal1 ;
+    ANTENNADIFFAREA 0.38395 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.27 0.905 0.82 0.905 0.82 0.39 1.51 0.39 1.51 0.46 0.89 0.46 0.89 0.905 1.285 0.905 1.285 1.25 1.215 1.25 1.215 0.975 0.715 0.975 0.715 1.25 0.645 1.25 0.645 0.975 0.34 0.975 0.34 1.25 0.27 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.08 1.315 0.08 1.04 0.15 1.04 0.15 1.315 0.455 1.315 0.455 1.04 0.525 1.04 0.525 1.315 0.835 1.315 0.835 1.04 0.905 1.04 0.905 1.315 1.595 1.315 1.595 1.04 1.665 1.04 1.665 1.315 1.71 1.315 1.71 1.485 1.665 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 0.52 0.085 0.52 0.32 0.45 0.32 0.45 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.08 0.185 0.15 0.185 0.15 0.39 0.59 0.39 0.59 0.185 1.665 0.185 1.665 0.46 1.595 0.46 1.595 0.255 0.66 0.255 0.66 0.46 0.08 0.46  ;
+  END
+END LVT_OAI211_X2
+
+MACRO LVT_OAI211_X4
+  CLASS core ;
+  FOREIGN LVT_OAI211_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.15165 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5369 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.125 0.39 1.52 0.39 1.52 0.66 1.39 0.66 1.39 0.46 0.875 0.46 0.875 0.66 0.805 0.66 0.805 0.46 0.195 0.46 0.195 0.66 0.125 0.66  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09695 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3601 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.42 0.525 0.51 0.525 0.51 0.77 1.175 0.77 1.175 0.525 1.245 0.525 1.245 0.84 0.42 0.84  ;
+    END
+  END B
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.119 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3588 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.91 0.56 2.045 0.56 2.045 0.77 2.665 0.77 2.665 0.56 2.8 0.56 2.8 0.84 1.91 0.84  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.13915 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5122 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.67 0.425 3.035 0.425 3.035 0.66 2.965 0.66 2.965 0.495 2.41 0.495 2.41 0.7 2.31 0.7 2.31 0.495 1.74 0.495 1.74 0.66 1.67 0.66  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.4606 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.729 LAYER metal1 ;
+    ANTENNADIFFAREA 0.7616 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.905 3.1 0.905 3.1 0.36 1.72 0.36 1.72 0.29 3.17 0.29 3.17 0.975 2.765 0.975 2.765 1.25 2.695 1.25 2.695 0.975 2.005 0.975 2.005 1.25 1.935 1.25 1.935 0.975 1.435 0.975 1.435 1.25 1.365 1.25 1.365 0.975 1.055 0.975 1.055 1.25 0.985 1.25 0.985 0.975 0.675 0.975 0.675 1.25 0.605 1.25 0.605 0.975 0.305 0.975 0.305 1.25 0.235 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.04 0.11 1.04 0.11 1.315 0.415 1.315 0.415 1.04 0.485 1.04 0.485 1.315 0.795 1.315 0.795 1.04 0.865 1.04 0.865 1.315 1.175 1.315 1.175 1.04 1.245 1.04 1.245 1.315 1.555 1.315 1.555 1.04 1.625 1.04 1.625 1.315 2.315 1.315 2.315 1.04 2.385 1.04 2.385 1.315 3.075 1.315 3.075 1.04 3.145 1.04 3.145 1.315 3.18 1.315 3.23 1.315 3.23 1.485 3.18 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 1.28 0.085 1.28 0.16 1.145 0.16 1.145 0.085 0.52 0.085 0.52 0.16 0.385 0.16 0.385 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.225 1.555 0.225 1.555 0.15 3.18 0.15 3.18 0.22 1.625 0.22 1.625 0.295 0.045 0.295  ;
+  END
+END LVT_OAI211_X4
+
+MACRO LVT_OAI21_X1
+  CLASS core ;
+  FOREIGN LVT_OAI21_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.525 0.51 0.525 0.51 0.7 0.385 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.08085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3185 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.285 0.32 0.285 0.32 0.765 0.51 0.765 0.51 1.25 0.44 1.25 0.44 0.835 0.25 0.835  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.065 1.315 0.065 0.975 0.135 0.975 0.135 1.315 0.51 1.315 0.63 1.315 0.63 0.975 0.7 0.975 0.7 1.315 0.76 1.315 0.76 1.485 0.51 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.7 0.085 0.7 0.46 0.63 0.46 0.63 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.07 0.15 0.51 0.15 0.51 0.425 0.44 0.425 0.44 0.22 0.14 0.22 0.14 0.425 0.07 0.425  ;
+  END
+END LVT_OAI21_X1
+
+MACRO LVT_OAI21_X2
+  CLASS core ;
+  FOREIGN LVT_OAI21_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.19 0.525 0.19 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.805 0.525 0.89 0.525 0.89 0.7 0.805 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09765 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3263 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.57 0.525 0.57 0.77 1.065 0.77 1.065 0.525 1.135 0.525 1.135 0.84 0.44 0.84  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.19285 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7345 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.905 1.2 0.905 1.2 0.425 0.58 0.425 0.58 0.355 1.27 0.355 1.27 0.975 0.865 0.975 0.865 1.25 0.795 1.25 0.795 0.975 0.305 0.975 0.305 1.25 0.235 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.04 0.11 1.04 0.11 1.315 0.415 1.315 0.415 1.04 0.485 1.04 0.485 1.315 1.175 1.315 1.175 1.04 1.245 1.04 1.245 1.315 1.28 1.315 1.33 1.315 1.33 1.485 1.28 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.355 0.415 0.355 0.415 0.15 1.28 0.15 1.28 0.22 0.485 0.22 0.485 0.425 0.045 0.425  ;
+  END
+END LVT_OAI21_X2
+
+MACRO LVT_OAI21_X4
+  CLASS core ;
+  FOREIGN LVT_OAI21_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.43 0.525 0.515 0.525 0.515 0.7 0.43 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0974 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3172 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.15 0.56 1.285 0.56 1.285 0.69 1.905 0.69 1.905 0.56 2.04 0.56 2.04 0.76 1.15 0.76  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.146925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4966 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.91 0.42 2.275 0.42 2.275 0.66 2.15 0.66 2.15 0.49 1.66 0.49 1.66 0.625 1.525 0.625 1.525 0.49 0.98 0.49 0.98 0.66 0.91 0.66  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.36505 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.3741 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.235 0.845 2.34 0.845 2.34 0.355 0.96 0.355 0.96 0.285 2.41 0.285 2.41 0.915 2.005 0.915 2.005 1.19 1.935 1.19 1.935 0.915 1.245 0.915 1.245 1.19 1.175 1.19 1.175 0.915 0.675 0.915 0.675 1.19 0.605 1.19 0.605 0.915 0.305 0.915 0.305 1.19 0.235 1.19  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.04 0.11 1.04 0.11 1.315 0.415 1.315 0.415 1.04 0.485 1.04 0.485 1.315 0.795 1.315 0.795 1.04 0.865 1.04 0.865 1.315 1.555 1.315 1.555 1.04 1.625 1.04 1.625 1.315 2.315 1.315 2.315 1.04 2.385 1.04 2.385 1.315 2.42 1.315 2.47 1.315 2.47 1.485 2.42 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.355 0.42 0.355 0.42 0.15 0.49 0.15 0.49 0.355 0.76 0.355 0.76 0.15 2.42 0.15 2.42 0.22 0.83 0.22 0.83 0.425 0.045 0.425  ;
+  END
+END LVT_OAI21_X4
+
+MACRO LVT_OAI221_X1
+  CLASS core ;
+  FOREIGN LVT_OAI221_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.485 0.525 0.565 0.525 0.565 0.7 0.485 0.7 0.44 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.525 1.055 0.525 1.08 0.525 1.08 0.7 1.055 0.7 0.955 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.74 0.525 0.74 0.7 0.63 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.12855 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4706 LAYER metal1 ;
+    ANTENNADIFFAREA 0.21245 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.85 0.485 0.85 0.805 0.85 0.805 0.4 0.89 0.4 0.89 0.85 1.055 0.85 1.055 1.25 0.985 1.25 0.985 0.92 0.495 0.92 0.495 1.25 0.485 1.25 0.425 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.04 0.11 1.04 0.11 1.315 0.485 1.315 0.605 1.315 0.605 1.04 0.675 1.04 0.675 1.315 1.055 1.315 1.14 1.315 1.14 1.485 1.055 1.485 0.485 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.355 0.415 0.355 0.415 0.15 0.485 0.15 0.485 0.425 0.045 0.425  ;
+        POLYGON 0.615 0.15 1.055 0.15 1.055 0.425 0.985 0.425 0.985 0.22 0.685 0.22 0.685 0.425 0.615 0.425  ;
+  END
+END LVT_OAI221_X1
+
+MACRO LVT_OAI221_X2
+  CLASS core ;
+  FOREIGN LVT_OAI221_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.139 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4927 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.525 1.025 0.525 1.025 0.9 1.89 0.9 1.93 0.9 1.93 0.525 2.03 0.525 2.03 0.97 1.89 0.97 0.955 0.97  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09475 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3211 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.155 0.525 1.225 0.525 1.225 0.765 1.715 0.765 1.715 0.525 1.84 0.525 1.84 0.835 1.155 0.835  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.38 0.525 1.48 0.525 1.48 0.7 1.38 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.525 0.525 0.525 0.7 0.44 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09765 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3263 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 0.77 0.76 0.77 0.76 0.525 0.89 0.525 0.89 0.84 0.195 0.84  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.27335 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.9321 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3808 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.13 1.035 1.89 1.035 1.89 1.245 1.755 1.245 1.755 1.105 1.13 1.105 1.13 1.245 0.995 1.245 0.995 1.105 0.56 1.105 0.56 1.245 0.425 1.245 0.425 1.105 0.06 1.105 0.06 0.39 0.75 0.39 0.75 0.46 0.13 0.46  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.085 1.315 0.085 1.17 0.155 1.17 0.155 1.315 0.835 1.315 0.835 1.17 0.905 1.17 0.905 1.315 1.405 1.315 1.405 1.17 1.475 1.17 1.475 1.315 1.89 1.315 1.975 1.315 1.975 1.065 2.045 1.065 2.045 1.315 2.09 1.315 2.09 1.485 2.045 1.485 1.89 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 1.7 0.085 1.7 0.19 1.565 0.19 1.565 0.085 1.32 0.085 1.32 0.19 1.185 0.19 1.185 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 1 0.39 1.89 0.39 1.89 0.46 1 0.46  ;
+        POLYGON 0.05 0.255 1.975 0.255 1.975 0.15 2.045 0.15 2.045 0.425 1.975 0.425 1.975 0.325 0.05 0.325  ;
+  END
+END LVT_OAI221_X2
+
+MACRO LVT_OAI221_X4
+  CLASS core ;
+  FOREIGN LVT_OAI221_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.020125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0754 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.585 0.525 0.7 0.525 0.7 0.7 0.585 0.7  ;
+    END
+  END A
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.775 0.525 0.9 0.525 0.9 0.7 0.775 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.025375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0832 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.155 0.525 1.155 0.7 1.01 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.032375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0936 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.245 0.525 0.245 0.7 0.06 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.020125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0754 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.395 0.525 0.51 0.525 0.51 0.7 0.395 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1911 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6318 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.795 0.185 1.865 0.185 1.865 0.7 2.165 0.7 2.165 0.185 2.235 0.185 2.235 1.25 2.165 1.25 2.165 0.84 1.865 0.84 1.865 1.25 1.795 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.47 1.315 0.47 1.04 0.54 1.04 0.54 1.315 1.19 1.315 1.19 1.04 1.26 1.04 1.26 1.315 1.35 1.315 1.595 1.315 1.595 0.975 1.665 0.975 1.665 1.315 1.73 1.315 1.975 1.315 1.975 0.975 2.045 0.975 2.045 1.315 2.355 1.315 2.355 0.975 2.425 0.975 2.425 1.315 2.47 1.315 2.47 1.485 1.73 1.485 1.35 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.425 0.085 2.425 0.46 2.355 0.46 2.355 0.085 2.045 0.085 2.045 0.46 1.975 0.46 1.975 0.085 1.665 0.085 1.665 0.335 1.595 0.335 1.595 0.085 1.26 0.085 1.26 0.2 1.19 0.2 1.19 0.085 0.955 0.085 0.955 0.16 0.82 0.16 0.82 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.1 0.15 0.54 0.15 0.54 0.285 0.47 0.285 0.47 0.22 0.17 0.22 0.17 0.285 0.1 0.285  ;
+        POLYGON 0.67 0.15 0.74 0.15 0.74 0.255 1.11 0.255 1.11 0.325 0.67 0.325  ;
+        POLYGON 0.1 0.775 1.28 0.775 1.28 0.46 0.29 0.46 0.29 0.285 0.36 0.285 0.36 0.39 1.35 0.39 1.35 0.845 0.73 0.845 0.73 1.12 0.66 1.12 0.66 0.845 0.17 0.845 0.17 1.12 0.1 1.12  ;
+        POLYGON 1.415 0.185 1.485 0.185 1.485 0.525 1.73 0.525 1.73 0.66 1.485 0.66 1.485 1.25 1.415 1.25  ;
+  END
+END LVT_OAI221_X4
+
+MACRO LVT_OAI222_X1
+  CLASS core ;
+  FOREIGN LVT_OAI222_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.52 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0767 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.34 0.525 1.43 0.525 1.46 0.525 1.46 0.7 1.43 0.7 1.34 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.018375 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.115 0.525 1.115 0.7 1.01 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.755 0.525 0.755 0.7 0.63 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.525 0.945 0.525 0.945 0.7 0.82 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.028 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0871 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.35 0.525 0.51 0.525 0.51 0.7 0.35 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0245 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0819 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.2 0.525 0.2 0.7 0.06 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.13775 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5005 LAYER metal1 ;
+    ANTENNADIFFAREA 0.3227 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.52 0.795 1.18 0.795 1.18 0.4 1.27 0.4 1.27 0.795 1.43 0.795 1.43 1.14 1.36 1.14 1.36 0.865 0.59 0.865 0.59 1.14 0.52 1.14  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.05 1.315 0.05 1.04 0.12 1.04 0.12 1.315 0.98 1.315 0.98 1.04 1.05 1.04 1.05 1.315 1.43 1.315 1.52 1.315 1.52 1.485 1.43 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.52 -0.085 1.52 0.085 0.53 0.085 0.53 0.19 0.395 0.19 0.395 0.085 0.12 0.085 0.12 0.425 0.05 0.425 0.05 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.245 0.15 0.315 0.15 0.315 0.255 0.79 0.255 0.79 0.15 0.86 0.15 0.86 0.325 0.315 0.325 0.315 0.425 0.245 0.425  ;
+        POLYGON 0.575 0.39 0.98 0.39 0.98 0.15 1.05 0.15 1.05 0.265 1.36 0.265 1.36 0.15 1.43 0.15 1.43 0.425 1.36 0.425 1.36 0.335 1.05 0.335 1.05 0.46 0.575 0.46  ;
+  END
+END LVT_OAI222_X1
+
+MACRO LVT_OAI222_X2
+  CLASS core ;
+  FOREIGN LVT_OAI222_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08205 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2821 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.85 0.525 1.92 0.525 1.92 0.725 2.34 0.725 2.34 0.525 2.465 0.525 2.465 0.795 1.85 0.795  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0168 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.15 0.42 2.22 0.42 2.22 0.66 2.15 0.66  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.096425 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3263 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.525 1.025 0.525 1.025 0.77 1.525 0.77 1.525 0.525 1.65 0.525 1.65 0.84 0.955 0.84  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.525 1.29 0.525 1.29 0.7 1.2 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.092225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3107 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.32 0.525 0.32 0.77 0.76 0.77 0.76 0.525 0.83 0.525 0.83 0.84 0.195 0.84  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.53 0.525 0.53 0.7 0.44 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.33845 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.2753 LAYER metal1 ;
+    ANTENNADIFFAREA 0.52885 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.09 0.905 2.53 0.905 2.53 0.355 1.925 0.355 1.925 0.285 2.6 0.285 2.6 1.25 2.53 1.25 2.53 0.975 1.675 0.975 1.675 1.25 1.605 1.25 1.605 0.975 0.91 0.975 0.91 1.25 0.84 1.25 0.84 0.975 0.16 0.975 0.16 1.25 0.09 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.46 1.315 0.46 1.04 0.53 1.04 0.53 1.315 1.22 1.315 1.22 1.04 1.29 1.04 1.29 1.315 2.14 1.315 2.14 1.04 2.21 1.04 2.21 1.315 2.625 1.315 2.66 1.315 2.66 1.485 2.625 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 0.72 0.085 0.72 0.285 0.65 0.285 0.65 0.085 0.34 0.085 0.34 0.285 0.27 0.285 0.27 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.09 0.15 0.16 0.15 0.16 0.355 0.465 0.355 0.465 0.15 0.535 0.15 0.535 0.355 0.84 0.355 0.84 0.15 1.705 0.15 1.705 0.22 0.91 0.22 0.91 0.425 0.09 0.425  ;
+        POLYGON 1.005 0.355 1.77 0.355 1.77 0.15 2.625 0.15 2.625 0.22 1.84 0.22 1.84 0.425 1.005 0.425  ;
+  END
+END LVT_OAI222_X2
+
+MACRO LVT_OAI222_X4
+  CLASS core ;
+  FOREIGN LVT_OAI222_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.66 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.56 0.9 0.56 0.9 0.7 0.765 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0287 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.495 0.56 0.7 0.56 0.7 0.7 0.495 0.7  ;
+    END
+  END B2
+  PIN C1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.56 1.13 0.56 1.13 0.7 0.995 0.7  ;
+    END
+  END C1
+  PIN C2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.195 0.56 1.25 0.56 1.33 0.56 1.33 0.7 1.25 0.7 1.195 0.7  ;
+    END
+  END C2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1967 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6513 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.915 0.15 1.985 0.15 1.985 0.56 2.29 0.56 2.29 0.15 2.36 0.15 2.36 1.25 2.29 1.25 2.29 0.7 1.985 0.7 1.985 1.25 1.915 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.415 1.315 0.415 1.03 0.485 1.03 0.485 1.315 1.335 1.315 1.335 1.04 1.405 1.04 1.405 1.315 1.465 1.315 1.715 1.315 1.715 0.975 1.785 0.975 1.785 1.315 1.85 1.315 2.095 1.315 2.095 0.975 2.165 0.975 2.165 1.315 2.475 1.315 2.475 0.975 2.545 0.975 2.545 1.315 2.66 1.315 2.66 1.485 1.85 1.485 1.465 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.66 -0.085 2.66 0.085 2.545 0.085 2.545 0.425 2.475 0.425 2.475 0.085 2.165 0.085 2.165 0.425 2.095 0.425 2.095 0.085 1.785 0.085 1.785 0.335 1.715 0.335 1.715 0.085 1.405 0.085 1.405 0.22 1.335 0.22 1.335 0.085 1.035 0.085 1.035 0.22 0.965 0.22 0.965 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.9 0.15 0.9 0.22 0.115 0.22 0.115 0.425 0.045 0.425  ;
+        POLYGON 0.58 0.42 1.25 0.42 1.25 0.49 0.58 0.49  ;
+        POLYGON 0.045 0.785 1.395 0.785 1.395 0.355 0.2 0.355 0.2 0.285 1.465 0.285 1.465 0.855 0.95 0.855 0.95 1.075 0.88 1.075 0.88 0.855 0.115 0.855 0.115 1.075 0.045 1.075  ;
+        POLYGON 1.535 0.15 1.605 0.15 1.605 0.525 1.85 0.525 1.85 0.66 1.605 0.66 1.605 1.16 1.535 1.16  ;
+  END
+END LVT_OAI222_X4
+
+MACRO LVT_OAI22_X1
+  CLASS core ;
+  FOREIGN LVT_OAI22_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.575 0.525 0.7 0.525 0.7 0.7 0.575 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.88 0.525 0.89 0.525 0.89 0.7 0.88 0.7 0.765 0.7  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2457 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.39 0.725 0.39 0.725 0.46 0.51 0.46 0.51 1.05 0.44 1.05  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 0.81 1.315 0.81 0.975 0.88 0.975 0.88 1.315 0.95 1.315 0.95 1.485 0.88 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.345 0.085 0.345 0.16 0.21 0.16 0.21 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.06 0.185 0.13 0.185 0.13 0.245 0.81 0.245 0.81 0.185 0.88 0.185 0.88 0.46 0.81 0.46 0.81 0.315 0.13 0.315 0.13 0.46 0.06 0.46  ;
+  END
+END LVT_OAI22_X1
+
+MACRO LVT_OAI22_X2
+  CLASS core ;
+  FOREIGN LVT_OAI22_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.185 0.525 1.27 0.525 1.27 0.7 1.185 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09665 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3237 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.525 0.95 0.525 0.95 0.765 1.445 0.765 1.445 0.525 1.515 0.525 1.515 0.835 0.82 0.835  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.525 0.525 0.525 0.525 0.7 0.425 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0951 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3224 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.765 0.68 0.765 0.68 0.525 0.75 0.525 0.75 0.835 0.06 0.835  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.20405 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.7761 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.9 1.58 0.9 1.58 0.46 0.96 0.46 0.96 0.39 1.65 0.39 1.65 0.97 1.255 0.97 1.255 1.25 1.185 1.25 1.185 0.97 0.495 0.97 0.495 1.25 0.425 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.035 0.11 1.035 0.11 1.315 0.795 1.315 0.795 1.035 0.865 1.035 0.865 1.315 1.555 1.315 1.555 1.035 1.625 1.035 1.625 1.315 1.66 1.315 1.71 1.315 1.71 1.485 1.66 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.15 0.115 0.15 0.115 0.355 0.415 0.355 0.415 0.15 0.485 0.15 0.485 0.355 0.795 0.355 0.795 0.15 1.66 0.15 1.66 0.22 0.865 0.22 0.865 0.425 0.045 0.425  ;
+  END
+END LVT_OAI22_X2
+
+MACRO LVT_OAI22_X4
+  CLASS core ;
+  FOREIGN LVT_OAI22_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.23 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1072 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3367 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.91 0.56 2.045 0.56 2.045 0.725 2.67 0.725 2.67 0.56 2.805 0.56 2.805 0.795 1.91 0.795  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.146025 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5187 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.645 0.425 3.035 0.425 3.035 0.7 2.91 0.7 2.91 0.495 2.39 0.495 2.39 0.66 2.32 0.66 2.32 0.495 1.715 0.495 1.715 0.66 1.645 0.66  ;
+    END
+  END A2
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1072 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3367 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.385 0.56 0.52 0.56 0.52 0.725 1.145 0.725 1.145 0.56 1.28 0.56 1.28 0.795 0.385 0.795  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.14565 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5135 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.15 0.425 1.52 0.425 1.52 0.7 1.39 0.7 1.39 0.495 0.865 0.495 0.865 0.66 0.795 0.66 0.795 0.495 0.22 0.495 0.22 0.66 0.15 0.66  ;
+    END
+  END B2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.406 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.5262 LAYER metal1 ;
+    ANTENNADIFFAREA 0.5852 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.865 3.1 0.865 3.1 0.36 1.72 0.36 1.72 0.29 3.17 0.29 3.17 0.935 2.765 0.935 2.765 1.21 2.695 1.21 2.695 0.935 2.005 0.935 2.005 1.21 1.935 1.21 1.935 0.935 1.245 0.935 1.245 1.21 1.175 1.21 1.175 0.935 0.495 0.935 0.495 1.21 0.425 1.21  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.04 0.11 1.04 0.11 1.315 0.795 1.315 0.795 1.04 0.865 1.04 0.865 1.315 1.555 1.315 1.555 1.04 1.625 1.04 1.625 1.315 2.315 1.315 2.315 1.04 2.385 1.04 2.385 1.315 3.075 1.315 3.075 1.04 3.145 1.04 3.145 1.315 3.18 1.315 3.23 1.315 3.23 1.485 3.18 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.23 -0.085 3.23 0.085 1.435 0.085 1.435 0.195 1.365 0.195 1.365 0.085 1.055 0.085 1.055 0.195 0.985 0.195 0.985 0.085 0.675 0.085 0.675 0.195 0.605 0.195 0.605 0.085 0.295 0.085 0.295 0.195 0.225 0.195 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.185 0.115 0.185 0.115 0.26 1.525 0.26 1.525 0.15 3.18 0.15 3.18 0.22 1.595 0.22 1.595 0.33 0.045 0.33  ;
+  END
+END LVT_OAI22_X4
+
+MACRO LVT_OAI33_X1
+  CLASS core ;
+  FOREIGN LVT_OAI33_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.765 0.525 0.89 0.525 0.89 0.7 0.765 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.955 0.525 1.08 0.525 1.08 0.7 0.955 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.145 0.525 1.27 0.525 1.27 0.7 1.145 0.7  ;
+    END
+  END A3
+  PIN B1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END B1
+  PIN B2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END B2
+  PIN B3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END B3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0987 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3848 LAYER metal1 ;
+    ANTENNADIFFAREA 0.189875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.365 1.105 0.365 1.19 0.365 1.19 0.15 1.26 0.15 1.26 0.435 1.105 0.435 0.7 0.435 0.7 1 0.63 1  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.055 1.315 0.055 0.975 0.125 0.975 0.125 1.315 1.105 1.315 1.19 1.315 1.19 0.975 1.26 0.975 1.26 1.315 1.33 1.315 1.33 1.485 1.105 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 0.535 0.085 0.535 0.16 0.4 0.16 0.4 0.085 0.125 0.085 0.125 0.335 0.055 0.335 0.055 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.215 0.225 1.105 0.225 1.105 0.295 0.215 0.295  ;
+  END
+END LVT_OAI33_X1
+
+MACRO LVT_OR2_X1
+  CLASS core ;
+  FOREIGN LVT_OR2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0981 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3068 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.61 0.15 0.7 0.15 0.7 1.24 0.61 1.24  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.415 1.315 0.415 0.965 0.485 0.965 0.485 1.315 0.54 1.315 0.76 1.315 0.76 1.485 0.54 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.285 0.04 0.285 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.83 0.47 0.83 0.47 0.42 0.235 0.42 0.235 0.15 0.305 0.15 0.305 0.35 0.54 0.35 0.54 0.9 0.115 0.9 0.115 1.24 0.045 1.24  ;
+  END
+END LVT_OR2_X1
+
+MACRO LVT_OR2_X2
+  CLASS core ;
+  FOREIGN LVT_OR2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.615 0.15 0.7 0.15 0.7 1.25 0.615 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.415 1.315 0.415 1.04 0.485 1.04 0.485 1.315 0.545 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.95 1.315 0.95 1.485 0.545 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.865 0.085 0.865 0.425 0.795 0.425 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.905 0.475 0.905 0.475 0.425 0.235 0.425 0.235 0.15 0.305 0.15 0.305 0.355 0.545 0.355 0.545 0.975 0.115 0.975 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_OR2_X2
+
+MACRO LVT_OR2_X4
+  CLASS core ;
+  FOREIGN LVT_OR2_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.7 0.25 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0874 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.325 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.15 0.525 0.15 0.765 0.69 0.765 0.69 0.525 0.76 0.525 0.76 0.835 0.06 0.835  ;
+    END
+  END A2
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1784 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5694 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.15 1.075 0.15 1.075 0.56 1.365 0.56 1.365 0.15 1.435 0.15 1.435 1.095 1.365 1.095 1.365 0.7 1.065 0.7 1.065 1.095 0.995 1.095  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.035 0.11 1.035 0.11 1.315 0.795 1.315 0.795 1.035 0.865 1.035 0.865 1.315 0.925 1.315 1.175 1.315 1.175 1.035 1.245 1.035 1.245 1.315 1.555 1.315 1.555 1.035 1.625 1.035 1.625 1.315 1.71 1.315 1.71 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.625 0.085 1.625 0.425 1.555 0.425 1.555 0.085 1.245 0.085 1.245 0.425 1.175 0.425 1.175 0.085 0.865 0.085 0.865 0.285 0.795 0.285 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.425 0.9 0.855 0.9 0.855 0.425 0.235 0.425 0.235 0.15 0.305 0.15 0.305 0.355 0.605 0.355 0.605 0.15 0.675 0.15 0.675 0.355 0.925 0.355 0.925 0.97 0.495 0.97 0.495 1.25 0.425 1.25  ;
+  END
+END LVT_OR2_X4
+
+MACRO LVT_OR3_X1
+  CLASS core ;
+  FOREIGN LVT_OR3_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.95 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.57 0.525 0.57 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0981 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3068 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.15 0.89 0.15 0.89 1.24 0.8 1.24  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.605 1.315 0.605 0.965 0.675 0.965 0.675 1.315 0.73 1.315 0.95 1.315 0.95 1.485 0.73 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.95 -0.085 0.95 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.83 0.66 0.83 0.66 0.42 0.045 0.42 0.045 0.15 0.115 0.15 0.115 0.35 0.415 0.35 0.415 0.15 0.485 0.15 0.485 0.35 0.73 0.35 0.73 0.9 0.115 0.9 0.115 1.24 0.045 1.24  ;
+  END
+END LVT_OR3_X1
+
+MACRO LVT_OR3_X2
+  CLASS core ;
+  FOREIGN LVT_OR3_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.57 0.525 0.57 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.805 0.15 0.89 0.15 0.89 1.25 0.805 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.605 1.315 0.605 0.975 0.675 0.975 0.675 1.315 0.73 1.315 0.985 1.315 0.985 0.975 1.055 0.975 1.055 1.315 1.14 1.315 1.14 1.485 0.73 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 1.055 0.085 1.055 0.425 0.985 0.425 0.985 0.085 0.675 0.085 0.675 0.285 0.605 0.285 0.605 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.84 0.66 0.84 0.66 0.46 0.045 0.46 0.045 0.15 0.115 0.15 0.115 0.39 0.415 0.39 0.415 0.15 0.485 0.15 0.485 0.39 0.73 0.39 0.73 0.91 0.115 0.91 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_OR3_X2
+
+MACRO LVT_OR3_X4
+  CLASS core ;
+  FOREIGN LVT_OR3_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0189 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.61 0.56 0.745 0.56 0.745 0.7 0.61 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.07755 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2652 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.375 0.42 0.985 0.42 0.985 0.66 0.915 0.66 0.915 0.49 0.51 0.49 0.51 0.66 0.375 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1099 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4095 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.185 0.525 0.255 0.525 0.255 0.7 0.32 0.7 0.32 0.77 1.13 0.77 1.13 0.525 1.2 0.525 1.2 0.84 0.185 0.84  ;
+    END
+  END A3
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1813 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5941 LAYER metal1 ;
+    ANTENNADIFFAREA 0.297825 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.415 0.26 1.485 0.26 1.485 0.56 1.79 0.56 1.79 0.26 1.86 0.26 1.86 1.25 1.79 1.25 1.79 0.7 1.485 0.7 1.485 1.25 1.415 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.075 1.315 0.075 1.035 0.145 1.035 0.145 1.315 1.21 1.315 1.21 1.045 1.28 1.045 1.28 1.315 1.35 1.315 1.595 1.315 1.595 1.035 1.665 1.035 1.665 1.315 1.975 1.315 1.975 1.035 2.045 1.035 2.045 1.315 2.09 1.315 2.09 1.485 1.35 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 2.045 0.085 2.045 0.335 1.975 0.335 1.975 0.085 1.665 0.085 1.665 0.335 1.595 0.335 1.595 0.085 1.28 0.085 1.28 0.195 1.21 0.195 1.21 0.085 0.9 0.085 0.9 0.195 0.83 0.195 0.83 0.085 0.52 0.085 0.52 0.195 0.45 0.195 0.45 0.085 0.145 0.085 0.145 0.335 0.075 0.335 0.075 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.65 0.91 1.28 0.91 1.28 0.33 0.235 0.33 0.235 0.26 1.35 0.26 1.35 0.98 0.72 0.98 0.72 1.25 0.65 1.25  ;
+  END
+END LVT_OR3_X4
+
+MACRO LVT_OR4_X1
+  CLASS core ;
+  FOREIGN LVT_OR4_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.76 0.525 0.76 0.7 0.63 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0981 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3068 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.99 0.15 1.08 0.15 1.08 1.24 0.99 1.24  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.795 1.315 0.795 0.965 0.865 0.965 0.865 1.315 0.92 1.315 1.14 1.315 1.14 1.485 0.92 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 0.865 0.085 0.865 0.285 0.795 0.285 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.285 0.04 0.285 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.83 0.85 0.83 0.85 0.42 0.235 0.42 0.235 0.15 0.305 0.15 0.305 0.35 0.605 0.35 0.605 0.15 0.675 0.15 0.675 0.35 0.92 0.35 0.92 0.9 0.115 0.9 0.115 1.24 0.045 1.24  ;
+  END
+END LVT_OR4_X1
+
+MACRO LVT_OR4_X2
+  CLASS core ;
+  FOREIGN LVT_OR4_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.33 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.7 0.06 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.375 0.525 0.375 0.7 0.25 0.7  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.525 0.565 0.525 0.565 0.7 0.44 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02275 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05225 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.525 0.76 0.525 0.76 0.7 0.63 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0935 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.995 0.15 1.08 0.15 1.08 1.25 0.995 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.795 1.315 0.795 0.975 0.865 0.975 0.865 1.315 0.925 1.315 1.175 1.315 1.175 0.975 1.245 0.975 1.245 1.315 1.33 1.315 1.33 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.33 -0.085 1.33 0.085 1.245 0.085 1.245 0.425 1.175 0.425 1.175 0.085 0.865 0.085 0.865 0.285 0.795 0.285 0.795 0.085 0.485 0.085 0.485 0.285 0.415 0.285 0.415 0.085 0.11 0.085 0.11 0.425 0.04 0.425 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.84 0.855 0.84 0.855 0.425 0.235 0.425 0.235 0.15 0.305 0.15 0.305 0.355 0.605 0.355 0.605 0.15 0.675 0.15 0.675 0.355 0.925 0.355 0.925 0.91 0.115 0.91 0.115 1.25 0.045 1.25  ;
+  END
+END LVT_OR4_X2
+
+MACRO LVT_OR4_X4
+  CLASS core ;
+  FOREIGN LVT_OR4_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN A1
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.805 0.525 0.89 0.525 0.89 0.7 0.805 0.7  ;
+    END
+  END A1
+  PIN A2
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08445 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2873 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.505 0.39 1.14 0.39 1.14 0.66 1.01 0.66 1.01 0.46 0.575 0.46 0.575 0.66 0.505 0.66  ;
+    END
+  END A2
+  PIN A3
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1162 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4264 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.525 0.38 0.525 0.38 0.77 1.26 0.77 1.26 0.525 1.33 0.525 1.33 0.84 0.31 0.84 0.31 0.7 0.25 0.7  ;
+    END
+  END A3
+  PIN A4
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.161175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5954 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.525 0.185 0.525 0.185 0.905 1.45 0.905 1.45 0.525 1.52 0.525 1.52 0.975 0.115 0.975 0.115 0.7 0.06 0.7  ;
+    END
+  END A4
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1967 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.6513 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.755 0.15 1.825 0.15 1.825 0.56 2.13 0.56 2.13 0.15 2.2 0.15 2.2 1.25 2.13 1.25 2.13 0.7 1.825 0.7 1.825 1.25 1.755 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 1.045 0.11 1.045 0.11 1.315 1.555 1.315 1.555 1.205 1.625 1.205 1.625 1.315 1.685 1.315 1.935 1.315 1.935 1.045 2.005 1.045 2.005 1.315 2.315 1.315 2.315 1.045 2.385 1.045 2.385 1.315 2.47 1.315 2.47 1.485 1.685 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 2.385 0.085 2.385 0.4 2.315 0.4 2.315 0.085 2.04 0.085 2.04 0.365 1.905 0.365 1.905 0.085 1.66 0.085 1.66 0.325 1.525 0.325 1.525 0.085 1.28 0.085 1.28 0.16 1.145 0.16 1.145 0.085 0.9 0.085 0.9 0.16 0.765 0.16 0.765 0.085 0.52 0.085 0.52 0.16 0.385 0.16 0.385 0.085 0.11 0.085 0.11 0.4 0.04 0.4 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.77 1.04 1.615 1.04 1.615 0.46 1.37 0.46 1.37 0.295 0.305 0.295 0.305 0.425 0.235 0.425 0.235 0.15 0.305 0.15 0.305 0.225 1.37 0.225 1.37 0.15 1.44 0.15 1.44 0.39 1.685 0.39 1.685 1.11 0.77 1.11  ;
+  END
+END LVT_OR4_X4
+
+MACRO LVT_SDFFRS_X1
+  CLASS core ;
+  FOREIGN LVT_SDFFRS_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 5.51 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.04085 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1053 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 5.07 0.765 5.26 0.765 5.26 0.98 5.07 0.98  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0615 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.525 0.92 0.525 0.92 0.7 0.82 0.7  ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.09325 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3367 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.76 0.39 5.335 0.39 5.335 0.56 5.19 0.56 5.19 0.46 4.83 0.46 4.83 0.765 5.005 0.765 5.005 0.835 4.76 0.835  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01885 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.56 0.695 4.69 0.695 4.69 0.84 4.56 0.84  ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0715 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.11 0.525 1.11 0.7 1.01 0.7  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0133 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0611 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.575 0.7 1.67 0.7 1.67 0.84 1.575 0.84  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.071825 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2418 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.045 0.26 0.13 0.26 0.13 1.105 0.045 1.105  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0374 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1365 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.36 0.51 0.36 0.51 0.8 0.425 0.8  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.195 1.315 0.195 1.18 0.33 1.18 0.33 1.315 0.545 1.315 0.545 1.035 0.68 1.035 0.68 1.315 0.865 1.315 0.925 1.315 0.925 1.105 1.06 1.105 1.06 1.315 1.305 1.315 1.305 1.105 1.44 1.105 1.44 1.315 1.815 1.315 1.945 1.315 1.945 0.83 2.015 0.83 2.015 1.315 2.665 1.315 2.665 0.99 2.8 0.99 2.8 1.315 3.045 1.315 3.045 0.865 3.18 0.865 3.18 1.315 3.585 1.315 3.585 1.03 3.72 1.03 3.72 1.315 3.875 1.315 4.28 1.315 4.415 1.315 4.415 1.13 4.55 1.13 4.55 1.315 4.93 1.315 5.175 1.315 5.175 1.095 5.31 1.095 5.31 1.315 5.47 1.315 5.51 1.315 5.51 1.485 5.47 1.485 4.93 1.485 4.28 1.485 3.875 1.485 1.815 1.485 0.865 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 5.51 -0.085 5.51 0.085 5.31 0.085 5.31 0.225 5.175 0.225 5.175 0.085 4.55 0.085 4.55 0.225 4.415 0.225 4.415 0.085 3.535 0.085 3.535 0.285 3.4 0.285 3.4 0.085 2.8 0.085 2.8 0.285 2.665 0.285 2.665 0.085 1.825 0.085 1.825 0.32 1.755 0.32 1.755 0.085 1.055 0.085 1.055 0.285 0.92 0.285 0.92 0.085 0.33 0.085 0.33 0.16 0.195 0.16 0.195 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.265 0.9 0.865 0.9 0.865 0.97 0.195 0.97 0.195 0.225 0.68 0.225 0.68 0.295 0.265 0.295  ;
+        POLYGON 1.35 0.905 1.655 0.905 1.655 1.165 1.815 1.165 1.815 1.235 1.585 1.235 1.585 0.975 1.28 0.975 1.28 0.41 1.485 0.41 1.485 0.285 1.555 0.285 1.555 0.48 1.35 0.48  ;
+        POLYGON 0.61 0.39 1.12 0.39 1.12 0.25 1.33 0.25 1.33 0.15 1.69 0.15 1.69 0.385 2.15 0.385 2.15 0.455 1.62 0.455 1.62 0.22 1.4 0.22 1.4 0.32 1.19 0.32 1.19 0.46 0.68 0.46 0.68 0.765 1.215 0.765 1.215 1.105 1.145 1.105 1.145 0.835 0.61 0.835  ;
+        POLYGON 1.755 0.695 2.195 0.695 2.195 0.965 2.125 0.965 2.125 0.765 1.825 0.765 1.825 0.965 1.755 0.965  ;
+        POLYGON 1.415 0.555 2.315 0.555 2.315 0.2 2.385 0.2 2.385 0.965 2.315 0.965 2.315 0.625 1.415 0.625  ;
+        POLYGON 2.615 0.485 3.045 0.485 3.045 0.295 3.18 0.295 3.18 0.485 3.8 0.485 3.8 0.555 2.685 0.555 2.685 0.755 2.99 0.755 2.99 0.825 2.615 0.825  ;
+        POLYGON 3.435 0.895 3.875 0.895 3.875 1.115 3.805 1.115 3.805 0.965 3.505 0.965 3.505 1.115 3.435 1.115  ;
+        POLYGON 2.75 0.62 4 0.62 4 0.295 4.145 0.295 4.145 1.115 4.075 1.115 4.075 0.69 2.75 0.69  ;
+        POLYGON 3.27 0.76 4.01 0.76 4.01 1.18 4.21 1.18 4.21 0.23 3.935 0.23 3.935 0.51 3.865 0.51 3.865 0.42 3.265 0.42 3.265 0.23 2.98 0.23 2.98 0.42 2.525 0.42 2.525 1.105 2.18 1.105 2.18 1.035 2.455 1.035 2.455 0.35 2.91 0.35 2.91 0.16 3.335 0.16 3.335 0.35 3.865 0.35 3.865 0.16 4.28 0.16 4.28 1.25 3.94 1.25 3.94 0.83 3.34 0.83 3.34 1.09 3.27 1.09  ;
+        POLYGON 4.44 0.945 4.93 0.945 4.93 1.015 4.37 1.015 4.37 0.41 4.615 0.41 4.615 0.22 4.93 0.22 4.93 0.29 4.685 0.29 4.685 0.48 4.44 0.48  ;
+        POLYGON 4.9 0.56 4.975 0.56 4.975 0.625 5.4 0.625 5.4 0.215 5.47 0.215 5.47 1.235 5.4 1.235 5.4 0.695 4.9 0.695  ;
+  END
+END LVT_SDFFRS_X1
+
+MACRO LVT_SDFFRS_X2
+  CLASS core ;
+  FOREIGN LVT_SDFFRS_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 5.89 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 5.495 0.42 5.64 0.42 5.64 0.56 5.495 0.56  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.024025 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.075 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.545 1.165 0.545 1.165 0.7 1.01 0.7  ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.07535 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2769 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 5.135 0.385 5.205 0.385 5.205 0.72 5.57 0.72 5.57 0.675 5.7 0.675 5.7 0.84 5.57 0.84 5.57 0.79 5.135 0.79  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.925 0.56 5.07 0.56 5.07 0.7 4.925 0.7  ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.065 LAYER metal1 ;
+    ANTENNAGATEAREA 0.04875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.365 0.545 1.46 0.545 1.46 0.7 1.365 0.7  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01155 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0611 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.9 0.175 2.065 0.175 2.065 0.245 1.9 0.245  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.078 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2743 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.24 0.15 0.32 0.15 0.32 1.125 0.24 1.125  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.062775 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.156 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.6 0.435 0.735 0.435 0.735 0.9 0.6 0.9  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.065 1.315 0.065 0.85 0.135 0.85 0.135 1.315 0.41 1.315 0.41 1.1 0.545 1.1 0.545 1.315 0.79 1.315 0.79 1.1 0.925 1.1 0.925 1.315 1.18 1.315 1.18 1.12 1.315 1.12 1.315 1.315 1.64 1.315 1.64 1.115 1.775 1.115 1.775 1.315 2.22 1.315 2.285 1.315 2.285 0.965 2.42 0.965 2.42 1.315 3.04 1.315 3.04 0.985 3.175 0.985 3.175 1.315 3.42 1.315 3.42 0.985 3.555 0.985 3.555 1.315 3.95 1.315 3.95 1.09 4.085 1.09 4.085 1.315 4.24 1.315 4.675 1.315 4.78 1.315 4.78 1.09 4.915 1.09 4.915 1.315 5.295 1.315 5.54 1.315 5.54 1.195 5.675 1.195 5.675 1.315 5.835 1.315 5.89 1.315 5.89 1.485 5.835 1.485 5.295 1.485 4.675 1.485 4.24 1.485 2.22 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 5.89 -0.085 5.89 0.085 5.675 0.085 5.675 0.18 5.54 0.18 5.54 0.085 4.88 0.085 4.88 0.27 4.81 0.27 4.81 0.085 3.895 0.085 3.895 0.285 3.76 0.285 3.76 0.085 3.175 0.085 3.175 0.285 3.04 0.285 3.04 0.085 2.2 0.085 2.2 0.32 2.13 0.32 2.13 0.085 1.835 0.085 1.835 0.285 1.7 0.285 1.7 0.085 0.925 0.085 0.925 0.16 0.79 0.16 0.79 0.085 0.545 0.085 0.545 0.16 0.41 0.16 0.41 0.085 0.135 0.085 0.135 0.41 0.065 0.41 0.065 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.39 0.23 1.305 0.23 1.305 0.3 0.46 0.3 0.46 0.965 1.12 0.965 1.12 1.035 0.39 1.035  ;
+        POLYGON 0.94 0.765 1.465 0.765 1.465 0.975 1.91 0.975 1.91 1.16 2.22 1.16 2.22 1.23 1.84 1.23 1.84 1.045 1.395 1.045 1.395 0.835 0.87 0.835 0.87 0.41 1.46 0.41 1.46 0.48 0.94 0.48  ;
+        POLYGON 2.13 0.83 2.57 0.83 2.57 1.05 2.5 1.05 2.5 0.9 2.2 0.9 2.2 1.05 2.13 1.05  ;
+        POLYGON 1.6 0.84 1.97 0.84 1.97 0.685 2.565 0.685 2.565 0.62 2.635 0.62 2.635 0.755 2.04 0.755 2.04 0.91 1.53 0.91 1.53 0.35 2.04 0.35 2.04 0.42 1.6 0.42  ;
+        POLYGON 1.665 0.485 2.7 0.485 2.7 0.2 2.77 0.2 2.77 1.05 2.7 1.05 2.7 0.555 1.735 0.555 1.735 0.68 1.665 0.68  ;
+        POLYGON 2.99 0.485 3.455 0.485 3.455 0.32 3.525 0.32 3.525 0.49 4.17 0.49 4.17 0.56 3.06 0.56 3.06 0.765 3.37 0.765 3.37 0.835 2.99 0.835  ;
+        POLYGON 3.8 0.955 4.24 0.955 4.24 1.175 4.17 1.175 4.17 1.025 3.87 1.025 3.87 1.175 3.8 1.175  ;
+        POLYGON 3.125 0.625 4.405 0.625 4.405 0.285 4.54 0.285 4.54 0.355 4.475 0.355 4.475 0.625 4.51 0.625 4.51 1.09 4.44 1.09 4.44 0.695 3.125 0.695  ;
+        POLYGON 3.615 0.765 4.375 0.765 4.375 1.155 4.605 1.155 4.605 0.825 4.575 0.825 4.575 0.69 4.605 0.69 4.605 0.22 4.34 0.22 4.34 0.425 3.61 0.425 3.61 0.22 3.39 0.22 3.39 0.42 2.915 0.42 2.915 1.185 2.555 1.185 2.555 1.115 2.845 1.115 2.845 0.35 3.32 0.35 3.32 0.15 3.68 0.15 3.68 0.355 4.27 0.355 4.27 0.15 4.675 0.15 4.675 1.225 4.305 1.225 4.305 0.835 3.615 0.835  ;
+        POLYGON 4.81 0.95 5.295 0.95 5.295 1.02 4.74 1.02 4.74 0.375 4.975 0.375 4.975 0.165 5.295 0.165 5.295 0.235 5.045 0.235 5.045 0.445 4.81 0.445  ;
+        POLYGON 5.27 0.565 5.34 0.565 5.34 0.285 5.765 0.285 5.765 0.15 5.835 0.15 5.835 1.09 5.765 1.09 5.765 0.355 5.41 0.355 5.41 0.635 5.27 0.635  ;
+  END
+END LVT_SDFFRS_X2
+
+MACRO LVT_SDFFR_X1
+  CLASS core ;
+  FOREIGN LVT_SDFFR_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.75 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.24 0.56 4.365 0.56 4.365 0.7 4.24 0.7  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0147 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.84 0.925 0.84 0.925 0.98 0.82 0.98  ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0651 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2366 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.105 0.565 4.175 0.565 4.175 0.77 4.43 0.77 4.43 0.56 4.53 0.56 4.53 0.84 4.105 0.84  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.017575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.67 0.655 3.765 0.655 3.765 0.84 3.67 0.84  ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0405 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1053 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.77 0.66 1.995 0.66 1.995 0.84 1.77 0.84  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2353 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.435 0.185 0.51 0.185 0.51 1.015 0.435 1.015  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0616 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.247 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.185 0.13 0.185 0.13 1.065 0.06 1.065  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.21 1.315 0.21 1.24 0.345 1.24 0.345 1.315 0.74 1.315 0.74 1.24 0.875 1.24 0.875 1.315 1.15 1.315 1.15 1.205 1.22 1.205 1.22 1.315 1.41 1.315 1.84 1.315 1.84 1.06 1.975 1.06 1.975 1.315 2.4 1.315 2.4 0.995 2.47 0.995 2.47 1.315 3.27 1.315 3.27 1.08 3.34 1.08 3.34 1.315 3.585 1.315 3.64 1.315 3.64 1.08 3.71 1.08 3.71 1.315 4.125 1.315 4.4 1.315 4.4 1.045 4.47 1.045 4.47 1.315 4.665 1.315 4.75 1.315 4.75 1.485 4.665 1.485 4.125 1.485 3.585 1.485 1.41 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.75 -0.085 4.75 0.085 4.47 0.085 4.47 0.32 4.4 0.32 4.4 0.085 3.71 0.085 3.71 0.32 3.64 0.32 3.64 0.085 3.18 0.085 3.18 0.32 3.11 0.32 3.11 0.085 2.34 0.085 2.34 0.425 2.27 0.425 2.27 0.085 1.845 0.085 1.845 0.285 1.71 0.285 1.71 0.085 0.84 0.085 0.84 0.32 0.77 0.32 0.77 0.085 0.31 0.085 0.31 0.46 0.24 0.46 0.24 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.195 0.525 0.265 0.525 0.265 1.08 0.585 1.08 0.585 0.185 0.655 0.185 0.655 0.39 1.075 0.39 1.075 0.635 1.005 0.635 1.005 0.46 0.655 0.46 0.655 1.24 0.585 1.24 0.585 1.15 0.195 1.15  ;
+        POLYGON 0.935 1.045 1.41 1.045 1.41 1.115 0.935 1.115  ;
+        POLYGON 1.21 0.905 1.56 0.905 1.56 1.04 1.49 1.04 1.49 0.975 1.14 0.975 1.14 0.775 0.72 0.775 0.72 0.525 0.79 0.525 0.79 0.705 1.14 0.705 1.14 0.215 1.46 0.215 1.46 0.285 1.21 0.285  ;
+        POLYGON 1.35 0.765 1.695 0.765 1.695 0.905 2.065 0.905 2.065 0.655 2.26 0.655 2.26 0.79 2.135 0.79 2.135 1.065 2.065 1.065 2.065 0.975 1.695 0.975 1.695 1.25 1.545 1.25 1.545 1.18 1.625 1.18 1.625 0.835 1.28 0.835 1.28 0.35 1.93 0.35 1.93 0.185 2 0.185 2 0.42 1.35 0.42  ;
+        POLYGON 2.22 0.855 2.335 0.855 2.335 0.56 1.5 0.56 1.5 0.7 1.43 0.7 1.43 0.49 2.09 0.49 2.09 0.185 2.16 0.185 2.16 0.49 2.405 0.49 2.405 0.17 2.92 0.17 2.92 0.835 2.85 0.835 2.85 0.24 2.475 0.24 2.475 0.56 2.405 0.56 2.405 0.925 2.29 0.925 2.29 1.13 2.22 1.13  ;
+        POLYGON 2.69 0.305 2.76 0.305 2.76 1.015 2.995 1.015 2.995 0.81 3.45 0.81 3.45 0.88 3.065 0.88 3.065 1.085 2.69 1.085  ;
+        POLYGON 2.54 0.505 2.61 0.505 2.61 1.18 3.135 1.18 3.135 0.945 3.515 0.945 3.515 0.725 2.985 0.725 2.985 0.385 3.265 0.385 3.265 0.185 3.335 0.185 3.335 0.455 3.055 0.455 3.055 0.655 3.585 0.655 3.585 1.015 3.52 1.015 3.52 1.2 3.45 1.2 3.45 1.015 3.205 1.015 3.205 1.25 2.54 1.25  ;
+        POLYGON 3.9 1.04 4.125 1.04 4.125 1.11 3.83 1.11 3.83 0.59 3.12 0.59 3.12 0.52 3.83 0.52 3.83 0.22 4.125 0.22 4.125 0.29 3.9 0.29  ;
+        POLYGON 3.965 0.715 4.035 0.715 4.035 0.905 4.595 0.905 4.595 0.485 4.1 0.485 4.1 0.415 4.595 0.415 4.595 0.185 4.665 0.185 4.665 1.22 4.595 1.22 4.595 0.975 3.965 0.975  ;
+  END
+END LVT_SDFFR_X1
+
+MACRO LVT_SDFFR_X2
+  CLASS core ;
+  FOREIGN LVT_SDFFR_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.94 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.025625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0858 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.565 0.42 4.69 0.42 4.69 0.625 4.565 0.625  ;
+    END
+  END D
+  PIN RN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.145 0.84 1.27 0.84 1.27 0.98 1.145 0.98  ;
+    END
+  END RN
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.07035 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.182 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.345 0.565 4.415 0.565 4.415 0.7 4.765 0.7 4.765 0.845 4.345 0.845  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02465 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0819 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.86 0.67 4.005 0.67 4.005 0.84 3.86 0.84  ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.019575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.145 0.695 2.28 0.695 2.28 0.84 2.145 0.84  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.05185 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1807 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.395 0.51 0.395 0.51 1.005 0.425 1.005  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.053825 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1833 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.795 0.395 0.865 0.395 0.865 0.56 0.89 0.56 0.89 1.005 0.795 1.005  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.205 0.295 1.205 0.295 1.315 0.575 1.315 0.575 1.24 0.71 1.24 0.71 1.315 0.985 1.315 0.985 1.205 1.055 1.205 1.055 1.315 1.37 1.315 1.37 1.205 1.44 1.205 1.44 1.315 1.63 1.315 2.06 1.315 2.06 1.06 2.195 1.06 2.195 1.315 2.66 1.315 2.66 0.995 2.73 0.995 2.73 1.315 3.46 1.315 3.46 1.115 3.595 1.115 3.595 1.315 3.76 1.315 3.875 1.315 3.875 1.08 3.945 1.08 3.945 1.315 4.36 1.315 4.635 1.315 4.635 1.045 4.705 1.045 4.705 1.315 4.9 1.315 4.94 1.315 4.94 1.485 4.9 1.485 4.36 1.485 3.76 1.485 1.63 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.94 -0.085 4.94 0.085 4.705 0.085 4.705 0.195 4.635 0.195 4.635 0.085 3.945 0.085 3.945 0.32 3.875 0.32 3.875 0.085 3.365 0.085 3.365 0.32 3.295 0.32 3.295 0.085 2.605 0.085 2.605 0.42 2.535 0.42 2.535 0.085 2.075 0.085 2.075 0.32 2.005 0.32 2.005 0.085 1.135 0.085 1.135 0.32 1.065 0.32 1.065 0.085 0.71 0.085 0.71 0.16 0.575 0.16 0.575 0.085 0.33 0.085 0.33 0.16 0.195 0.16 0.195 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.26 0.115 0.26 0.115 1.07 0.66 1.07 0.66 0.525 0.73 0.525 0.73 1.07 1.01 1.07 1.01 0.64 1.36 0.64 1.36 0.775 1.08 0.775 1.08 1.14 0.045 1.14  ;
+        POLYGON 1.155 1.045 1.63 1.045 1.63 1.115 1.29 1.115 1.29 1.25 1.155 1.25  ;
+        POLYGON 1.495 0.885 1.815 0.885 1.815 0.955 1.425 0.955 1.425 0.455 0.93 0.455 0.93 0.33 0.36 0.33 0.36 0.66 0.29 0.66 0.29 0.26 1 0.26 1 0.385 1.425 0.385 1.425 0.265 1.73 0.265 1.73 0.335 1.495 0.335  ;
+        POLYGON 1.63 0.75 1.95 0.75 1.95 0.915 2.345 0.915 2.345 0.68 2.56 0.68 2.56 0.75 2.415 0.75 2.415 0.985 1.95 0.985 1.95 1.25 1.79 1.25 1.79 1.18 1.88 1.18 1.88 0.82 1.56 0.82 1.56 0.41 2.195 0.41 2.195 0.26 2.265 0.26 2.265 0.48 1.63 0.48  ;
+        POLYGON 2.48 0.815 2.67 0.815 2.67 0.615 1.785 0.615 1.785 0.685 1.715 0.685 1.715 0.545 2.35 0.545 2.35 0.285 2.42 0.285 2.42 0.545 2.67 0.545 2.67 0.165 3.22 0.165 3.22 0.775 3.15 0.775 3.15 0.235 2.74 0.235 2.74 0.885 2.55 0.885 2.55 1.09 2.48 1.09  ;
+        POLYGON 2.89 0.33 3.025 0.33 3.025 0.84 3.625 0.84 3.625 0.91 3.11 0.91 3.11 1.115 3.04 1.115 3.04 0.915 2.955 0.915 2.955 0.4 2.89 0.4  ;
+        POLYGON 2.805 0.5 2.875 0.5 2.875 1.18 3.185 1.18 3.185 0.975 3.69 0.975 3.69 0.725 3.285 0.725 3.285 0.385 3.5 0.385 3.5 0.2 3.57 0.2 3.57 0.455 3.355 0.455 3.355 0.655 3.76 0.655 3.76 1.2 3.69 1.2 3.69 1.045 3.255 1.045 3.255 1.25 2.805 1.25  ;
+        POLYGON 4.14 1.045 4.36 1.045 4.36 1.115 4.07 1.115 4.07 0.59 3.42 0.59 3.42 0.52 4.07 0.52 4.07 0.23 4.36 0.23 4.36 0.3 4.14 0.3  ;
+        POLYGON 4.205 0.715 4.275 0.715 4.275 0.91 4.83 0.91 4.83 0.355 4.495 0.355 4.495 0.485 4.36 0.485 4.36 0.415 4.425 0.415 4.425 0.285 4.83 0.285 4.83 0.195 4.9 0.195 4.9 1.22 4.83 1.22 4.83 0.98 4.205 0.98  ;
+  END
+END LVT_SDFFR_X2
+
+MACRO LVT_SDFFS_X1
+  CLASS core ;
+  FOREIGN LVT_SDFFS_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.75 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0195 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0728 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.55 0.38 0.55 0.38 0.7 0.25 0.7  ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.077625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2626 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.55 0.185 0.55 0.185 0.765 0.5 0.765 0.5 0.55 0.57 0.55 0.57 0.835 0.06 0.835  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0238 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.91 0.42 1.08 0.42 1.08 0.56 0.91 0.56  ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01395 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.84 0.42 3.93 0.42 3.93 0.575 3.84 0.575  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.020475 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.078 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.785 1.115 0.785 1.115 0.98 1.01 0.98  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2457 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.24 0.98 4.265 0.98 4.265 0.4 4.335 0.4 4.335 1.25 4.24 1.25  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.08105 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3081 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.62 0.98 4.635 0.98 4.635 0.15 4.705 0.15 4.705 1.25 4.62 1.25  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.035 0.295 1.035 0.295 1.315 0.985 1.315 0.985 1.045 1.055 1.045 1.055 1.315 1.52 1.315 1.52 1.04 1.59 1.04 1.59 1.315 2.3 1.315 2.3 1.155 2.37 1.155 2.37 1.315 2.59 1.315 2.83 1.315 2.83 1.07 2.9 1.07 2.9 1.315 3.735 1.315 3.735 1.07 3.805 1.07 3.805 1.315 4.105 1.315 4.105 0.975 4.175 0.975 4.175 1.315 4.445 1.315 4.445 0.975 4.515 0.975 4.515 1.315 4.565 1.315 4.75 1.315 4.75 1.485 4.565 1.485 2.59 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.75 -0.085 4.75 0.085 4.515 0.085 4.515 0.195 4.445 0.195 4.445 0.085 3.805 0.085 3.805 0.32 3.735 0.32 3.735 0.085 2.94 0.085 2.94 0.285 2.805 0.285 2.805 0.085 2.555 0.085 2.555 0.37 2.485 0.37 2.485 0.085 1.625 0.085 1.625 0.215 1.49 0.215 1.49 0.085 1.055 0.085 1.055 0.285 0.985 0.285 0.985 0.085 0.295 0.085 0.295 0.285 0.225 0.285 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.9 0.635 0.9 0.635 0.485 0.045 0.485 0.045 0.15 0.115 0.15 0.115 0.415 0.705 0.415 0.705 0.835 0.765 0.835 0.765 0.97 0.115 0.97 0.115 1.25 0.045 1.25  ;
+        POLYGON 0.58 1.035 0.83 1.035 0.83 0.695 0.775 0.695 0.775 0.285 0.615 0.285 0.615 0.15 0.845 0.15 0.845 0.625 1.54 0.625 1.54 0.695 0.9 0.695 0.9 1.105 0.715 1.105 0.715 1.24 0.58 1.24  ;
+        POLYGON 1.18 0.77 1.605 0.77 1.605 0.485 1.18 0.485 1.18 0.15 1.25 0.15 1.25 0.415 1.675 0.415 1.675 0.6 1.89 0.6 1.89 0.67 1.675 0.67 1.675 0.84 1.25 0.84 1.25 1.25 1.18 1.25  ;
+        POLYGON 2.07 1.17 2.135 1.17 2.135 1.02 2.525 1.02 2.525 1.17 2.59 1.17 2.59 1.24 2.455 1.24 2.455 1.09 2.205 1.09 2.205 1.24 2.07 1.24  ;
+        POLYGON 1.87 1.17 1.935 1.17 1.935 0.88 2.09 0.88 2.09 0.355 1.875 0.355 1.875 0.285 2.16 0.285 2.16 0.665 2.945 0.665 2.945 0.735 2.16 0.735 2.16 0.95 2.005 0.95 2.005 1.24 1.87 1.24  ;
+        POLYGON 1.34 0.905 1.795 0.905 1.795 0.74 1.955 0.74 1.955 0.49 1.74 0.49 1.74 0.35 1.34 0.35 1.34 0.15 1.41 0.15 1.41 0.28 1.74 0.28 1.74 0.15 2.295 0.15 2.295 0.485 3.355 0.485 3.355 0.86 3.285 0.86 3.285 0.555 2.225 0.555 2.225 0.22 1.81 0.22 1.81 0.42 2.025 0.42 2.025 0.81 1.865 0.81 1.865 0.975 1.41 0.975 1.41 1.25 1.34 1.25  ;
+        POLYGON 2.225 0.805 2.685 0.805 2.685 0.93 3.42 0.93 3.42 0.42 2.65 0.42 2.65 0.2 2.72 0.2 2.72 0.35 3.49 0.35 3.49 1 2.615 1 2.615 0.875 2.225 0.875  ;
+        POLYGON 3.255 1.1 3.555 1.1 3.555 0.285 3.25 0.285 3.25 0.215 3.625 0.215 3.625 0.64 3.995 0.64 3.995 0.525 4.065 0.525 4.065 0.71 3.625 0.71 3.625 1.17 3.255 1.17  ;
+        POLYGON 3.69 0.775 4.13 0.775 4.13 0.335 4.075 0.335 4.075 0.265 4.565 0.265 4.565 0.66 4.495 0.66 4.495 0.335 4.2 0.335 4.2 0.845 3.985 0.845 3.985 1.25 3.915 1.25 3.915 0.915 3.69 0.915  ;
+  END
+END LVT_SDFFS_X1
+
+MACRO LVT_SDFFS_X2
+  CLASS core ;
+  FOREIGN LVT_SDFFS_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 5.13 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02125 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0767 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.67 0.375 0.67 0.375 0.84 0.25 0.84  ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.068625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2496 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.795 0.185 0.795 0.185 0.91 0.525 0.91 0.525 0.67 0.595 0.67 0.595 0.98 0.06 0.98  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0253 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0871 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.965 0.42 1.08 0.42 1.08 0.64 0.965 0.64  ;
+    END
+  END SI
+  PIN SN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.14245 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5473 LAYER metal1 ;
+    ANTENNAGATEAREA 0.06125 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.42 0.425 2.91 0.425 2.91 0.28 3.41 0.28 3.41 0.56 4.03 0.56 4.03 0.63 3.34 0.63 3.34 0.35 2.98 0.35 2.98 0.495 2.42 0.495  ;
+    END
+  END SN
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0168 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0676 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.84 1.13 0.84 1.13 0.98 1.01 0.98  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0273 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1196 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.43 0.395 4.5 0.395 4.5 0.785 4.43 0.785  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0273 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1196 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.81 0.395 4.88 0.395 4.88 0.785 4.81 0.785  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.195 1.315 0.195 1.24 0.33 1.24 0.33 1.315 0.99 1.315 0.99 1.115 1.06 1.115 1.06 1.315 1.505 1.315 1.505 1.24 1.64 1.24 1.64 1.315 2.265 1.315 2.265 1.165 2.4 1.165 2.4 1.315 2.555 1.315 2.64 1.315 2.64 1.03 2.71 1.03 2.71 1.315 3.51 1.315 3.51 1.12 3.58 1.12 3.58 1.315 3.825 1.315 3.825 1.15 3.96 1.15 3.96 1.315 4.2 1.315 4.2 1.15 4.335 1.15 4.335 1.315 4.58 1.315 4.58 1.15 4.715 1.15 4.715 1.315 4.99 1.315 4.99 1.125 5.015 1.125 5.06 1.125 5.06 1.315 5.13 1.315 5.13 1.485 5.015 1.485 2.555 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 5.13 -0.085 5.13 0.085 5.06 0.085 5.06 0.195 4.99 0.195 4.99 0.085 4.715 0.085 4.715 0.18 4.58 0.18 4.58 0.085 4.335 0.085 4.335 0.18 4.2 0.18 4.2 0.085 3.61 0.085 3.61 0.48 3.475 0.48 3.475 0.085 2.61 0.085 2.61 0.345 2.475 0.345 2.475 0.085 1.645 0.085 1.645 0.345 1.51 0.345 1.51 0.085 1.095 0.085 1.095 0.28 0.96 0.28 0.96 0.085 0.335 0.085 0.335 0.465 0.2 0.465 0.2 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 1.045 0.695 1.045 0.695 0.605 0.045 0.605 0.045 0.38 0.115 0.38 0.115 0.535 0.765 0.535 0.765 1.115 0.115 1.115 0.115 1.25 0.045 1.25  ;
+        POLYGON 0.585 1.18 0.83 1.18 0.83 0.42 0.585 0.42 0.585 0.35 0.9 0.35 0.9 0.705 1.57 0.705 1.57 0.775 0.9 0.775 0.9 1.25 0.585 1.25  ;
+        POLYGON 1.195 0.87 1.635 0.87 1.635 0.63 1.195 0.63 1.195 0.315 1.265 0.315 1.265 0.56 1.705 0.56 1.705 0.625 1.915 0.625 1.915 0.695 1.705 0.695 1.705 0.94 1.265 0.94 1.265 1.25 1.195 1.25  ;
+        POLYGON 2.115 1.03 2.555 1.03 2.555 1.25 2.485 1.25 2.485 1.1 2.185 1.1 2.185 1.25 2.115 1.25  ;
+        POLYGON 1.925 0.895 2.125 0.895 2.125 0.695 2.15 0.695 2.15 0.36 1.895 0.36 1.895 0.29 2.22 0.29 2.22 0.695 2.825 0.695 2.825 0.765 2.195 0.765 2.195 0.965 1.995 0.965 1.995 1.25 1.925 1.25  ;
+        POLYGON 1.355 1.105 1.785 1.105 1.785 0.76 1.98 0.76 1.98 0.495 1.355 0.495 1.355 0.36 1.425 0.36 1.425 0.425 1.75 0.425 1.75 0.155 2.355 0.155 2.355 0.56 3.14 0.56 3.14 0.845 3.175 0.845 3.175 0.98 3.07 0.98 3.07 0.63 2.285 0.63 2.285 0.225 1.82 0.225 1.82 0.425 2.075 0.425 2.075 0.575 2.05 0.575 2.05 0.83 1.855 0.83 1.855 1.175 1.425 1.175 1.425 1.25 1.355 1.25  ;
+        POLYGON 3.045 1.045 3.24 1.045 3.24 0.76 3.205 0.76 3.205 0.485 3.045 0.485 3.045 0.415 3.275 0.415 3.275 0.695 4.095 0.695 4.095 0.56 4.23 0.56 4.23 0.765 3.31 0.765 3.31 1.115 3.045 1.115  ;
+        POLYGON 3.375 0.85 4.295 0.85 4.295 0.485 3.825 0.485 3.825 0.415 4.365 0.415 4.365 0.85 4.675 0.85 4.675 0.525 4.745 0.525 4.745 0.92 3.375 0.92  ;
+        POLYGON 2.26 0.83 2.98 0.83 2.98 1.18 3.375 1.18 3.375 0.985 4.945 0.985 4.945 0.33 3.76 0.33 3.76 0.495 3.69 0.495 3.69 0.26 5.015 0.26 5.015 1.055 3.445 1.055 3.445 1.25 2.91 1.25 2.91 0.965 2.26 0.965  ;
+  END
+END LVT_SDFFS_X2
+
+MACRO LVT_SDFF_X1
+  CLASS core ;
+  FOREIGN LVT_SDFF_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.37 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02175 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0767 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.975 0.42 4.125 0.42 4.125 0.565 3.975 0.565  ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.05405 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1768 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.75 0.59 3.885 0.59 3.885 0.7 4.18 0.7 4.18 0.84 4.05 0.84 4.05 0.77 3.75 0.77  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.023625 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.415 0.525 3.55 0.525 3.55 0.7 3.415 0.7  ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0328 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0949 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.02 0.42 2.225 0.42 2.225 0.58 2.02 0.58  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.04445 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1833 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.44 0.15 0.51 0.15 0.51 0.785 0.44 0.785  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.079875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2964 LAYER metal1 ;
+    ANTENNADIFFAREA 0.109725 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.15 0.135 0.15 0.135 1.215 0.06 1.215  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.25 1.315 0.25 1.04 0.32 1.04 0.32 1.315 0.75 1.315 0.75 1.165 0.885 1.165 0.885 1.315 0.925 1.315 1.265 1.315 1.51 1.315 1.51 0.975 1.645 0.975 1.645 1.315 1.8 1.315 2.07 1.315 2.07 0.94 2.14 0.94 2.14 1.315 2.935 1.315 2.935 1.08 3.005 1.08 3.005 1.315 3.295 1.315 3.295 1.04 3.365 1.04 3.365 1.315 3.74 1.315 4.02 1.315 4.02 0.975 4.155 0.975 4.155 1.315 4.315 1.315 4.37 1.315 4.37 1.485 4.315 1.485 3.74 1.485 1.8 1.485 1.265 1.485 0.925 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.37 -0.085 4.37 0.085 4.155 0.085 4.155 0.16 4.02 0.16 4.02 0.085 3.365 0.085 3.365 0.195 3.295 0.195 3.295 0.085 3.04 0.085 3.04 0.19 2.905 0.19 2.905 0.085 2.175 0.085 2.175 0.285 2.04 0.285 2.04 0.085 1.645 0.085 1.645 0.285 1.51 0.285 1.51 0.085 0.885 0.085 0.885 0.285 0.75 0.285 0.75 0.085 0.32 0.085 0.32 0.425 0.25 0.425 0.25 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.2 0.51 0.27 0.51 0.27 0.885 0.595 0.885 0.595 0.15 0.665 0.15 0.665 0.73 0.925 0.73 0.925 0.865 0.665 0.865 0.665 1.215 0.595 1.215 0.595 0.955 0.2 0.955  ;
+        POLYGON 1.06 1.15 1.265 1.15 1.265 1.22 0.99 1.22 0.99 0.66 0.73 0.66 0.73 0.525 0.99 0.525 0.99 0.23 1.265 0.23 1.265 0.3 1.06 0.3  ;
+        POLYGON 1.195 0.84 1.8 0.84 1.8 1.215 1.73 1.215 1.73 0.91 1.125 0.91 1.125 0.475 1.73 0.475 1.73 0.32 1.8 0.32 1.8 0.545 1.195 0.545  ;
+        POLYGON 1.26 0.65 1.885 0.65 1.885 0.2 1.955 0.2 1.955 0.68 2.495 0.68 2.495 0.35 2.565 0.35 2.565 0.75 2.44 0.75 2.44 0.95 2.37 0.95 2.37 0.75 1.955 0.75 1.955 1.09 1.885 1.09 1.885 0.72 1.26 0.72  ;
+        POLYGON 2.53 0.975 2.63 0.975 2.63 0.285 2.53 0.285 2.53 0.215 2.7 0.215 2.7 0.325 3.08 0.325 3.08 0.46 2.7 0.46 2.7 1.045 2.53 1.045  ;
+        POLYGON 2.205 0.815 2.275 0.815 2.275 1.14 2.765 1.14 2.765 0.545 3.145 0.545 3.145 0.15 3.215 0.15 3.215 0.615 2.835 0.615 2.835 0.92 3.195 0.92 3.195 1.215 3.125 1.215 3.125 0.99 2.835 0.99 2.835 1.21 2.205 1.21  ;
+        POLYGON 3.35 0.905 3.74 0.905 3.74 1.215 3.67 1.215 3.67 0.975 3.28 0.975 3.28 0.83 2.9 0.83 2.9 0.695 3.28 0.695 3.28 0.285 3.67 0.285 3.67 0.15 3.74 0.15 3.74 0.355 3.35 0.355  ;
+        POLYGON 3.615 0.45 3.81 0.45 3.81 0.28 4.245 0.28 4.245 0.15 4.315 0.15 4.315 1.215 4.245 1.215 4.245 0.35 3.88 0.35 3.88 0.52 3.685 0.52 3.685 0.84 3.615 0.84  ;
+  END
+END LVT_SDFF_X1
+
+MACRO LVT_SDFF_X2
+  CLASS core ;
+  FOREIGN LVT_SDFF_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.56 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0231 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0793 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 4.165 0.42 4.33 0.42 4.33 0.56 4.165 0.56  ;
+    END
+  END D
+  PIN SE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.06405 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.169 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05775 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.95 0.595 4.02 0.595 4.02 0.7 4.355 0.7 4.355 0.84 3.95 0.84  ;
+    END
+  END SE
+  PIN SI
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.014 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0624 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.48 0.42 3.58 0.42 3.58 0.56 3.48 0.56  ;
+    END
+  END SI
+  PIN CK
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0296 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0897 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.225 0.42 2.41 0.42 2.41 0.58 2.225 0.58  ;
+    END
+  END CK
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.032725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1222 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.425 0.4 0.51 0.4 0.51 0.785 0.425 0.785  ;
+    END
+  END Q
+  PIN QN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.055675 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1924 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.805 0.185 0.89 0.185 0.89 0.84 0.805 0.84  ;
+    END
+  END QN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.04 0.295 1.04 0.295 1.315 0.605 1.315 0.605 1.04 0.675 1.04 0.675 1.315 0.985 1.315 0.985 1.04 1.055 1.04 1.055 1.315 1.47 1.315 1.745 1.315 1.745 0.94 1.815 0.94 1.815 1.315 2.005 1.315 2.275 1.315 2.275 0.91 2.345 0.91 2.345 1.315 3.135 1.315 3.135 1.08 3.205 1.08 3.205 1.315 3.455 1.315 3.455 1.24 3.59 1.24 3.59 1.315 4.24 1.315 4.24 0.965 4.31 0.965 4.31 1.315 4.5 1.315 4.56 1.315 4.56 1.485 4.5 1.485 2.005 1.485 1.47 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.56 -0.085 4.56 0.085 4.345 0.085 4.345 0.16 4.21 0.16 4.21 0.085 3.555 0.085 3.555 0.255 3.485 0.255 3.485 0.085 3.2 0.085 3.2 0.165 3.065 0.165 3.065 0.085 2.345 0.085 2.345 0.32 2.275 0.32 2.275 0.085 1.815 0.085 1.815 0.32 1.745 0.32 1.745 0.085 1.055 0.085 1.055 0.32 0.985 0.32 0.985 0.085 0.675 0.085 0.675 0.195 0.605 0.195 0.605 0.085 0.295 0.085 0.295 0.195 0.225 0.195 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.045 0.185 0.115 0.185 0.115 0.265 0.74 0.265 0.74 0.66 0.67 0.66 0.67 0.335 0.115 0.335 0.115 1.185 0.045 1.185  ;
+        POLYGON 1.2 1.055 1.47 1.055 1.47 1.125 1.13 1.125 1.13 0.975 0.29 0.975 0.29 0.525 0.36 0.525 0.36 0.905 1.13 0.905 1.13 0.22 1.47 0.22 1.47 0.29 1.2 0.29  ;
+        POLYGON 1.335 0.79 2.005 0.79 2.005 1.185 1.935 1.185 1.935 0.86 1.335 0.86 1.335 0.985 1.265 0.985 1.265 0.475 1.935 0.475 1.935 0.185 2.005 0.185 2.005 0.545 1.335 0.545  ;
+        POLYGON 1.42 0.63 2.09 0.63 2.09 0.185 2.16 0.185 2.16 0.65 2.7 0.65 2.7 0.35 2.77 0.35 2.77 0.72 2.645 0.72 2.645 0.88 2.575 0.88 2.575 0.72 2.16 0.72 2.16 1.185 2.09 1.185 2.09 0.7 1.42 0.7  ;
+        POLYGON 2.63 0.945 2.835 0.945 2.835 0.285 2.635 0.285 2.635 0.215 2.905 0.215 2.905 0.37 3.27 0.37 3.27 0.44 2.905 0.44 2.905 1.015 2.63 1.015  ;
+        POLYGON 2.41 0.785 2.48 0.785 2.48 1.11 2.97 1.11 2.97 0.505 3.335 0.505 3.335 0.185 3.405 0.185 3.405 0.575 3.04 0.575 3.04 0.89 3.4 0.89 3.4 1.185 3.33 1.185 3.33 0.96 3.04 0.96 3.04 1.18 2.41 1.18  ;
+        POLYGON 3.105 0.64 3.645 0.64 3.645 0.15 3.965 0.15 3.965 0.22 3.715 0.22 3.715 0.96 3.93 0.96 3.93 1.24 3.86 1.24 3.86 1.03 3.645 1.03 3.645 0.775 3.105 0.775  ;
+        POLYGON 3.78 0.42 3.98 0.42 3.98 0.285 4.43 0.285 4.43 0.195 4.5 0.195 4.5 1.24 4.43 1.24 4.43 0.355 4.05 0.355 4.05 0.49 3.85 0.49 3.85 0.895 3.78 0.895  ;
+  END
+END LVT_SDFF_X2
+
+MACRO LVT_TBUF_X1
+  CLASS core ;
+  FOREIGN LVT_TBUF_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.52 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0427 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1768 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.51 0.495 0.89 0.495 0.89 0.73 0.82 0.73 0.82 0.565 0.58 0.565 0.58 0.63 0.51 0.63  ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.02925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0923 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0525 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.2 0.695 1.33 0.695 1.33 0.92 1.2 0.92  ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.0959 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3211 LAYER metal1 ;
+    ANTENNADIFFAREA 0.093975 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.105 0.97 0.14 0.97 0.14 1.245 0.035 1.245 0.035 0.15 0.14 0.15 0.14 0.425 0.105 0.425  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.145 0.36 1.145 0.36 1.315 0.565 1.315 0.69 1.315 0.69 1.145 0.76 1.145 0.76 1.315 1.19 1.315 1.19 1.24 1.325 1.24 1.325 1.315 1.48 1.315 1.52 1.315 1.52 1.485 1.48 1.485 0.565 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.52 -0.085 1.52 0.085 1.285 0.085 1.285 0.295 1.15 0.295 1.15 0.085 0.905 0.085 0.905 0.295 0.77 0.295 0.77 0.085 0.36 0.085 0.36 0.16 0.225 0.16 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.44 0.835 0.565 0.835 0.565 1.115 0.495 1.115 0.495 0.905 0.37 0.905 0.37 0.715 0.17 0.715 0.17 0.645 0.37 0.645 0.37 0.36 0.53 0.36 0.53 0.43 0.44 0.43  ;
+        POLYGON 0.17 0.495 0.235 0.495 0.235 0.225 0.685 0.225 0.685 0.36 1.135 0.36 1.135 1.04 1.065 1.04 1.065 0.43 0.615 0.43 0.615 0.295 0.305 0.295 0.305 0.565 0.17 0.565  ;
+        POLYGON 0.65 0.645 0.72 0.645 0.72 0.94 0.945 0.94 0.945 1.105 1.41 1.105 1.41 0.435 1.345 0.435 1.345 0.365 1.48 0.365 1.48 1.245 1.41 1.245 1.41 1.175 0.875 1.175 0.875 1.01 0.65 1.01  ;
+  END
+END LVT_TBUF_X1
+
+MACRO LVT_TBUF_X16
+  CLASS core ;
+  FOREIGN LVT_TBUF_X16 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 4.94 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3367 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.475 0.555 3.67 0.555 3.67 0.39 4.335 0.39 4.335 0.66 4.265 0.66 4.265 0.46 3.74 0.46 3.74 0.625 3.475 0.625  ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0707 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2808 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 3.955 0.56 4.12 0.56 4.12 0.725 4.53 0.725 4.53 0.525 4.6 0.525 4.6 0.795 4.05 0.795 4.05 0.63 3.955 0.63  ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.897925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.8239 LAYER metal1 ;
+    ANTENNADIFFAREA 1.0024 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.24 0.86 0.36 0.86 0.36 0.43 0.24 0.43 0.24 0.36 0.43 0.36 0.43 0.56 0.62 0.56 0.62 0.36 0.755 0.36 0.755 0.56 1 0.56 1 0.36 1.135 0.36 1.135 0.56 1.375 0.56 1.375 0.36 1.51 0.36 1.51 0.56 1.76 0.56 1.76 0.36 1.895 0.36 1.895 0.56 2.135 0.56 2.135 0.36 2.27 0.36 2.27 0.56 2.515 0.56 2.515 0.36 2.65 0.36 2.65 0.56 2.895 0.56 2.895 0.36 3.03 0.36 3.03 1.005 2.895 1.005 2.895 0.7 2.65 0.7 2.65 1.005 2.515 1.005 2.515 0.7 2.275 0.7 2.275 1.005 2.14 1.005 2.14 0.7 1.89 0.7 1.89 1.005 1.755 1.005 1.755 0.7 1.515 0.7 1.515 1.005 1.38 1.005 1.38 0.7 1.13 0.7 1.13 1.005 0.995 1.005 0.995 0.7 0.755 0.7 0.755 1.005 0.62 1.005 0.62 0.7 0.43 0.7 0.43 0.93 0.24 0.93  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.05 1.315 0.05 1.24 0.185 1.24 0.185 1.315 0.425 1.315 0.425 1.24 0.56 1.24 0.56 1.315 0.805 1.315 0.805 1.24 0.94 1.24 0.94 1.315 1.185 1.315 1.185 1.24 1.32 1.24 1.32 1.315 1.565 1.315 1.565 1.24 1.7 1.24 1.7 1.315 1.945 1.315 1.945 1.24 2.08 1.24 2.08 1.315 2.325 1.315 2.325 1.24 2.46 1.24 2.46 1.315 2.705 1.315 2.705 1.24 2.84 1.24 2.84 1.315 3.085 1.315 3.085 1.24 3.22 1.24 3.22 1.315 3.465 1.315 3.465 1.24 3.6 1.24 3.6 1.315 3.79 1.315 3.845 1.315 3.845 1.24 3.98 1.24 3.98 1.315 4.605 1.315 4.605 1.24 4.74 1.24 4.74 1.315 4.895 1.315 4.94 1.315 4.94 1.485 4.895 1.485 3.79 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 4.94 -0.085 4.94 0.085 4.74 0.085 4.74 0.16 4.605 0.16 4.605 0.085 4.36 0.085 4.36 0.16 4.225 0.16 4.225 0.085 3.98 0.085 3.98 0.16 3.845 0.16 3.845 0.085 3.22 0.085 3.22 0.16 3.085 0.16 3.085 0.085 2.84 0.085 2.84 0.16 2.705 0.16 2.705 0.085 2.46 0.085 2.46 0.16 2.325 0.16 2.325 0.085 2.08 0.085 2.08 0.16 1.945 0.16 1.945 0.085 1.7 0.085 1.7 0.16 1.565 0.16 1.565 0.085 1.32 0.085 1.32 0.16 1.185 0.16 1.185 0.085 0.94 0.085 0.94 0.16 0.805 0.16 0.805 0.085 0.56 0.085 0.56 0.16 0.425 0.16 0.425 0.085 0.185 0.085 0.185 0.16 0.05 0.16 0.05 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 3.165 1.085 3.79 1.085 3.79 1.155 0.105 1.155 0.105 0.65 0.295 0.65 0.295 0.72 0.175 0.72 0.175 1.085 3.095 1.085 3.095 0.36 3.6 0.36 3.6 0.43 3.165 0.43  ;
+        POLYGON 4.23 0.86 4.665 0.86 4.665 0.295 0.175 0.295 0.175 0.495 0.29 0.495 0.29 0.565 0.105 0.565 0.105 0.225 4.735 0.225 4.735 0.93 4.23 0.93  ;
+        POLYGON 3.23 0.525 3.3 0.525 3.3 0.83 3.805 0.83 3.805 0.525 3.875 0.525 3.875 0.83 3.93 0.83 3.93 0.995 4.825 0.995 4.825 0.26 4.895 0.26 4.895 1.25 4.825 1.25 4.825 1.065 3.86 1.065 3.86 0.9 3.23 0.9  ;
+  END
+END LVT_TBUF_X16
+
+MACRO LVT_TBUF_X2
+  CLASS core ;
+  FOREIGN LVT_TBUF_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0203 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.82 0.56 0.825 0.56 0.965 0.56 0.965 0.7 0.825 0.7 0.82 0.7  ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.13335 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4446 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.685 0.285 0.825 0.285 1.27 0.285 1.27 0.7 1.535 0.7 1.535 0.84 1.2 0.84 1.2 0.355 0.825 0.355 0.755 0.355 0.755 0.66 0.685 0.66  ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.06475 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2587 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1253 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.13 0.8 0.335 0.8 0.335 0.87 0.06 0.87 0.06 0.35 0.33 0.35 0.33 0.42 0.13 0.42  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.04 1.315 0.04 0.995 0.11 0.995 0.11 1.315 0.415 1.315 0.415 1.135 0.485 1.135 0.485 1.315 0.975 1.315 0.975 1.065 1.045 1.065 1.045 1.315 1.27 1.315 1.39 1.315 1.39 1.065 1.46 1.065 1.46 1.315 1.67 1.315 1.71 1.315 1.71 1.485 1.67 1.485 1.27 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.475 0.085 1.475 0.25 1.405 0.25 1.405 0.085 0.98 0.085 0.98 0.2 0.91 0.2 0.91 0.085 0.485 0.085 0.485 0.39 0.415 0.39 0.415 0.085 0.11 0.085 0.11 0.25 0.04 0.25 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.235 0.495 0.55 0.495 0.55 0.15 0.825 0.15 0.825 0.22 0.62 0.22 0.62 0.725 0.705 0.725 0.705 0.795 0.55 0.795 0.55 0.565 0.235 0.565  ;
+        POLYGON 0.235 0.65 0.47 0.65 0.47 0.925 1.065 0.925 1.065 0.5 1 0.5 1 0.43 1.135 0.43 1.135 0.925 1.27 0.925 1.27 0.995 0.4 0.995 0.4 0.72 0.235 0.72  ;
+        POLYGON 1.335 0.56 1.6 0.56 1.6 0.15 1.67 0.15 1.67 1.25 1.6 1.25 1.6 0.63 1.335 0.63  ;
+  END
+END LVT_TBUF_X2
+
+MACRO LVT_TBUF_X4
+  CLASS core ;
+  FOREIGN LVT_TBUF_X4 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.09 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0741 LAYER metal1 ;
+    ANTENNAGATEAREA 0.1045 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.35 0.525 1.46 0.525 1.46 0.7 1.35 0.7  ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01575 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0689 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.75 0.525 1.84 0.525 1.84 0.7 1.75 0.7  ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.127925 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4524 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2506 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.32 1.065 0.745 1.065 0.745 1.135 0.235 1.135 0.235 0.33 0.745 0.33 0.745 0.4 0.32 0.4  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.075 1.315 0.075 1.205 0.145 1.205 0.145 1.315 0.45 1.315 0.45 1.205 0.52 1.205 0.52 1.315 0.83 1.315 0.83 1.205 0.9 1.205 0.9 1.315 1.21 1.315 1.21 1.205 1.28 1.205 1.28 1.315 1.63 1.315 1.745 1.315 1.745 0.86 1.815 0.86 1.815 1.315 2.005 1.315 2.09 1.315 2.09 1.485 2.005 1.485 1.63 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.09 -0.085 2.09 0.085 1.81 0.085 1.81 0.195 1.74 0.195 1.74 0.085 1.435 0.085 1.435 0.195 1.365 0.195 1.365 0.085 0.9 0.085 0.9 0.195 0.83 0.195 0.83 0.085 0.52 0.085 0.52 0.195 0.45 0.195 0.45 0.085 0.145 0.085 0.145 0.335 0.075 0.335 0.075 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.73 0.615 0.8 0.615 0.8 0.725 1.21 0.725 1.21 0.4 1.28 0.4 1.28 0.795 0.73 0.795  ;
+        POLYGON 0.59 0.465 0.66 0.465 0.66 0.895 1.56 0.895 1.56 0.4 1.63 0.4 1.63 0.965 1.435 0.965 1.435 1.14 1.365 1.14 1.365 0.965 0.59 0.965  ;
+        POLYGON 0.945 0.265 1.935 0.265 1.935 0.15 2.005 0.15 2.005 0.995 1.935 0.995 1.935 0.335 1.015 0.335 1.015 0.66 0.945 0.66  ;
+  END
+END LVT_TBUF_X4
+
+MACRO LVT_TBUF_X8
+  CLASS core ;
+  FOREIGN LVT_TBUF_X8 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 3.42 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0847 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3328 LAYER metal1 ;
+    ANTENNAGATEAREA 0.209 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.95 0.56 2.14 0.56 2.14 0.39 2.79 0.39 2.79 0.66 2.72 0.66 2.72 0.46 2.21 0.46 2.21 0.63 1.95 0.63  ;
+    END
+  END A
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.08405 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2821 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.465 0.525 2.6 0.525 2.6 0.725 3.01 0.725 3.01 0.525 3.08 0.525 3.08 0.795 2.465 0.795  ;
+    END
+  END EN
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.406725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 1.2363 LAYER metal1 ;
+    ANTENNADIFFAREA 0.505675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.425 0.775 1.43 0.775 1.43 1.01 1.505 1.01 1.505 1.08 1.36 1.08 1.36 0.84 1.09 0.84 1.09 1.25 1.02 1.25 1.02 0.84 0.715 0.84 0.715 1.25 0.645 1.25 0.645 0.84 0.335 0.84 0.335 1.25 0.265 1.25 0.265 0.2 0.335 0.2 0.335 0.7 0.645 0.7 0.645 0.2 0.715 0.2 0.715 0.7 1.02 0.7 1.02 0.2 1.095 0.2 1.095 0.7 1.355 0.7 1.355 0.375 1.505 0.375 1.505 0.445 1.425 0.445  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.07 1.315 0.07 0.975 0.14 0.975 0.14 1.315 0.415 1.315 0.415 1.01 0.55 1.01 0.55 1.315 0.83 1.315 0.83 0.975 0.9 0.975 0.9 1.315 1.21 1.315 1.21 0.975 1.28 0.975 1.28 1.315 1.59 1.315 1.59 0.995 1.66 0.995 1.66 1.315 1.97 1.315 1.97 0.995 2.04 0.995 2.04 1.315 2.23 1.315 2.32 1.315 2.32 1.15 2.455 1.15 2.455 1.315 3.085 1.315 3.085 1.13 3.22 1.13 3.22 1.315 3.375 1.315 3.42 1.315 3.42 1.485 3.375 1.485 2.23 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 3.42 -0.085 3.42 0.085 3.225 0.085 3.225 0.16 3.09 0.16 3.09 0.085 2.835 0.085 2.835 0.16 2.7 0.16 2.7 0.085 2.455 0.085 2.455 0.16 2.32 0.16 2.32 0.085 1.695 0.085 1.695 0.16 1.56 0.16 1.56 0.085 1.315 0.085 1.315 0.16 1.18 0.16 1.18 0.085 0.935 0.085 0.935 0.16 0.8 0.16 0.8 0.085 0.55 0.085 0.55 0.375 0.415 0.375 0.415 0.085 0.14 0.085 0.14 0.41 0.07 0.41 0.07 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 1.64 0.86 2.23 0.86 2.23 1.25 2.16 1.25 2.16 0.93 1.85 0.93 1.85 1.25 1.78 1.25 1.78 0.93 1.57 0.93 1.57 0.75 1.49 0.75 1.49 0.615 1.57 0.615 1.57 0.39 2.075 0.39 2.075 0.46 1.64 0.46  ;
+        POLYGON 2.705 0.86 3.145 0.86 3.145 0.295 1.275 0.295 1.275 0.6 1.205 0.6 1.205 0.225 3.215 0.225 3.215 0.93 2.705 0.93  ;
+        POLYGON 1.705 0.525 1.775 0.525 1.775 0.725 2.275 0.725 2.275 0.525 2.365 0.525 2.365 0.995 3.305 0.995 3.305 0.2 3.375 0.2 3.375 1.25 3.305 1.25 3.305 1.065 2.295 1.065 2.295 0.795 1.705 0.795  ;
+  END
+END LVT_TBUF_X8
+
+MACRO LVT_TINV_X1
+  CLASS core ;
+  FOREIGN LVT_TINV_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 0.76 BY 1.4 ;
+  PIN EN
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0812 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2483 LAYER metal1 ;
+    ANTENNAGATEAREA 0.05325 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.175 0.625 0.245 0.625 0.245 0.84 0.45 0.84 0.45 0.65 0.585 0.65 0.585 0.72 0.52 0.72 0.52 0.98 0.175 0.98  ;
+    END
+  END EN
+  PIN I
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.021 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0806 LAYER metal1 ;
+    ANTENNAGATEAREA 0.04475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.25 0.42 0.38 0.42 0.38 0.6 0.31 0.6 0.31 0.56 0.25 0.56  ;
+    END
+  END I
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.08395 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3055 LAYER metal1 ;
+    ANTENNADIFFAREA 0.093975 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.84 0.65 0.84 0.65 0.155 0.72 0.155 0.72 1.24 0.63 1.24  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.225 1.315 0.225 1.065 0.295 1.065 0.295 1.315 0.585 1.315 0.76 1.315 0.76 1.485 0.585 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 0.76 -0.085 0.76 0.085 0.295 0.085 0.295 0.195 0.225 0.195 0.225 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.04 0.195 0.11 0.195 0.11 0.275 0.52 0.275 0.52 0.495 0.585 0.495 0.585 0.565 0.45 0.565 0.45 0.345 0.11 0.345 0.11 1.24 0.04 1.24  ;
+  END
+END LVT_TINV_X1
+
+MACRO LVT_TLAT_X1
+  CLASS core ;
+  FOREIGN LVT_TLAT_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 2.47 BY 1.4 ;
+  PIN D
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0255 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0923 LAYER metal1 ;
+    ANTENNAGATEAREA 0.03475 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.585 0.73 0.585 0.73 0.84 0.63 0.84  ;
+    END
+  END D
+  PIN G
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.031725 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0962 LAYER metal1 ;
+    ANTENNAGATEAREA 0.02625 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.185 0.745 0.32 0.745 0.32 0.98 0.185 0.98  ;
+    END
+  END G
+  PIN OE
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.06015 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.1716 LAYER metal1 ;
+    ANTENNAGATEAREA 0.044 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.815 0.5 2.275 0.5 2.275 0.57 2.03 0.57 2.03 0.7 1.815 0.7  ;
+    END
+  END OE
+  PIN Q
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.1004 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.3159 LAYER metal1 ;
+    ANTENNADIFFAREA 0.111875 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 2.265 1.01 2.275 1.01 2.34 1.01 2.34 0.425 2.265 0.425 2.265 0.22 2.41 0.22 2.41 1.215 2.275 1.215 2.265 1.215  ;
+    END
+  END Q
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.235 1.315 0.235 1.045 0.305 1.045 0.305 1.315 0.365 1.315 0.585 1.315 0.585 1.04 0.655 1.04 0.655 1.315 1.305 1.315 1.305 1.08 1.44 1.08 1.44 1.315 1.465 1.315 1.6 1.315 1.87 1.315 1.87 0.975 1.94 0.975 1.94 1.315 2.275 1.315 2.47 1.315 2.47 1.485 2.275 1.485 1.6 1.485 1.465 1.485 0.365 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 2.47 -0.085 2.47 0.085 1.94 0.085 1.94 0.32 1.87 0.32 1.87 0.085 1.405 0.085 1.405 0.32 1.335 0.32 1.335 0.085 0.655 0.085 0.655 0.46 0.585 0.46 0.585 0.085 0.305 0.085 0.305 0.32 0.235 0.32 0.235 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.185 0.12 0.185 0.12 0.46 0.365 0.46 0.365 0.595 0.12 0.595 0.12 1.25 0.05 1.25  ;
+        POLYGON 0.43 0.185 0.5 0.185 0.5 0.905 0.875 0.905 0.875 0.51 0.945 0.51 0.945 0.975 0.5 0.975 0.5 1.25 0.43 1.25  ;
+        POLYGON 0.93 1.07 1.02 1.07 1.02 0.29 0.93 0.29 0.93 0.22 1.09 0.22 1.09 0.745 1.465 0.745 1.465 0.88 1.09 0.88 1.09 1.14 0.93 1.14  ;
+        POLYGON 1.26 0.515 1.53 0.515 1.53 0.185 1.6 0.185 1.6 1.185 1.53 1.185 1.53 0.65 1.26 0.65  ;
+        POLYGON 1.68 0.185 1.75 0.185 1.75 0.775 2.14 0.775 2.14 0.65 2.275 0.65 2.275 0.855 1.75 0.855 1.75 1.245 1.68 1.245  ;
+  END
+END LVT_TLAT_X1
+
+MACRO LVT_XNOR2_X1
+  CLASS core ;
+  FOREIGN LVT_XNOR2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0688 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2496 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.185 0.39 0.72 0.39 0.72 0.555 0.81 0.555 0.81 0.625 0.65 0.625 0.65 0.46 0.32 0.46 0.32 0.56 0.185 0.56  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.0763 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2782 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.35 0.84 0.585 0.84 0.895 0.84 0.895 0.525 0.965 0.525 0.965 0.91 0.585 0.91 0.51 0.91 0.51 0.98 0.35 0.98  ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.112 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4342 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.63 0.98 1.03 0.98 1.03 0.365 0.785 0.365 0.785 0.295 1.1 0.295 1.1 1.05 0.7 1.05 0.7 1.25 0.63 1.25  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.05 1.315 0.05 1.115 0.12 1.115 0.12 1.315 0.43 1.315 0.43 1.115 0.5 1.115 0.5 1.315 0.585 1.315 1 1.315 1 1.115 1.07 1.115 1.07 1.315 1.105 1.315 1.14 1.315 1.14 1.485 1.105 1.485 0.585 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 0.53 0.085 0.53 0.25 0.395 0.25 0.395 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.05 0.15 0.12 0.15 0.12 0.67 0.515 0.67 0.515 0.525 0.585 0.525 0.585 0.74 0.28 0.74 0.28 1.145 0.345 1.145 0.345 1.215 0.21 1.215 0.21 0.74 0.05 0.74  ;
+        POLYGON 0.595 0.16 1.105 0.16 1.105 0.23 0.595 0.23  ;
+  END
+END LVT_XNOR2_X1
+
+MACRO LVT_XNOR2_X2
+  CLASS core ;
+  FOREIGN LVT_XNOR2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.9 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.01225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.0637 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 1.01 0.525 1.08 0.525 1.08 0.7 1.01 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.112 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4342 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.505 0.56 0.89 0.56 0.89 0.77 0.91 0.77 1.58 0.77 1.58 0.525 1.65 0.525 1.65 0.84 0.91 0.84 0.82 0.84 0.82 0.63 0.505 0.63  ;
+    END
+  END B
+  PIN ZN
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.22065 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.8346 LAYER metal1 ;
+    ANTENNADIFFAREA 0.32165 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.21 0.905 0.91 0.905 1.675 0.905 1.77 0.905 1.77 0.43 1.675 0.43 0.975 0.43 0.975 0.36 1.675 0.36 1.765 0.36 1.765 0.19 1.84 0.19 1.84 0.975 1.675 0.975 0.91 0.975 0.21 0.975  ;
+    END
+  END ZN
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.05 1.315 0.05 1.065 0.12 1.065 0.12 1.315 0.425 1.315 0.425 1.065 0.495 1.065 0.495 1.315 0.805 1.315 0.805 1.065 0.875 1.065 0.875 1.315 0.91 1.315 1.54 1.315 1.54 1.24 1.675 1.24 1.675 1.315 1.865 1.315 1.9 1.315 1.9 1.485 1.865 1.485 0.91 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.9 -0.085 1.9 0.085 0.53 0.085 0.53 0.16 0.395 0.16 0.395 0.085 0.12 0.085 0.12 0.325 0.05 0.325 0.05 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.245 0.39 0.91 0.39 0.91 0.46 0.315 0.46 0.315 0.725 0.72 0.725 0.72 0.795 0.245 0.795  ;
+        POLYGON 0.21 0.225 1.675 0.225 1.675 0.295 0.21 0.295  ;
+        POLYGON 0.975 1.095 1.865 1.095 1.865 1.165 0.975 1.165  ;
+  END
+END LVT_XNOR2_X2
+
+MACRO LVT_XOR2_X1
+  CLASS core ;
+  FOREIGN LVT_XOR2_X1 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.14 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.063075 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2392 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.175 0.665 0.245 0.665 0.245 0.73 0.565 0.73 0.63 0.73 0.63 0.525 0.755 0.525 0.755 0.66 0.7 0.66 0.7 0.8 0.565 0.8 0.175 0.8  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.072875 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.2756 LAYER metal1 ;
+    ANTENNAGATEAREA 0.0785 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.305 0.875 0.565 0.875 0.82 0.875 0.82 0.525 0.945 0.525 0.945 0.66 0.89 0.66 0.89 0.945 0.565 0.945 0.305 0.945  ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.11095 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.4303 LAYER metal1 ;
+    ANTENNADIFFAREA 0.1463 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.775 1.04 1.01 1.04 1.01 0.42 0.62 0.42 0.62 0.15 0.69 0.15 0.69 0.35 1.08 0.35 1.08 1.11 0.775 1.11  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.42 1.315 0.42 1.15 0.49 1.15 0.49 1.315 0.565 1.315 1.095 1.315 1.14 1.315 1.14 1.485 1.095 1.485 0.565 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.14 -0.085 1.14 0.085 1.06 0.085 1.06 0.285 0.99 0.285 0.99 0.085 0.49 0.085 0.49 0.285 0.42 0.285 0.42 0.085 0.11 0.085 0.11 0.285 0.04 0.285 0.04 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.04 0.525 0.225 0.525 0.225 0.15 0.295 0.15 0.295 0.525 0.565 0.525 0.565 0.66 0.495 0.66 0.495 0.595 0.11 0.595 0.11 1.25 0.04 1.25  ;
+        POLYGON 0.585 1.175 1.095 1.175 1.095 1.245 0.585 1.245  ;
+  END
+END LVT_XOR2_X1
+
+MACRO LVT_XOR2_X2
+  CLASS core ;
+  FOREIGN LVT_XOR2_X2 0.0 0.0 ;
+  ORIGIN 0 0 ;
+  SYMMETRY X Y ;
+  SITE FreePDK45_38x28_10R_NP_162NW_34O ;
+  SIZE 1.71 BY 1.4 ;
+  PIN A
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1613 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5668 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.06 0.285 0.82 0.285 0.82 0.395 1.325 0.395 1.325 0.66 1.255 0.66 1.255 0.465 0.82 0.465 0.82 0.66 0.745 0.66 0.745 0.355 0.165 0.355 0.165 0.7 0.06 0.7  ;
+    END
+  END A
+  PIN B
+    DIRECTION INPUT ;
+    ANTENNAPARTIALMETALAREA 0.1099 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.325 LAYER metal1 ;
+    ANTENNAGATEAREA 0.15675 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.365 0.56 0.5 0.56 0.5 0.77 0.99 0.77 0.99 0.56 1.125 0.56 1.125 0.84 0.365 0.84  ;
+    END
+  END B
+  PIN Z
+    DIRECTION OUTPUT ;
+    ANTENNAPARTIALMETALAREA 0.157225 LAYER metal1 ;
+    ANTENNAPARTIALMETALSIDEAREA 0.5902 LAYER metal1 ;
+    ANTENNADIFFAREA 0.2926 ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0.8 0.905 1.39 0.905 1.39 0.33 0.885 0.33 0.885 0.22 0.61 0.22 0.61 0.15 0.955 0.15 0.955 0.26 1.465 0.26 1.465 0.975 0.8 0.975  ;
+    END
+  END Z
+  PIN VDD
+    DIRECTION INOUT ;
+    USE power ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 1.315 0.445 1.315 0.445 1.205 0.515 1.205 0.515 1.315 1.5 1.315 1.585 1.315 1.585 1.205 1.6 1.205 1.655 1.205 1.655 1.315 1.71 1.315 1.71 1.485 1.6 1.485 1.5 1.485 0 1.485  ;
+    END
+  END VDD
+  PIN VSS
+    DIRECTION INOUT ;
+    USE ground ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal1 ;
+        POLYGON 0 -0.085 1.71 -0.085 1.71 0.085 1.655 0.085 1.655 0.335 1.585 0.335 1.585 0.085 1.095 0.085 1.095 0.195 1.025 0.195 1.025 0.085 0.515 0.085 0.515 0.195 0.445 0.195 0.445 0.085 0.14 0.085 0.14 0.21 0.07 0.21 0.07 0.085 0 0.085  ;
+    END
+  END VSS
+  OBS
+      LAYER metal1 ;
+        POLYGON 0.61 1.175 1.5 1.175 1.5 1.245 0.61 1.245  ;
+        POLYGON 0.3 1.04 1.53 1.04 1.53 0.525 1.6 0.525 1.6 1.11 0.04 1.11 0.04 1.04 0.23 1.04 0.23 0.425 0.645 0.425 0.645 0.66 0.575 0.66 0.575 0.495 0.3 0.495  ;
+  END
+END LVT_XOR2_X2
+
+END LIBRARY
+#
+# End of file
+#

--- a/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.macro.rect.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.macro.rect.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/NangateOpenCellLibrary.macro.rect.lef

--- a/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.tech.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/NangateOpenCellLibrary.tech.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/NangateOpenCellLibrary.tech.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_1024x32.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_1024x32.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_1024x32.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_2048x39.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_2048x39.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_2048x39.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x16.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x16.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_256x16.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x34.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x34.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_256x34.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x95.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x95.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_256x95.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x96.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_256x96.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_256x96.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_32x64.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_32x64.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_32x64.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_512x64.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_512x64.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_512x64.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x15.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x15.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_64x15.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x21.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x21.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_64x21.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x32.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x32.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_64x32.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x7.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x7.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_64x7.lef

--- a/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x96.lef
+++ b/flow/platforms/nangate45_fakelvt/lef/fakeram45_64x96.lef
@@ -1,0 +1,1 @@
+../../nangate45/lef/fakeram45_64x96.lef

--- a/flow/platforms/nangate45_fakelvt/lib/NangateOpenCellLibrary_typical.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/NangateOpenCellLibrary_typical.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/NangateOpenCellLibrary_typical.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_1024x32.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_1024x32.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_1024x32.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_2048x39.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_2048x39.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_2048x39.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x16.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x16.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_256x16.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x34.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x34.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_256x34.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x95.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x95.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_256x95.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x96.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_256x96.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_256x96.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_32x64.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_32x64.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_32x64.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_512x64.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_512x64.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_512x64.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x15.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x15.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_64x15.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x21.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x21.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_64x21.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x32.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x32.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_64x32.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x7.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x7.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_64x7.lib

--- a/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x96.lib
+++ b/flow/platforms/nangate45_fakelvt/lib/fakeram45_64x96.lib
@@ -1,0 +1,1 @@
+../../nangate45/lib/fakeram45_64x96.lib

--- a/flow/platforms/nangate45_fakelvt/magic.tech
+++ b/flow/platforms/nangate45_fakelvt/magic.tech
@@ -1,0 +1,1 @@
+../nangate45/magic.tech

--- a/flow/platforms/nangate45_fakelvt/make_tracks.tcl
+++ b/flow/platforms/nangate45_fakelvt/make_tracks.tcl
@@ -1,0 +1,1 @@
+../nangate45/make_tracks.tcl

--- a/flow/platforms/nangate45_fakelvt/rcx_patterns.rules
+++ b/flow/platforms/nangate45_fakelvt/rcx_patterns.rules
@@ -1,0 +1,1 @@
+../nangate45/rcx_patterns.rules

--- a/flow/platforms/nangate45_fakelvt/setRC.tcl
+++ b/flow/platforms/nangate45_fakelvt/setRC.tcl
@@ -1,0 +1,1 @@
+../nangate45/setRC.tcl

--- a/flow/platforms/nangate45_fakelvt/tapcell.tcl
+++ b/flow/platforms/nangate45_fakelvt/tapcell.tcl
@@ -1,0 +1,1 @@
+../nangate45/tapcell.tcl

--- a/flow/platforms/nangate45_fakelvt/template_pga.cfg
+++ b/flow/platforms/nangate45_fakelvt/template_pga.cfg
@@ -1,0 +1,1 @@
+../nangate45/template_pga.cfg


### PR DESCRIPTION
Added a LEF file with copies of cells with "LVT" prefix. For example, for AND gates we now have:

[AND2_X1, AND2_X2, AND2_X4, NAND2_X1, NAND2_X2, NAND2_X4]

and we have:
[LVT_AND2_X1, LVT_AND2_X2, LVT_AND2_X4, LVT_NAND2_X1, LVT_NAND2_X2, LVT_NAND2_X4]

Also added a timing library file for the LVT cells where the max rising slew at max load was reduced for a few cells (buffers/flops for now) so the resizer would pick them over the the normal cells.

I will also try to setup a more realistic design with asap7 where we don't currently read the LVT libs in any design flow.