### PR TITLE
makefile: exclude do-step and do-copy for make issue and $(UNSET_AND_MAKE)

### DIFF
--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -87,7 +87,7 @@ define \n
 endef
 
 define get_variables
-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% %TIME_CMD% KLAYOUT% GENERATE_ABSTRACT_RULE%, $(V)), $V$ )))
+$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% %TIME_CMD% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy%, $(V)), $V$ )))
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)


### PR DESCRIPTION
This fixes the following warnings on CentOS 7, not visible on e.g. Ubuntu 22.04:

```
$ make test-unset-and-make-print-PATH
[deleted]
--: line 0: unset: `do-copy': not a valid identifier
--: line 0: unset: `do-step': not a valid identifier
[deleted]
```