### PR TITLE
makefile: first example on how to move logic from makefile to tcl

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -463,11 +463,7 @@ $(RESULTS_DIR)/2_1_floorplan.odb: $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synt
 # STEP 2: IO Placement (random)
 #-------------------------------------------------------------------------------
 $(RESULTS_DIR)/2_2_floorplan_io.odb: $(RESULTS_DIR)/2_1_floorplan.odb $(IO_CONSTRAINTS)
-ifndef IS_CHIP
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/io_placement_random.tcl -metrics $(LOG_DIR)/2_2_floorplan_io.json) 2>&1 | tee $(LOG_DIR)/2_2_floorplan_io.log
-else
-	cp $< $@
-endif
 
 # STEP 3: Timing Driven Mixed Sized Placement
 #-------------------------------------------------------------------------------

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -449,9 +449,9 @@ floorplan_info:
 # ==============================================================================
 
 ifneq ($(FOOTPRINT),)
-IS_CHIP = 1
+export IS_CHIP = 1
 else ifneq ($(FOOTPRINT_TCL),)
-IS_CHIP = 1
+export IS_CHIP = 1
 endif
 
 # STEP 1: Translate verilog to odb

--- a/flow/scripts/io_placement_random.tcl
+++ b/flow/scripts/io_placement_random.tcl
@@ -1,4 +1,4 @@
-if {![info exists ::env(IS_CHIP)]} {
+if {[info exists ::env(IS_CHIP)]} {
   file copy -force $::env(RESULTS_DIR)/2_1_floorplan.odb $::env(RESULTS_DIR)/2_2_floorplan_io.odb
   # Ouch! The file date is copied by Tcl, but the precision is seconds, so
   # this means that a copied file can be *older* than the source, or

--- a/flow/scripts/io_placement_random.tcl
+++ b/flow/scripts/io_placement_random.tcl
@@ -1,3 +1,12 @@
+if {![info exists ::env(IS_CHIP)]} {
+  file copy -force $::env(RESULTS_DIR)/2_1_floorplan.odb $::env(RESULTS_DIR)/2_2_floorplan_io.odb
+  # Ouch! The file date is copied by Tcl, but the precision is seconds, so
+  # this means that a copied file can be *older* than the source, or
+  # worse, older than some *other* dependency for this target.
+  exec touch $::env(RESULTS_DIR)/2_2_floorplan_io.odb
+  exit
+}
+
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 2_1_floorplan.odb 1_synth.sdc "Starting random IO placement"
 


### PR DESCRIPTION
@maliberty moving logic from Makefile to tcl is a step in the direction of separating the concern of dependencies from how to execute ORFS stages.