### PR TITLE
DO NOT MERGE - testing designs/asap7/mock-array-big: use mpl2

### DIFF
--- a/flow/designs/asap7/mock-array-big/config.mk
+++ b/flow/designs/asap7/mock-array-big/config.mk
@@ -17,13 +17,16 @@ BLOCKS = Element
 
 export GDS_ALLOW_EMPTY = Element
 
-export MACRO_PLACEMENT_TCL = ./designs/asap7/mock-array-big/macro-placement.tcl
+#export MACRO_PLACEMENT_TCL = ./designs/asap7/mock-array-big/macro-placement.tcl
 
 export IO_CONSTRAINTS = designs/asap7/mock-array-big/io.tcl
 
 export MACRO_PLACE_HALO = 1 1
 
 export PDN_TCL = designs/asap7/mock-array-big/pdn.tcl
+
+export RTLMP_FLOW = True
+export SYNTH_HIERARCHICAL = 1
 
 # Avoid global routing too close to macros
 export MACRO_EXTENSION = 2


### PR DESCRIPTION
Doesn't work...

```
$ make DESIGN_CONFIG=designs/asap7/mock-array-big/config.mk
[deleted]
Determine shaping function for clusters -- Macro Tilings.

/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Signal Signal 66/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
 received
Stack trace:
 received
Stack trace:
Signal /usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
6 received
Stack trace:
Signal 6 received
Stack trace:
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Signal 6Signal 6/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
 received
Stack trace:
 received
Stack trace:
Signal 6 received
Stack trace:
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Signal 6 received
Stack trace:
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Signal 6 received
Stack trace:
/usr/include/c++/11/bits/stl_vector.h:1045: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = float; _Alloc = std::allocator<float>; std::vector<_Tp, _Alloc>::reference = float&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__n < this->size()' failed.
Signal 6 received
Stack trace:
 0# 0x000055B941CEACEB in /home/oyvind/ascenium/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 1# 0x00007F0D9DA42520 in /lib/x86_64-linux-gnu/libc.so.6
 2# pthread_kill in /lib/x86_64-linux-gnu/libc.so.6
 3# raise in /lib/x86_64-linux-gnu/libc.so.6
 4# abort in /lib/x86_64-linux-gnu/libc.so.6
 5# 0x000055B941CE8CF8 in /home/oyvind/ascenium/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 6# mpl2::SimulatedAnnealingCore<mpl2::SoftMacro>::packFloorplan() in /home/oyvind/ascenium/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 7# mpl2::SimulatedAnnealingCore<mpl2::SoftMacro>::fastSA() in /home/oyvind/ascenium/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 8# 0x00007F0D9DEDC2B3 in /lib/x86_64-linux-gnu/libstdc++.so.6
 9# 0x00007F0D9DA94B43 in /lib/x86_64-linux-gnu/libc.so.6
10# 0x00007F0D9DB26A00 in /lib/x86_64-linux-gnu/libc.so.6
Command terminated by signal 6
Elapsed time: 0:01.38[h:]min:sec. CPU time: user 1.26 sys 0.06 (95%). Peak memory: 189796KB.
make: *** [Makefile:457: results/asap7/mock-array-big/base/2_4_floorplan_macro.odb] Error 134
```
