### PR TITLE
asap7: remove TNS_END_PERCENT=100, when default 5 works fine

### DIFF
--- a/flow/designs/asap7/ibex/config.mk
+++ b/flow/designs/asap7/ibex/config.mk
@@ -14,4 +14,3 @@ export PLACE_DENSITY_LB_ADDON  = 0.20
 export ENABLE_DPO = 0
 
 export DFF_LIB_FILE           = $($(CORNER)_DFF_LIB_FILE)
-export TNS_END_PERCENT        = 100

--- a/flow/designs/asap7/jpeg/config.mk
+++ b/flow/designs/asap7/jpeg/config.mk
@@ -14,5 +14,3 @@ export CORE_MARGIN            = 2
 export PLACE_DENSITY          = 0.60
 
 export DFF_LIB_FILE           = $($(CORNER)_DFF_LIB_FILE)
-
-export TNS_END_PERCENT        = 100

--- a/flow/designs/asap7/jpeg_lvt/config.mk
+++ b/flow/designs/asap7/jpeg_lvt/config.mk
@@ -23,4 +23,3 @@ export CORE_MARGIN            = 2
 export PLACE_DENSITY          = 0.60
 
 export DFF_LIB_FILE           = $($(CORNER)_DFF_LIB_FILE)
-export TNS_END_PERCENT        = 100

--- a/flow/designs/asap7/riscv32i/config.mk
+++ b/flow/designs/asap7/riscv32i/config.mk
@@ -20,5 +20,3 @@ export HAS_IO_CONSTRAINTS = 1
 export PLACE_PINS_ARGS    = -exclude left:* -exclude right:* -exclude top:*
 export MACRO_PLACE_HALO    = 3 3
 export MACRO_PLACE_CHANNEL = 6 6
-#
-export TNS_END_PERCENT   = 100

--- a/flow/designs/asap7/swerv_wrapper/config.mk
+++ b/flow/designs/asap7/swerv_wrapper/config.mk
@@ -32,4 +32,3 @@ export FASTROUTE_TCL = ./designs/$(PLATFORM)/swerv_wrapper/fastroute.tcl
 #Temporary until sta bug is fixed
 export PWR_NETS_VOLTAGES  = ""
 export GND_NETS_VOLTAGES  = ""
-export TNS_END_PERCENT        = 100


### PR DESCRIPTION
A test build to see what happens.