### PR TITLE
makefile: sweep do-copy/step warnings under the rug

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -443,7 +443,7 @@ else ifneq ($(FOOTPRINT_TCL),)
 IS_CHIP = 1
 endif
 
-UNSET_AND_MAKE = @bash -c 'for var in $(UNSET_VARIABLES_NAMES); do unset $$var; done; echo $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@; $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@' --
+UNSET_AND_MAKE = @bash -c 'for var in $(UNSET_VARIABLES_NAMES); do if [ -v $$var ]; then unset $$var; fi; done; echo $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@; $(MAKE) DESIGN_CONFIG=$(DESIGN_CONFIG) $$@' --
 
 # Separate dependency checking and doing a step. This can
 # be useful to retest a stage without having to delete the


### PR DESCRIPTION
would show the following warnings, but only on CentOS 7, not on Ubuntu 22.04.

```
$ make test-unset-and-make-print-PATH
[deleted]
--: line 0: unset: `do-copy': not a valid identifier
--: line 0: unset: `do-step': not a valid identifier
[deleted]
```