### PR TITLE
makefile: add elapsed target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -656,6 +656,10 @@ finish: $(LOG_DIR)/6_report.log \
         $(RESULTS_DIR)/6_final.v \
         $(RESULTS_DIR)/6_final.sdc \
         $(GDS_FINAL_FILE)
+	$(MAKE) elapsed
+	
+.PHONY:
+elapsed:
 	@printf "%-25s %10s\n" Log "Elapsed seconds"
 	-@$(UTILS_DIR)/genElapsedTime.py -d "$(LOG_DIR)"
 


### PR DESCRIPTION
useful to print out elapsed time in the case of a failure or just debugging.