### PR TITLE
mock-array-big: more floreplan fixes

### DIFF
--- a/flow/designs/asap7/mock-array-big/config.py
+++ b/flow/designs/asap7/mock-array-big/config.py
@@ -20,17 +20,17 @@ placement_grid_y = 0.27
 ce_width    = (3 * 2.16) * pitch_scale
 ce_height   = (3 * 2.16) * pitch_scale
 
-# Element placement, can be controlled by user
-ce_pitch_x  = ce_width  * pitch_scale
-ce_pitch_y  = ce_height * pitch_scale
-
 # top level core offset 
 margin_x    = 2.16
 margin_y    = 2.16
 
+# Element placement, can be controlled by user
+ce_pitch_x  = ce_width + 2 * margin_x
+ce_pitch_y  = ce_height + 2 * margin_y
+
 # top level core size
-core_width  = (ce_pitch_x * (cols + 0.5))
-core_height = (ce_pitch_y * (rows + 0.5))
+core_width  = (ce_pitch_x * (cols + 1))
+core_height = (ce_pitch_y * (rows + 1))
 
 die_width = core_width + (2 * margin_x)
 die_height = core_height + (2 * margin_y)


### PR DESCRIPTION
@louiic @maliberty I missed more stuff in review. It looks like the macros are intended to be placed half a pitch from the borders, which is a lot of space, compared to the distance between the macros in the array.

@louiic I have a pull request in flight that allows me to set up a settings.mk file locally with configurations, such that I can just type "make configure" to geneate Verilog(from Chisel) for the configuration and "make floorplan" will then generate the floorplan. https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1085

Example 1:

```
export MOCK_ARRAY_WIDTH=2
export MOCK_ARRAY_HEIGHT=2
export MOCK_ARRAY_DATAWIDTH=4
export MOCK_ARRAY_PITCH_SCALE=40
export DESIGN_CONFIG=designs/asap7/mock-array-big/config.mk
export FLOW_VARIANT=2x2x4x10
```

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/81c8d0ac-540d-4453-a93a-6d2a632e111b)

Example 2:

```
export MOCK_ARRAY_WIDTH=8
export MOCK_ARRAY_HEIGHT=8
export MOCK_ARRAY_DATAWIDTH=8
export MOCK_ARRAY_PITCH_SCALE=2
export DESIGN_CONFIG=designs/asap7/mock-array-big/config.mk
export FLOW_VARIANT=8x8x8x2
```

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/e1126235-3141-48dc-b7b8-55a155f1a34f)
