### PR TITLE
Make issue fix needed

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -8,7 +8,6 @@ EXCLUDED_VARS+="|LD_LIBRARY_PATH|INFOPATH|HOME|PWD|MAIL|QT_QPA_PLATFORM"
 EXCLUDED_VARS+="|OPENROAD_CMD|OPENROAD_GUI_CMD|OPENROAD_NO_EXIT_CMD"
 EXCLUDED_VARS+="|LSORACLE_CMD|YOSYS_CMD|TIME_CMD|STDBUF_CMD"
 EXCLUDED_VARS+="|SHELL|OPENROAD_EXE|YOSYS_EXE"
-EXCLUDED_VARS+="|NPROC|NUM_CORES|PUBLIC|CURDIR|ISSUE_SCRIPTS|MAKEFLAGS"
 EXCLUDED_VARS+="|UNSET_VARIABLES_NAMES|do-step|get_variables|do-copy"
 
 # get the root directory of the Git repository
@@ -20,10 +19,6 @@ do
         continue
     fi
     rhs=`sed -e 's/^"//' -e 's/"$//' <<<"${V#*=}"`
-    if [[ "${rhs}" == "''" ]]; then
-        echo "Skiping empty variable ${V}"
-        continue
-    fi
     # handle absolute paths
     if [[ "${rhs}" == /* ]]; then
         if [[ ! -e "${rhs}" ]]; then


### PR DESCRIPTION
`make issue` is now broken for the case where the working directory is not in the OpenROAD-flow-scripts/flow folder.

We use OpenROAD-flow-scripts, but our source code is in another folder in our private git repository.

We have an `orfs` scripts, so we can from within our repository run `./orfs make detail_route_issue` to invoke ORFS makefile:

```
#!/bin/bash
set -ex
DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

export ORFS=~/OpenROAD-flow-scripts/
export FLOW_HOME=$ORFS/flow/
export MAKEFILES=$FLOW_HOME/Makefile

cd $ORFS
. env.sh

cd $DIR
"$@"
```


Suggestion:

1. revert the changes
2. add the new features without breaking the use-case building a projects outside of OpenROAD-flow-scripts/flow folder.