### PR TITLE
Mock array big spacing between macros

### DIFF
--- a/flow/designs/asap7/mock-array-big/Element/config.mk
+++ b/flow/designs/asap7/mock-array-big/Element/config.mk
@@ -12,8 +12,18 @@ export PLACE_DENSITY          = 0.50
 export GPL_TIMING_DRIVEN      = 0
 export GPL_ROUTABILITY_DRIVEN = 0
 
-export CORE_AREA = $(shell export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && python3 designs/asap7/mock-array-big/ce_core_area.py)
-export DIE_AREA = $(shell export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && python3 designs/asap7/mock-array-big/ce_die_area.py)
+export CORE_AREA = $(shell \
+ export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && \
+ export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && \
+ export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && \
+ cd designs/asap7/mock-array-big && \
+ python3 -c "import config; print(f'{config.ce_margin_x} {config.ce_margin_y} {config.ce_width - config.ce_margin_x} {config.ce_height - config.ce_margin_y}')")
+export DIE_AREA = $(shell \
+ export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && \
+ export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && \
+ export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && \
+ cd designs/asap7/mock-array-big && \
+ python3 -c "import config; print(f'0 0 {config.ce_width} {config.ce_height}')")
 
 export IO_CONSTRAINTS = designs/asap7/mock-array-big/Element/io.tcl
 

--- a/flow/designs/asap7/mock-array-big/ce_core_area.py
+++ b/flow/designs/asap7/mock-array-big/ce_core_area.py
@@ -1,6 +1,0 @@
-import config
-
-margin_x = config.placement_grid_x * 8
-margin_y = config.placement_grid_y * 2
-
-print(f'{margin_x} {margin_y} {config.ce_width - margin_x} {config.ce_height - margin_y}')

--- a/flow/designs/asap7/mock-array-big/ce_die_area.py
+++ b/flow/designs/asap7/mock-array-big/ce_die_area.py
@@ -1,4 +1,0 @@
-import config
-import os
-
-print(f'0 0 {config.ce_width} {config.ce_height}')

--- a/flow/designs/asap7/mock-array-big/config.mk
+++ b/flow/designs/asap7/mock-array-big/config.mk
@@ -12,8 +12,18 @@ export PLATFORM               = asap7
 
 export PLACE_DENSITY          = 0.30
 
-export CORE_AREA = $(shell export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && python3 designs/asap7/mock-array-big/core_area.py)
-export DIE_AREA = $(shell export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && python3 designs/asap7/mock-array-big/die_area.py)
+export CORE_AREA = $(shell \
+ export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && \
+ export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && \
+ export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && \
+ cd designs/asap7/mock-array-big && \
+ python3 -c "import config; print(f'{config.margin_x} {config.margin_y} {config.core_width + config.margin_x} {config.core_height + config.margin_y}')")
+export DIE_AREA = $(shell \
+ export MOCK_ARRAY_HEIGHT=$(MOCK_ARRAY_HEIGHT) && \
+ export MOCK_ARRAY_WIDTH=$(MOCK_ARRAY_WIDTH) && \
+ export MOCK_ARRAY_PITCH_SCALE=$(MOCK_ARRAY_PITCH_SCALE) && \
+ cd designs/asap7/mock-array-big && \
+ python3 -c "import config; print(f'0 0 {config.die_width} {config.die_height}')")
 
 BLOCKS = Element
 

--- a/flow/designs/asap7/mock-array-big/config.py
+++ b/flow/designs/asap7/mock-array-big/config.py
@@ -26,9 +26,11 @@ ce_margin_y = placement_grid_y * 2
 margin_x    = 2.16
 margin_y    = 2.16
 
+channel = 12 # int(os.environ.get("MACRO_PLACE_CHANNEL").split()[0])
+
 # Element placement, can be controlled by user
-ce_pitch_x  = ce_width + 2 * margin_x
-ce_pitch_y  = ce_height + 2 * margin_y
+ce_pitch_x  = ce_width + int((channel * 2) / placement_grid_x) * placement_grid_x
+ce_pitch_y  = ce_height + int((channel * 2) / placement_grid_y) * placement_grid_y
 
 # top level core size
 core_width  = ce_pitch_x * cols + ce_width

--- a/flow/designs/asap7/mock-array-big/config.py
+++ b/flow/designs/asap7/mock-array-big/config.py
@@ -19,6 +19,8 @@ placement_grid_y = 0.27
 # Element size is set to multiple of 2.16
 ce_width    = (3 * 2.16) * pitch_scale
 ce_height   = (3 * 2.16) * pitch_scale
+ce_margin_x = placement_grid_x * 8
+ce_margin_y = placement_grid_y * 2
 
 # top level core offset 
 margin_x    = 2.16

--- a/flow/designs/asap7/mock-array-big/config.py
+++ b/flow/designs/asap7/mock-array-big/config.py
@@ -31,8 +31,8 @@ ce_pitch_x  = ce_width + 2 * margin_x
 ce_pitch_y  = ce_height + 2 * margin_y
 
 # top level core size
-core_width  = (ce_pitch_x * (cols + 1))
-core_height = (ce_pitch_y * (rows + 1))
+core_width  = ce_pitch_x * cols + ce_width
+core_height = ce_pitch_y * rows + ce_height
 
 die_width = core_width + (2 * margin_x)
 die_height = core_height + (2 * margin_y)

--- a/flow/designs/asap7/mock-array-big/core_area.py
+++ b/flow/designs/asap7/mock-array-big/core_area.py
@@ -1,3 +1,0 @@
-import config
-
-print(f'{config.margin_x} {config.margin_y} {config.core_width + config.margin_x} {config.core_height + config.margin_y}')

--- a/flow/designs/asap7/mock-array-big/die_area.py
+++ b/flow/designs/asap7/mock-array-big/die_area.py
@@ -1,3 +1,0 @@
-import config
-
-print(f'0 0 {config.die_width} {config.die_height}')


### PR DESCRIPTION
Before:

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/45442c5a-8d64-4770-b08a-98100ba88b54)


After:

- superfluous space to the right and on the top gone
- no blockage in the middle between macros

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/e9e7e37e-ed71-4583-9f8e-94e9187db0d5)


MOCK_ARRAY_BIG_PITCH=20

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/182ec86b-8147-4ebf-ba6d-56ed1173c2ef)


![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/2fd50944-7776-44fe-aa29-646aab417d0e)


