### PR TITLE
makefile: remove mysterious no-op rule

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -583,8 +583,6 @@ $(RESULTS_DIR)/4_1_cts.odb: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sd
 $(RESULTS_DIR)/4_2_cts_fillcell.odb: $(RESULTS_DIR)/4_1_cts.odb
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/fillcell.tcl -metrics $(LOG_DIR)/4_2_cts_fillcell.json) 2>&1 | tee $(LOG_DIR)/4_2_cts_fillcell.log
 
-$(RESULTS_DIR)/4_cts.sdc: $(RESULTS_DIR)/4_cts.odb
-
 $(RESULTS_DIR)/4_cts.odb: $(RESULTS_DIR)/4_2_cts_fillcell.odb
 	cp $< $@
 


### PR DESCRIPTION
let us see if anything bad happens if we remove it.

4_cts.sdc is written by cts.tcl, which is run by the rule a few lines above this rule