### PR TITLE
util: exclude do-step from make-issue

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -5,6 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # exclude system and CI variables
 EXCLUDED_VARS="MAKE|PYTHONPATH|PKG_CONFIG_PATH|PERL5LIB|PCP_DIR|PATH|MANPATH"
 EXCLUDED_VARS+="|LD_LIBRARY_PATH|INFOPATH|HOME|PWD|MAIL|TIME_CMD|QT_QPA_PLATFORM"
+EXCLUDED_VARS+="|do-step"
 
 printf '%s\n' "$ISSUE_VARIABLES" | while read -r V;
 do


### PR DESCRIPTION
Variables with `-` in the name cause errors.