### PR TITLE
util: make issue must save empty variables

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -20,10 +20,6 @@ do
         continue
     fi
     rhs=`sed -e 's/^"//' -e 's/"$//' <<<"${V#*=}"`
-    if [[ "${rhs}" == "''" ]]; then
-        echo "Skiping empty variable ${V}"
-        continue
-    fi
     # handle absolute paths
     if [[ "${rhs}" == /* ]]; then
         if [[ ! -e "${rhs}" ]]; then


### PR DESCRIPTION
.tcl scripts check for the presence of variables sometimes. Hence an empty enviornment variable is not the same as an absent environment variable.

Therefore empty environment variables have to be saved, in general.

This reverts parts of commit 0a4b13f3b62fc95fb0f1978f23a4d2338bdaff73.