### PR TITLE
mock-array: improve clock skew

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -54,3 +54,7 @@ export MAX_ROUTING_LAYER = M7
 
 # works with 28 or more iterations as of writing, so give it a few more.
 export GLOBAL_ROUTE_ARGS=-congestion_iterations 40 -verbose
+
+# ensure we have some rows, so we don't get a bad clock skew.
+export MACRO_HALO_X            = 1
+export MACRO_HALO_Y            = 1


### PR DESCRIPTION
use x/y feature by @louiic and the tip from @maliberty 

https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1220#issuecomment-1630216386

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/de0443cc-cebb-4828-be25-f685259cb500)

