### PR TITLE
[Docs] mermaid diagrams and link to readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ perf.data.old
 docs/main
 docs/build
 GitGuide.md
+mainREADME.md

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of QoR and detailed physical design implementation. However, ORFS
 also enables manual intervention for finer user control of individual
 flow stages through Tcl commands and Python APIs.
 
-```{mermaid}
+```mermaid
 :align: center
 
 %%{init: { 'logLevel': 'debug', 'theme': 'dark'

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ also enables manual intervention for finer user control of individual
 flow stages through Tcl commands and Python APIs.
 
 ```mermaid
-:align: center
 
 %%{init: { 'logLevel': 'debug', 'theme': 'dark'
   } }%%

--- a/README.md
+++ b/README.md
@@ -9,7 +9,42 @@ of QoR and detailed physical design implementation. However, ORFS
 also enables manual intervention for finer user control of individual
 flow stages through Tcl commands and Python APIs.
 
-![ORFS_Flow](./docs/images/ORFS_Flow.svg)
+```{mermaid}
+:align: center
+
+%%{init: { 'logLevel': 'debug', 'theme': 'dark'
+  } }%%
+timeline
+  title RTL-GDSII Using OpenROAD-flow-scripts
+  Synthesis
+    : Inputs  [RTL, SDC, .lib, .lef]
+    : Logic Synthesis  (Yosys)
+    : Output files  [Netlist, SDC]
+  Floorplan
+    : Floorplan Initialization
+    : IO placement  (random)
+    : Timing-driven mixed-size placement
+    : Macro placement
+    : Tapcell and welltie insertion
+    : PDN generation
+  Placement
+    : Global placement without placed IOs
+    : IO placement  (optimized)
+    : Global placement with placed IOs
+    : Resizing and buffering
+    : Detailed placement
+  CTS : Clock Tree Synthesis
+    : Timing optimization
+    : Filler cell insertion
+  Routing
+    : Global Routing
+    : Detailed Routing
+  Finishing
+    : Metal Fill insertion
+    : Signoff timing report
+    : Generate GDSII  (KLayout)
+    : DRC/LVS check (KLayout)
+```
 
 ## Tool Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ also enables manual intervention for finer user control of individual
 flow stages through Tcl commands and Python APIs.
 
 ```mermaid
-
 %%{init: { 'logLevel': 'debug', 'theme': 'dark'
   } }%%
 timeline

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,9 +19,11 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	rm -f main
+	./revert-links.py
 
 checklinks:
 	$(SPHINXBUILD) -b linkcheck "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo
 	@echo "Check finished. Report is in $(BUILDDIR)."
 	rm -f main
+	./revert-links.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,7 +151,7 @@ def setup(app):
     
     # symlink does not work for ORFS because of long recursive file links
     shutil.copy('../README.md', 'mainREADME.md')
-    swap_prefix('../README.md', '```mermaid', '```{mermaid}\n:align: center\n')   
+    swap_prefix('mainREADME.md', '```mermaid', '```{mermaid}\n:align: center\n')   
 
     url = 'https://raw.githubusercontent.com/The-OpenROAD-Project/OpenROAD/master/docs/contrib/GitGuide.md'
     get_file_from_url(url, 'contrib/GitGuide.md') 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx_external_toc',
     'sphinx_copybutton',
     'myst_parser',
+    'sphinxcontrib.mermaid'
 ]
 
 myst_enable_extensions = [
@@ -138,16 +139,19 @@ def get_file_from_url(url, fname):
     with open(fname, 'wb') as f:
         f.write(r.content)
 
-def setup(app):
-    if not os.path.exists('main'):
-        os.symlink('..', 'main')
-    prefix = '(../'
-    newPath = '(./main/'
-    with open('index.md', 'r') as f:
+def swap_prefix(file, old, new):
+    with open(file, 'r') as f:
         lines = f.read()
-    lines = lines.replace(prefix, newPath)
-    with open('index.md', 'wt') as f:
+    lines = lines.replace(old, new)
+    with open(file, 'wt') as f:
         f.write(lines)
+
+def setup(app):
+    import shutil
+    
+    # symlink does not work for ORFS because of long recursive file links
+    shutil.copy('../README.md', 'mainREADME.md')
+    swap_prefix('../README.md', '```mermaid', '```{mermaid}\n:align: center\n')   
 
     url = 'https://raw.githubusercontent.com/The-OpenROAD-Project/OpenROAD/master/docs/contrib/GitGuide.md'
     get_file_from_url(url, 'contrib/GitGuide.md') 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,8 @@ Learn more about the project at our website and our resources page
 
 OpenROAD Flow is a full RTL-to-GDS flow built entirely on open-source tools.
 The project aims for automated, no-human-in-the-loop digital circuit design
-with 24-hour turnaround time.
+with 24-hour turnaround time. For more information, refer to our repository
+[README](mainREADME.md).
 
 ```{tip}
 See these [tips](user/FAQS.md#how-do-i-get-better-search-results) to help improve your search results.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx-autobuild
 myst-parser
 sphinx-book-theme
 sphinx-copybutton
+sphinxcontrib-mermaid

--- a/docs/revert-links.py
+++ b/docs/revert-links.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+def swap_prefix(file, old, new):
+    with open(file, 'r') as f:
+        lines = f.read()
+    lines = lines.replace(old, new)
+    with open(file, 'wt') as f:
+        f.write(lines)
+
+
+swap_prefix('../README.md', '```{mermaid}\n:align: center\n', '```mermaid')

--- a/docs/revert-links.py
+++ b/docs/revert-links.py
@@ -8,4 +8,4 @@ def swap_prefix(file, old, new):
         f.write(lines)
 
 
-swap_prefix('../README.md', '```{mermaid}\n:align: center\n', '```mermaid')
+swap_prefix('mainREADME.md', '```{mermaid}\n:align: center\n', '```mermaid')


### PR DESCRIPTION
@dralabeing @vvbandeira 

Changes 

- The symbolic linking we used in OR docs (../ to ./main) did not work for this docs because the links were too long for all the submodules. So I opted to copy the main README to another file, and add that file to gitignore
- Also added mermaid diagram to be consistent with OR diagrams

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/39641663/8c6e1fbd-afe1-4be3-b090-c12f0173f763)