### PR TITLE
Makefile: add generate_mock_abstract target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -664,8 +664,23 @@ $(LOG_DIR)/6_report.log: $(RESULTS_DIR)/6_1_fill.odb $(RESULTS_DIR)/6_1_fill.sdc
 
 $(RESULTS_DIR)/6_final.def: $(LOG_DIR)/6_report.log
 
+# To speed up turnaround times when composing
+# macros to a higher level design, such as doing floorplanning,
+# or tweaking options for detailed routing, it can be useful to quickly
+# generate a mock abstract.
+#
+# This mock abstract has the same
+# interface(pins in the same places, blockages, etc.) as the final abstract,
+# but it is essentially an eviscerated macro.
+#
+# At a higher level, it is then possible to take the designs all
+# the way through "make route" (detailed route), but beyond that a .gds file is
+# needed, which the mock abstract does not contain.
+generate_mock_abstract: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sdc
+	(ABSTRACT_FROM=3_place $(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/generate_abstract.tcl -metrics $(LOG_DIR)/generate_abstract.json ) 2>&1 | tee $(LOG_DIR)/generate_abstract.log
+
 generate_abstract: $(RESULTS_DIR)/6_final.gds $(RESULTS_DIR)/6_final.def  $(RESULTS_DIR)/6_final.v
-	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/generate_abstract.tcl -metrics $(LOG_DIR)/generate_abstract.json) 2>&1 | tee $(LOG_DIR)/generate_abstract.log
+	(ABSTRACT_FROM=6_1_fill $(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/generate_abstract.tcl -metrics $(LOG_DIR)/generate_abstract.json) 2>&1 | tee $(LOG_DIR)/generate_abstract.log
 
 # Merge wrapped macros using Klayout
 #-------------------------------------------------------------------------------

--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -1,5 +1,5 @@
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 6_1_fill.odb 6_1_fill.sdc "Starting generation of abstract views"
+load_design $::env(ABSTRACT_FROM).odb $::env(ABSTRACT_FROM).sdc "Starting generation of abstract views"
  
 puts "Starting generation of abstract views"
 write_timing_model $::env(RESULTS_DIR)/$::env(DESIGN_NAME).lib


### PR DESCRIPTION
@maliberty Any tips?

Perhaps it is OK to have mock abstracts work only to and including the "make route"(detailed route) stage and not all the way to "make finish"?

When I try:

```
make DESIGN_CONFIG=designs/asap7/mock-array-big/Element/config.mk generate_mock_abstract
make DESIGN_CONFIG=designs/asap7/mock-array-big/config.mk
```

I get:

```
[deleted]
[INFO] Merging GDS/OAS files...
	./platforms/asap7/gds/asap7sc7p5t_28_R_220121a.gds
	./results/asap7/mock-array-big_Element/base/6_final.gds
ERROR: Unable to open file: ./results/asap7/mock-array-big_Element/base/6_final.gds (errno=2) in Layout.read
  ./util/def2stream.py:134
Elapsed time: 0:01.99[h:]min:sec. CPU time: user 1.60 sys 0.16 (89%). Peak memory: 330036KB.
make: *** [results/asap7/mock-array-big/base/6_1_merged.gds] Error 1
```