### PR TITLE
designs/asap7/mock-array-big/Element: restricted clk-io-pin into specific region in the grid

### DIFF
--- a/flow/designs/asap7/mock-array-big/Element/io.tcl
+++ b/flow/designs/asap7/mock-array-big/Element/io.tcl
@@ -51,4 +51,4 @@ foreach {direction direction2 names} $assignments {
     set_io_pin_constraint -mirrored_pins $mirrored
 }
 
-set_io_pin_constraint -region top:* -pin_names clock
+set_io_pin_constraint -region top:{0 0 3 0} -pin_names clock


### PR DESCRIPTION
Currently, when we group (by order) the IO pins, the tool aggregates them in one edge (for example, in the element, when region is top - the middle of it). W'd like to have the ability to specify exactly where the pins group would be located (along the region)
Tried using the this command : (from openroad PIN_CONSTRAINTS manual)
``` -region up:{llx lly urx ury} ``` 

Floorplan show the following error :
``` 
[ERROR STA-0406] set_io_pin_constraint positional arguments not supported.
Error: io.tcl, 54 STA-0406
```
Is there any way to force the exact location of pins group ?

FYI @oharboe 