### PR TITLE
Enable OpenROAD GUI access in WSL Ubuntu22.04

### DIFF
--- a/docs/user/BuildLocally.md
+++ b/docs/user/BuildLocally.md
@@ -28,3 +28,8 @@ yosys -help
 openroad -help
 exit
 ```
+
+> **Note:** For WSL based Ubuntu22.04 install `xterm` to access OpenROAD GUI.
+ ```
+ sudo apt update && sudo apt upgrade && sudo apt-get install xterm
+ ```


### PR DESCRIPTION
For WSL based Ubuntu22.04 by installing `xterm` OpenROAD gui will be opened. 
Otherwise you may face following error and get stuck for long.
```
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-'
This plugin does not support propagateSizeHints()
```
