### PR TITLE
global route: change default iterations to 20

### DIFF
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -30,3 +30,5 @@ export CTS_CLUSTER_DIAMETER = 100
 export CTS_CLUSTER_SIZE = 30
 
 export export SETUP_SLACK_MARGIN = 0.2
+
+export GLOBAL_ROUTE_ARGS=-congestion_iterations 100 -verbose

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -18,7 +18,7 @@ if {[info exist env(FASTROUTE_TCL)]} {
 
 global_route -guide_file $env(RESULTS_DIR)/route.guide \
                -congestion_report_file $env(REPORTS_DIR)/congestion.rpt \
-               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 100 -verbose}}]
+               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 10 -verbose}}]
 
 set_propagated_clock [all_clocks]
 estimate_parasitics -global_routing

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -18,7 +18,7 @@ if {[info exist env(FASTROUTE_TCL)]} {
 
 global_route -guide_file $env(RESULTS_DIR)/route.guide \
                -congestion_report_file $env(REPORTS_DIR)/congestion.rpt \
-               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 20 -verbose}}]
+               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 40 -verbose}}]
 
 set_propagated_clock [all_clocks]
 estimate_parasitics -global_routing

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -18,7 +18,7 @@ if {[info exist env(FASTROUTE_TCL)]} {
 
 global_route -guide_file $env(RESULTS_DIR)/route.guide \
                -congestion_report_file $env(REPORTS_DIR)/congestion.rpt \
-               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 10 -verbose}}]
+               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 20 -verbose}}]
 
 set_propagated_clock [all_clocks]
 estimate_parasitics -global_routing

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -18,7 +18,7 @@ if {[info exist env(FASTROUTE_TCL)]} {
 
 global_route -guide_file $env(RESULTS_DIR)/route.guide \
                -congestion_report_file $env(REPORTS_DIR)/congestion.rpt \
-               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 40 -verbose}}]
+               {*}[expr {[info exists ::env(GLOBAL_ROUTE_ARGS)] ? $::env(GLOBAL_ROUTE_ARGS) : {-congestion_iterations 20 -verbose}}]
 
 set_propagated_clock [all_clocks]
 estimate_parasitics -global_routing


### PR DESCRIPTION
a 100 iterations can take a very long time. If global route doesn't complete in 20, it normally requires some attention from the developer to find out what is wrong.

I have a guess, easily checked by this draft PR, is that none of the designs in the test-suite need very many global route iterations.