### PR TITLE
metrics: do not round synth area

### DIFF
--- a/flow/util/genRuleFile.py
+++ b/flow/util/genRuleFile.py
@@ -74,7 +74,7 @@ rules_dict = {
     'synth__design__instance__area__stdcell': {
         'mode': 'padding',
         'padding': 15,
-        'round_value': True,
+        'round_value': False,
         'compare': '<=',
     },
     # clock


### PR DESCRIPTION
It can cause issues with small designs such as asap7/mock-array-big which has area less than 1.0