### PR TITLE
autotuner: fix error due to use of deprecated module

### DIFF
--- a/flow/util/distributed.py
+++ b/flow/util/distributed.py
@@ -42,12 +42,12 @@ import ray
 from ray import tune
 from ray.tune.schedulers import AsyncHyperBandScheduler
 from ray.tune.schedulers import PopulationBasedTraining
-from ray.tune.suggest import ConcurrencyLimiter
-from ray.tune.suggest.ax import AxSearch
-from ray.tune.suggest.basic_variant import BasicVariantGenerator
-from ray.tune.suggest.hyperopt import HyperOptSearch
-from ray.tune.suggest.nevergrad import NevergradSearch
-from ray.tune.suggest.optuna import OptunaSearch
+from ray.tune.search import ConcurrencyLimiter
+from ray.tune.search.ax import AxSearch
+from ray.tune.search.basic_variant import BasicVariantGenerator
+from ray.tune.search.hyperopt import HyperOptSearch
+from ray.tune.search.nevergrad import NevergradSearch
+from ray.tune.search.optuna import OptunaSearch
 from ray.util.queue import Queue
 
 import nevergrad as ng


### PR DESCRIPTION
Fixes:

DeprecationWarning: The module `ray.tune.suggest` has been moved to `ray.tune.search` and the old location has been deprecated. Please adjust your imports to point to the new location. Example: Do a global search and replace `ray.tune.suggest` with `ray.tune.search`.