### PR TITLE
makefile: add gui_synth target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -858,6 +858,10 @@ RESULTS_OAS = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.oas)))
 $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): klayout_%: $(OBJECTS_DIR)/klayout.lyt
 	$(KLAYOUT_CMD) -nn $(OBJECTS_DIR)/klayout.lyt $(RESULTS_DIR)/$*
 
+.PHONY: gui_synth
+gui_synth:
+	$(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
+
 .PHONY: gui_floorplan
 gui_floorplan: gui_2_floorplan.odb
 .PHONY: gui_place

--- a/flow/scripts/sta-synth.tcl
+++ b/flow/scripts/sta-synth.tcl
@@ -1,0 +1,2 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_synth.v 1_synth.sdc "Loading synthesis results"


### PR DESCRIPTION
in early exploration, basic problems with timing closure can be iterated on immediately after synthesis,
so it's useful to have a fast turnaround gui_synth target