### PR TITLE
Remove PRIVATE_DIR variable from config.mk

### DIFF
--- a/flow/designs/asap7/mock-array-big/Element/config.mk
+++ b/flow/designs/asap7/mock-array-big/Element/config.mk
@@ -23,8 +23,6 @@ export PDN_TCL = designs/asap7/mock-array-big/Element/pdn.tcl
 # to the ring and stipe
 export MAX_ROUTING_LAYER = M5
 
-export PRIVATE_DIR=designs/asap7/mock-array-big
-
 # If this design isn't quickly done in detailed routing, something is wrong.
 # At time of adding this option, only 3 iterations were needed for 0
 # violations.

--- a/flow/designs/asap7/mock-array-big/config.mk
+++ b/flow/designs/asap7/mock-array-big/config.mk
@@ -26,7 +26,10 @@ export IO_CONSTRAINTS = designs/asap7/mock-array-big/io.tcl
 export PDN_TCL = designs/asap7/mock-array-big/pdn.tcl
 export TNS_END_PERCENT       = 100
 
-export PRIVATE_DIR=designs/asap7/mock-array-big
+# Target to force generation of Verilog per user settings
+#   MOCK_ARRAY_WIDTH and MOCK_ARRAY_HEIGHT
+verilog:
+	./designs/asap7/mock-array-big/verilog.sh
 
 # If this design isn't quickly done in detailed routing, something is wrong.
 # At time of adding this option, only 3 iterations were needed for 0

--- a/flow/designs/asap7/mock-array-big/private.mk
+++ b/flow/designs/asap7/mock-array-big/private.mk
@@ -1,3 +1,0 @@
-.PHONY: verilog
-verilog:
-	designs/asap7/mock-array-big/verilog.sh


### PR DESCRIPTION
PRIVATE_DIR is a reserved variable - need to update OpenROAD        
Remove from config.mk - both mock-array-big and Element
Pull in target from private.mk, then remove private.mk