### PR TITLE
makefile: add vars target

### DIFF
--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -1,1 +1,4 @@
 settings.mk
+vars.sh
+vars.gdb
+vars.tcl

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -846,6 +846,9 @@ nuke: clean_test clean_issues
 	rm -rf *.rpt *.rpt.old *.def.v pin_dumper.log
 	rm -rf versions.txt
 
+.PHONY: vars
+vars:
+	$(UTILS_DIR)/generate-vars.sh vars
 
 # DEF/GDS/OAS viewer shortcuts
 #-------------------------------------------------------------------------------

--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# exclude system and CI variables
+EXCLUDED_VARS="MAKE|PYTHONPATH|PKG_CONFIG_PATH|PERL5LIB|PCP_DIR|PATH|MANPATH"
+EXCLUDED_VARS+="|LD_LIBRARY_PATH|INFOPATH|HOME|PWD|MAIL|TIME_CMD|QT_QPA_PLATFORM"
+
+printf '%s\n' "$ISSUE_VARIABLES" | while read -r V;
+do
+    if [[ ! ${V%=*} =~ ^[[:digit:]] && ${V} == *"="* && ! -z ${V#*=} && ${V%=*} != *"MAKEFILE"* && ! ${V%=*} =~ ^(${EXCLUDED_VARS})$ ]] ; then
+        rhs=`sed -e 's/^"//' -e 's/"$//' <<<"${V#*=}"`
+        # handle special case where the variable needs to be splitted in Tcl code
+        if [[ "${V%=*}" == "GND_NETS_VOLTAGES" || "${V%=*}" == "PWR_NETS_VOLTAGES" ]]; then
+            echo "export "${V%=*}"='"\"${rhs}"\"'" >> $1.sh;
+        else
+            echo "export "${V%=*}"='"${rhs}"'" >> $1.sh;
+        fi
+        echo "set env("${V%=*}") \""${rhs}\""" >> $1.tcl;
+        echo "set env "${V%=*}" "${rhs}"" >> $1.gdb;
+    fi
+done
+
+# remove variables starting with a dot
+sed -i -e '/export \./d' $1.sh
+sed -i -e '/set env(\./d' $1.tcl
+sed -i -e '/set env \./d' $1.gdb


### PR DESCRIPTION
@maliberty This allows generating vars.sh/tcl/gdb files, which is useful when debugging, openroad command line can be copied and pasted after sourcing vars.sh.

Also, it could be useful in separating the concern of executing ORFS stages and checking dependencies, opening the road implementing Bazel support on top of ORFS with a minimal maintenance burden for ORFS and the Bazel support.