### PR TITLE
DO NOT MERGE - macros on top of eachother

### DIFF
--- a/flow/designs/asap7/mock-array-big/macro-placement.tcl
+++ b/flow/designs/asap7/mock-array-big/macro-placement.tcl
@@ -9,7 +9,7 @@ for {set row 0} {$row < $rows} {incr row} {
   for {set col 0} {$col < $cols} {incr col} {
     set inst [$block findInst [format "ces_%d_%d" $row $col]]
     $inst setOrient R0
-    set x [expr round([expr {$die_offset_x + $col * $pitch_and_margin}] * $units)]
+    set x [expr round([expr {$die_offset_x}] * $units)]
     set y [expr round([expr {$die_offset_y + $row * $pitch_and_margin}] * $units)]
 
     $inst setOrigin $x $y


### PR DESCRIPTION
The macros in this modified mock-array-big are on top of eachother, yet `make floorplan` does not produce an error.

![image](https://user-images.githubusercontent.com/2798822/230757209-3d4b1ade-f2ac-4a97-bb32-f74395076332.png)
