### PR TITLE
makefile: mixing symlinks and normal files doesn't work with make

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -455,7 +455,7 @@ $(RESULTS_DIR)/2_2_floorplan_io.odb: $(RESULTS_DIR)/2_1_floorplan.odb $(IO_CONST
 ifndef IS_CHIP
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/io_placement_random.tcl -metrics $(LOG_DIR)/2_2_floorplan_io.json) 2>&1 | tee $(LOG_DIR)/2_2_floorplan_io.log
 else
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 endif
 
 # STEP 3: Timing Driven Mixed Sized Placement
@@ -465,7 +465,7 @@ ifeq ($(MACRO_PLACEMENT),)
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/tdms_place.tcl -metrics $(LOG_DIR)/2_3_tdms.json) 2>&1 | tee $(LOG_DIR)/2_3_tdms_place.log
 else
 	$(info [INFO][FLOW] Using manual macro placement file $(MACRO_PLACEMENT))
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 endif
 
 # STEP 4: Macro Placement
@@ -485,7 +485,7 @@ $(RESULTS_DIR)/2_6_floorplan_pdn.odb: $(RESULTS_DIR)/2_5_floorplan_tapcell.odb $
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/pdn.tcl -metrics $(LOG_DIR)/2_6_pdn.json) 2>&1 | tee $(LOG_DIR)/2_6_pdn.log
 
 $(RESULTS_DIR)/2_floorplan.odb: $(RESULTS_DIR)/2_6_floorplan_pdn.odb
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 
 $(RESULTS_DIR)/2_floorplan.sdc: $(RESULTS_DIR)/2_1_floorplan.odb
 
@@ -518,7 +518,7 @@ $(RESULTS_DIR)/3_2_place_iop.odb: $(RESULTS_DIR)/3_1_place_gp_skip_io.odb $(IO_C
 ifndef IS_CHIP
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/io_placement.tcl -metrics $(LOG_DIR)/3_2_place_iop.json) 2>&1 | tee $(LOG_DIR)/3_2_place_iop.log
 else
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 endif
 
 # STEP 3: Global placement with placed IOs, timing-driven, and routability-driven.
@@ -541,7 +541,7 @@ $(RESULTS_DIR)/3_5_place_dp.odb: $(RESULTS_DIR)/3_4_place_resized.odb
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/detail_place.tcl -metrics $(LOG_DIR)/3_5_opendp.json) 2>&1 | tee $(LOG_DIR)/3_5_opendp.log
 
 $(RESULTS_DIR)/3_place.odb: $(RESULTS_DIR)/3_5_place_dp.odb
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 
 $(RESULTS_DIR)/3_place.sdc: $(RESULTS_DIR)/2_floorplan.sdc
 	cp $< $@
@@ -582,7 +582,7 @@ $(RESULTS_DIR)/4_2_cts_fillcell.odb: $(RESULTS_DIR)/4_1_cts.odb
 $(RESULTS_DIR)/4_cts.sdc: $(RESULTS_DIR)/4_cts.odb
 
 $(RESULTS_DIR)/4_cts.odb: $(RESULTS_DIR)/4_2_cts_fillcell.odb
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 
 .PHONY: clean_cts
 clean_cts:
@@ -620,7 +620,7 @@ endif
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/detail_route.tcl -metrics $(LOG_DIR)/5_2_TritonRoute.json) 2>&1 | tee $(LOG_DIR)/5_2_TritonRoute.log
 
 $(RESULTS_DIR)/5_route.odb: $(RESULTS_DIR)/5_2_route.odb
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 
 $(RESULTS_DIR)/5_route.sdc: $(RESULTS_DIR)/4_cts.sdc
 	cp $< $@
@@ -681,7 +681,7 @@ $(RESULTS_DIR)/6_1_fill.odb: $(RESULTS_DIR)/5_route.odb $(FILL_CONFIG)
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/density_fill.tcl -metrics $(LOG_DIR)/6_density_fill.json) 2>&1 | tee $(LOG_DIR)/6_density_fill.log
 else
 $(RESULTS_DIR)/6_1_fill.odb: $(RESULTS_DIR)/5_route.odb
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 endif
 
 $(RESULTS_DIR)/6_1_fill.sdc: $(RESULTS_DIR)/5_route.sdc
@@ -705,17 +705,17 @@ skip_resize: $(RESULTS_DIR)/3_3_place_gp.odb
 .PHONY: skip_cts
 skip_cts: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sdc
 	# mock all intermediate results
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_1_cts.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_2_cts_fillcell.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.sdc 4_cts.sdc
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 4_cts.odb
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_1_cts.odb
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_2_cts_fillcell.odb
+	cp $(RESULTS_DIR)/3_place.sdc $(RESULTS_DIR)/4_cts.sdc
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_cts.odb
 
 # Skipping route can be useful to create a mock abstract
 .PHONY: skip_route
 skip_route: $(RESULTS_DIR)/4_cts.odb $(RESULTS_DIR)/4_cts.sdc
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_1_grt.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 5_2_route.odb
-	cd $(RESULTS_DIR) && ln -sf 3_place.odb 6_1_fill.odb
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/5_1_grt.odb
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/5_2_route.odb
+	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/6_1_fill.odb
 	touch $(RESULTS_DIR)/6_final.spef
 
 # To create a mock abstract quickly, good enough to iterate quickly on
@@ -758,7 +758,7 @@ $(GDS_MERGED_FILE): $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klayout.lyt $(GDSO
 $(RESULTS_DIR)/6_final.v: $(LOG_DIR)/6_report.log
 
 $(GDS_FINAL_FILE): $(GDS_MERGED_FILE)
-	ln -sf $(shell realpath --relative-to=$(dir $@) $<) $@
+	cp $< $@
 
 .PHONY: drc
 drc: $(REPORTS_DIR)/6_drc.lyrdb


### PR DESCRIPTION
Symlinks were introduced to save space on .odb files for large designs, however, I have concluded that make doesn't work with a mix of regular files and symlinks in dependencies.

In this rule, one of the dependencies is a symlink the other a file:

```
$(RESULTS_DIR)/4_1_cts.odb: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sdc
```

This causes a problem where make incorrectly concludes that 4_1_cts.odb needs to be built.


I ran some experiments that landed me on that symlinks and files can't mix when it comes to make: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1104#issuecomment-1569575996



Revert "Makefile: limit 'ln -fs' usage to within the results dir and .odb files"

This reverts commit 25db9b8566f154051240206b09befccb24713db8.

Revert "Makefile: use ln -fs instead of cp to save space"

This reverts commit 020154f64fdcba78dd9a20e570f94517c0e26eb3.