### PR TITLE
setup: safe, no choices to be made, setup & build locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ core.*
 
 # Python bytecode
 __pycache__/
+
+dependencies/

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -7,6 +7,10 @@ set -eu
 # Make sure we are on the correct folder before beginning
 cd "$(dirname $(readlink -f $0))"
 
+# Set up paths to dependencies, such as cmake and boost. Safe no-op
+# if tools were set up elsewhere in the path.
+. dev_env.sh
+
 # Defaults variable values
 NICE=""
 

--- a/dev_env.sh
+++ b/dev_env.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+function setpaths() {
+    local DIR=$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")
+    export PATH="$DIR/dependencies/bin:$PATH"
+}
+
+setpaths

--- a/docs/user/BuildLocally.md
+++ b/docs/user/BuildLocally.md
@@ -2,12 +2,12 @@
 
 ## Clone and Install Dependencies
 
-The `DependencyInstaller.sh` script installs all of the dependencies, including OpenROAD dependencies, if they are not already installed.
+The `setup.sh` script installs all of the dependencies, including OpenROAD dependencies, if they are not already installed.
 
 ``` shell
 git clone --recursive https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
 cd OpenROAD-flow-scripts
-./etc/DependencyInstaller.sh
+sudo ./setup.sh
 ```
 
 ## Build
@@ -27,4 +27,15 @@ source ./setup_env.sh
 yosys -help
 openroad -help
 exit
+```
+
+## Compiling and debugging in Visual Studio Code
+
+Set up environment variables to point to tools that CMake from within
+Visual Studio Code will need, then start Visual Studio Code as usual
+and hit F7, assuming you have CMake plugins installed.
+
+``` shell
+. ./dev_env.sh
+code tools/OpenROAD/
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# allow this script to be invoked from any folder
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ $EUID -ne 0 ]; then
+  echo "This script must be run with sudo"
+  exit 1
+fi
+
+"$DIR/tools/OpenROAD/etc/DependencyInstaller.sh" -base
+
+sudo -u $SUDO_USER "$DIR/tools/OpenROAD/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"


### PR DESCRIPTION
Safer and easier to build OpenROAD locally and no choices to be made:

```
sudo ./setup.sh
./build_openroad --local
. setup_env.sh
cd flow
make DESIGN_CONFIG=designs/asap7/gcd/config.mk
```

Voila!