### PR TITLE
cts: write out 4_1_error.odb file when detailed placement fails

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -87,7 +87,15 @@ if { [info exists ::env(ENABLE_GATE_CLONING)] } {
 
 repair_timing {*}$additional_args
 
-detailed_placement
+set result [catch {detailed_placement} msg]
+if {$result != 0} {
+  puts "Detailed placement failed in CTS: $msg"
+  puts "Run 'make gui_4_1_error.odb' to load failed snapshot"
+  write_db $::env(RESULTS_DIR)/4_1_error.odb
+  write_sdc $::env(RESULTS_DIR)/4_1_error.sdc
+  return -code $result
+}
+
 check_placement -verbose
 
 report_metrics "cts final"


### PR DESCRIPTION
@maliberty @nerriav  The idea is to be able to load up the most recent information of failed CTS.

However, when I update timing, I don't see hold errors.

There are no hold cells in `make gui_place` and  I do see hold cells with `make gui_4_1_error.odb`, though:

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/43c7cff7-9c94-4689-9df0-4f86206013df)


Thoughts?

```
[INFO DPL-0035]  hold20044
[INFO DPL-0035]  hold35033
[INFO DPL-0035]  hold35032
[INFO DPL-0035]  hold35032
[INFO DPL-0035]  hold20042
[INFO DPL-0035]  hold35029
[ERROR DPL-0036] Detailed placement failed.
Detailed placement failed in CTS: DPL-0036
Run 'make gui_4_1_error.odb' to load failed snapshot
Error: cts.tcl, 97 invoked "return" outside of a proc.
Command exited with non-zero status 1
Elapsed time: 2:13.14[h:]min:sec. CPU time: user 132.66 sys 0.45 (99%). Peak memory: 1319780KB.
make[1]: *** [/home/oyvind/OpenROAD-flow-scripts//flow//Makefile:619: do-4_1_cts] Error 1
```