### PR TITLE
openroad : added Autotuner configuration

### DIFF
--- a/flow/designs/asap7/mock-array-big/autotuner.json
+++ b/flow/designs/asap7/mock-array-big/autotuner.json
@@ -1,0 +1,100 @@
+{
+    "_SDC_FILE_PATH": "constraints.sdc",
+    "_SDC_CLK_PERIOD": {
+        "type": "float",
+        "minmax": [
+            0.1,
+            0.4
+        ],
+        "step": 0
+    },
+    "CORE_UTILIZATION": {
+        "type": "int",
+        "minmax": [
+            5,
+            100
+        ],
+        "step": 1
+    },
+    "CORE_ASPECT_RATIO": {
+        "type": "float",
+        "minmax": [
+            0.5,
+            2.0
+        ],
+        "step": 0
+    },
+    "CORE_MARGIN": {
+        "type": "int",
+        "minmax": [
+            2,
+            2
+        ],
+        "step": 0
+    },
+    "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
+        "type": "int",
+        "minmax": [
+            0,
+            5
+        ],
+        "step": 1
+    },
+    "CELL_PAD_IN_SITES_DETAIL_PLACEMENT": {
+        "type": "int",
+        "minmax": [
+            0,
+            5
+        ],
+        "step": 1
+    },
+    "_FR_LAYER_ADJUST": {
+        "type": "float",
+        "minmax": [
+            0.1,
+            0.7
+        ],
+        "step": 0
+    },
+    "PLACE_DENSITY_LB_ADDON": {
+        "type": "float",
+        "minmax": [
+            0.0,
+            0.99
+        ],
+        "step": 0
+    },
+    "_PINS_DISTANCE": {
+        "type": "int",
+        "minmax": [
+            1,
+            4
+        ],
+        "step": 1
+    },
+    "CTS_CLUSTER_SIZE": {
+        "type": "int",
+        "minmax": [
+            10,
+            200
+        ],
+        "step": 1
+    },
+    "CTS_CLUSTER_DIAMETER": {
+        "type": "int",
+        "minmax": [
+            20,
+            400
+        ],
+        "step": 1
+    },
+    "_FR_FILE_PATH": "",
+    "_FR_GR_OVERFLOW": {
+        "type": "int",
+        "minmax": [
+            1,
+            1
+        ],
+        "step": 0
+    }
+}


### PR DESCRIPTION
A default configuration file for Auto-tuner in order to find the best parameter optimisation for this module. 

``` 
Best parameters found: 
_SDC_CLK_PERIOD': 0.15956539173310666,
'CORE_UTILIZATION': 42, 
'CORE_ASPECT_RATIO': 0.8125375117590468,
'CORE_MARGIN': 2, 
'CELL_PAD_IN_SITES_GLOBAL_PLACEMENT': 0,
'CELL_PAD_IN_SITES_DETAIL_PLACEMENT': 4, 
'_FR_LAYER_ADJUST': 0.32645297897776243, 
'PLACE_DENSITY_LB_ADDON':  0.27619906180834825, 
'_PINS_DISTANCE': 2, 
'CTS_CLUSTER_SIZE': 128, 
'CTS_CLUSTER_DIAMETER': 331, 
'_FR_FILE_PATH': '', 
'_FR_GR_OVERFLOW': 1
```