### PR TITLE
Make BLOCKS is idempotent

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -672,7 +672,7 @@ finish: $(LOG_DIR)/6_report.log \
         $(RESULTS_DIR)/6_final.v \
         $(RESULTS_DIR)/6_final.sdc \
         $(GDS_FINAL_FILE)
-	-@$(UTILS_DIR)/genElapsedTime.py -d "$(LOG_DIR)"
+	$(UNSET_AND_MAKE) elapsed
 
 .PHONY:
 elapsed:

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -454,6 +454,8 @@ else ifneq ($(FOOTPRINT_TCL),)
 IS_CHIP = 1
 endif
 
+UNSET_AND_MAKE = @bash -c 'for var in $(ISSUE_VARIABLES_NAMES); do unset $$var; done; echo $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@; $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@' --
+
 # STEP 1: Translate verilog to odb
 #-------------------------------------------------------------------------------
 $(RESULTS_DIR)/2_1_floorplan.odb: $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -318,16 +318,7 @@ export WRAPPED_GDSOAS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/$(le
 define GENERATE_ABSTRACT_RULE
 # Single rule, two targets, hence the "&:", syntax
 $(1) $(2) &: $(3)
-	# Make sure environment variables modified in this Makefile do not leak into the sub-build
-	bash -c " \
-	unset BLOCKS && \
-	unset ADDITIONAL_LEFS && \
-	unset ADDITIONAL_GDS && \
-	unset ADDITIONAL_LIBS && \
-	unset DONT_USE_SC_LIB && \
-	unset LIB_FILES && \
-	unset MACRO_PLACEMENT && \
-	$(MAKE) \"DESIGN_CONFIG=$(3)\" generate_abstract"
+	$$(UNSET_AND_MAKE) DESIGN_CONFIG=$(3) generate_abstract
 endef
 
 # Targets to harden Blocks in case of hierarchical flow is triggered

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -85,7 +85,8 @@ define \n
 
 endef
 
-export ISSUE_VARIABLES := $(foreach V, $(.VARIABLES),$(if $(filter-out environment% default automatic, $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% %TIME_CMD% KLAYOUT% GENERATE_ABSTRACT_RULE%, $(V)), $(if $($V),$V=$($V),$V=''))${\n}))
+export ISSUE_VARIABLES_NAMES := $(foreach V, $(.VARIABLES),$(if $(filter-out environment% default automatic, $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% %TIME_CMD% KLAYOUT% GENERATE_ABSTRACT_RULE%, $(V)), $V$ )))
+export ISSUE_VARIABLES := $(foreach V, $(ISSUE_VARIABLES_NAMES), $(if $($V),$V=$($V),$V=''))${\n}))
 
 $(foreach script,$(ISSUE_SCRIPTS),$(script)_issue): %_issue : versions.txt
 	$(UTILS_DIR)/makeIssue.sh $*


### PR DESCRIPTION
Variables at the top level should not be visible inside the macros that are built by the BLOCKS macros. If they are, then building the macro standalone is not the same as the macro being built by the top level macro.

In other words, these two sequences should be idempontent and I believe they are with this change, regardless of what variables are defined at the top level `config.mk`:

```
make DESIGN_CONFIG=designs/asap7/mock-array/config.mk
```

```
make DESIGN_CONFIG=designs/asap7/mock-array/Element/config.mk generate_abstract
make DESIGN_CONFIG=designs/asap7/mock-array/config.mk
```