### PR TITLE
mock-array: less magic numbers

### DIFF
--- a/flow/designs/asap7/mock-array/Element/config.mk
+++ b/flow/designs/asap7/mock-array/Element/config.mk
@@ -14,11 +14,13 @@ export GPL_ROUTABILITY_DRIVEN = 0
 
 export CORE_AREA = $(shell \
   export MOCK_ARRAY_TABLE="$(MOCK_ARRAY_TABLE)" && \
+  export MOCK_ARRAY_SCALE="$(MOCK_ARRAY_SCALE)" && \
   cd $(dir $(DESIGN_CONFIG))/../ && \
   python3 -c "import config; print(f'{config.ce_margin_x} {config.ce_margin_y} {config.ce_width - config.ce_margin_x} {config.ce_height - config.ce_margin_y}')")
 
 export DIE_AREA = $(shell \
   export MOCK_ARRAY_TABLE="$(MOCK_ARRAY_TABLE)" && \
+  export MOCK_ARRAY_SCALE="$(MOCK_ARRAY_SCALE)" && \
   cd $(dir $(DESIGN_CONFIG))/../ && \
   python3 -c "import config; print(f'0 0 {config.ce_width} {config.ce_height}')")
 

--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -14,11 +14,13 @@ export PLACE_DENSITY          = 0.30
 
 export CORE_AREA = $(shell \
   export MOCK_ARRAY_TABLE="$(MOCK_ARRAY_TABLE)"  && \
+  export MOCK_ARRAY_SCALE="$(MOCK_ARRAY_SCALE)" && \
   cd $(dir $(DESIGN_CONFIG)) && \
   python3 -c "import config ; print(f'{config.margin_x} {config.margin_y} {config.core_width + config.margin_x} {config.core_height + config.margin_y}')")
 
 export DIE_AREA  = $(shell \
   export MOCK_ARRAY_TABLE="$(MOCK_ARRAY_TABLE)" && \
+  export MOCK_ARRAY_SCALE="$(MOCK_ARRAY_SCALE)" && \
   cd $(dir $(DESIGN_CONFIG)) && \
   python3 -c "import config; print(f'{0} {0} {config.die_width} {config.die_height}')")
 

--- a/flow/designs/asap7/mock-array/config.py
+++ b/flow/designs/asap7/mock-array/config.py
@@ -1,10 +1,15 @@
 import os
 
-# routing pitch for M4, M5 and M6 tied to placement grid at 2.16
-# therefore, the optimal placement and Element size should be multiple of 2.16
-# set grid x and y
-placement_grid_x     = 2.16
-placement_grid_y     = 2.16
+# Routing pitches for relevant metal layers.
+#  For x, this is M5; for y, this is M4.
+#  Pitches are specified in OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7_tech_1x_201209.lef.
+#  For asap7, x and y pitch is the same.
+#
+# make_tracks M5 -x_offset 0.012 -x_pitch 0.048 -y_offset 0.012 -y_pitch 0.048
+#
+# the macro needs to be on a multiple of the track pattern
+placement_grid_x     = 0.048 * int(os.environ.get("MOCK_ARRAY_SCALE"))
+placement_grid_y     = 0.048 * int(os.environ.get("MOCK_ARRAY_SCALE"))
 
 # number of Elements in row and column, can be control by user via environment variable 
 # MOCK_ARRAY_TABLE (rows, cols, width, height, pitch_x, pitch_y)

--- a/flow/designs/asap7/mock-array/defaults.mk
+++ b/flow/designs/asap7/mock-array/defaults.mk
@@ -10,3 +10,5 @@ export MOCK_ARRAY_DATAWIDTH     ?= 64
 
 # Must be zero for routing by abutment
 export MACRO_BLOCKAGE_HALO      ?= 0.5
+
+export MOCK_ARRAY_SCALE         ?= 45


### PR DESCRIPTION
@louiic FYI, no change, just fewer magic numbers and a bit of documentation as to where the numbers come from.

Also, I introduced the MOCK_ARRAY_SCALE variable, which will be used to plot running times as a function of area in an upcoming utility script.