### PR TITLE
util: metadata depends on finish

### DIFF
--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -1,39 +1,38 @@
 # Utilities
 #===============================================================================
 .PHONY: metadata
-metadata: $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log
+metadata: finish
+	@echo $(DESIGN_DIR) > $(REPORTS_DIR)/design-dir.txt
+	@$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
+		-p $(PLATFORM) \
+		-v $(FLOW_VARIANT) \
+		-o $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json 2>&1 \
+		| tee $(REPORTS_DIR)/gen-metrics-$(FLOW_VARIANT)-check.log
+	@$(UTILS_DIR)/checkMetadata.py \
+		-m $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
+		-r $(dir $(DESIGN_CONFIG))rules-$(FLOW_VARIANT).json 2>&1 \
+		| tee $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log
 
 .PHONY: clean_metadata
 clean_metadata:
 	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log
 	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json
 
-.PHONY: update_metadata update_rules update_ok
+.PHONY: update_ok
 update_ok: update_metadata update_rules
 
-update_metadata: $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json
+.PHONY: update_metadata
+update_metadata: metadata
 	cp -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
 	      $(DESIGN_DIR)/metadata-$(FLOW_VARIANT)-ok.json
 
-update_rules:
+.PHONY: update_rules
+update_rules: metadata
 	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) --variant $(FLOW_VARIANT) --failing --tighten
 
 .PHONY: update_rules_force
-update_rules_force:
+update_rules_force: metadata
 	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) --variant $(FLOW_VARIANT) --update
-
-$(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json: $(wildcard $(LOG_DIR)/*.json) \
-  $(wildcard $(LOG_DIR)/*.log) $(REPORTS_DIR)/synth_stat.txt
-	echo $(DESIGN_DIR) > $(REPORTS_DIR)/design-dir.txt
-	$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
-		-p $(PLATFORM) \
-		-v $(FLOW_VARIANT) \
-		-o $@ 2>&1 | tee $(REPORTS_DIR)/gen-metrics-$(FLOW_VARIANT)-check.log
-
-RULES_DESIGN = $(dir $(DESIGN_CONFIG))rules-$(FLOW_VARIANT).json
-
-$(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log: $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json
-	$(UTILS_DIR)/checkMetadata.py -m $< -r $(RULES_DESIGN) 2>&1 | tee $@
 
 #-------------------------------------------------------------------------------
 
@@ -101,7 +100,7 @@ $(foreach script,$(ISSUE_SCRIPTS),$(script)_issue): %_issue : versions.txt
 clean_issues:
 	rm -rf $(foreach issue, $(ISSUE_SCRIPTS), $(issue)_*.tar.gz)
 	rm -rf $(VARS_BASENAME).sh $(RUN_ME_SCRIPT)
- 
+
 $(RESULTS_DIR)/6_final_only_clk.def: $(RESULTS_DIR)/6_final.def
 	$(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/deleteNonClkNets.tcl
 


### PR DESCRIPTION
Change target and dependencies for metadata. This change makes sure that the flow has finished before generating the metadata and metrics check. Calling `make metadata` will always update the generated json file.