### PR TITLE
gitignore: .vscode and .metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ __pycache__/
 dependencies/
 .vscode/
 .metals/
+perf.data
+perf.data.old

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ core.*
 __pycache__/
 
 dependencies/
+.vscode/
+.metals/


### PR DESCRIPTION
when working with any vscode project or with Scala(e.g. Chisel)