### PR TITLE
Make fix symlink mock abstract dates

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -699,23 +699,23 @@ $(RESULTS_DIR)/6_final.def: $(LOG_DIR)/6_report.log
 # Skipping resize can be useful for mock abstracts
 .PHONY: skip_resize
 skip_resize: $(RESULTS_DIR)/3_3_place_gp.odb
-	cp $(RESULTS_DIR)/3_3_place_gp.odb $(RESULTS_DIR)/3_4_place_resized.odb
+	cd $(RESULTS_DIR) && ln -sf 3_3_place_gp.odb 3_4_place_resized.odb && touch 3_4_place_resized.odb
 
 # Skipping CTS can be useful to smoketest later stages.
 .PHONY: skip_cts
 skip_cts: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sdc
 	# mock all intermediate results
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_1_cts.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_2_cts_fillcell.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.sdc 4_cts.sdc
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_cts.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_1_cts.odb && touch 4_1_cts.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_2_cts_fillcell.odb && touch 4_2_cts_fillcell.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.sdc 4_cts.sdc && touch 4_cts.sdc
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_cts.odb && touch 4_cts.odb
 
 # Skipping route can be useful to create a mock abstract
 .PHONY: skip_route
 skip_route: $(RESULTS_DIR)/4_cts.odb $(RESULTS_DIR)/4_cts.sdc
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_1_grt.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_2_route.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 6_1_fill.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_1_grt.odb && touch 5_1_grt.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_2_route.odb && touch 5_2_route.odb
+	cd $(RESULTS_DIR) && ln -sf 3_place.odb 6_1_fill.odb && touch 6_1_fill.odb
 	touch $(RESULTS_DIR)/6_final.spef
 
 # To create a mock abstract quickly, good enough to iterate quickly on


### PR DESCRIPTION
Log from new test run where CTS takes no time. No time in CTS, resize or route:

A couple of macros build with `make skip_resize skip_cts skip_route generate_abstract` and extracting times:

```
1_1_yosys                        616
3_3_place_gp                      57
3_3_place_gp                      51
1_1_yosys                         39
3_3_place_gp                      32
1_1_yosys                         26
3_5_opendp                        24
1_1_yosys                         22
6_report                          12
3_3_place_gp                      12
6_report                           8
3_5_opendp                         8
3_5_opendp                         8
6_report                           7
3_1_place_gp_skip_io               7
3_5_opendp                         6
6_report                           5
3_1_place_gp_skip_io               5
3_1_place_gp_skip_io               4
2_1_floorplan                      4
1_1_yosys                          4
3_2_place_iop                      3
2_6_pdn                            3
2_6_pdn                            3
2_1_floorplan                      3
6_1_merge                          2
6_1_merge                          2
3_2_place_iop                      2
3_1_place_gp_skip_io               2
2_2_floorplan_io                   2
2_1_floorplan                      2
2_1_floorplan                      2
6_1_merge                          1
6_1_merge                          1
3_2_place_iop                      1
3_2_place_iop                      1
2_6_pdn                            1
2_6_pdn                            1
2_5_tapcell                        1
2_5_tapcell                        1
2_5_tapcell                        1
2_5_tapcell                        1
2_4_mplace                         1
2_4_mplace                         1
2_4_mplace                         1
2_4_mplace                         1
2_3_tdms_place                     1
2_3_tdms_place                     1
2_2_floorplan_io                   1
2_2_floorplan_io                   1
2_2_floorplan_io                   1

```