### PR TITLE
Makefile fix lyt generation outside of orfs folder

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -361,7 +361,9 @@ $(OBJECTS_DIR)/klayout_tech.lef: $(TECH_LEF)
 	sed '/OR_DEFAULT/d' $< > $@
 
 $(OBJECTS_DIR)/klayout.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
-	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(SC_LEF) $(ADDITIONAL_LEFS),<lef-files>$(shell realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>),g' $< > $@
+	SC_LEF_RELATIVE_PATH="$$\(env('FLOW_HOME')\)/$(shell realpath --relative-to=$(FLOW_HOME) $(SC_LEF))"; \
+	OTHER_LEFS_RELATIVE_PATHS=$$(echo "$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(ADDITIONAL_LEFS),<lef-files>$$(realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>)"); \
+	sed 's,<lef-files>.*</lef-files>,<lef-files>'"$$SC_LEF_RELATIVE_PATH"'</lef-files>'"$$OTHER_LEFS_RELATIVE_PATHS"',g' $< > $@
 
 $(OBJECTS_DIR)/klayout_wrap.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
 	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(WRAP_LEFS),<lef-files>$(shell realpath --relative-to=$(OBJECTS_DIR)/def $(file))</lef-files>),g' $< > $@

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -279,7 +279,18 @@ YOSYS_CMD               ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yos
 
 KLAYOUT_CMD             ?= $(shell command -v klayout)
 
-KLAYOUT_FOUND            = $(if $(KLAYOUT_CMD),,$(error KLayout not found in PATH))
+MIN_VERSION = 0.28.11
+KLAYOUT_VERSION = $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
+
+IS_VALID = $(shell if [ -z "$(KLAYOUT_VERSION)" ]; then echo "not_found"; elif [ "$(KLAYOUT_VERSION)" \< "$(MIN_VERSION)" ]; then echo "invalid"; else echo "valid"; fi)
+
+ifeq ($(IS_VALID),not_found)
+$(error KLayout not found in PATH)
+else ifeq ($(IS_VALID),invalid)
+$(error KLayout version is below the minimum required $(MIN_VERSION))
+else
+$(info KLayout found. Minimum required version: $(MIN_VERSION). Installed version: $(KLAYOUT_VERSION))
+endif
 
 ifneq ($(shell command -v stdbuf),)
   STDBUF_CMD = stdbuf -o L


### PR DESCRIPTION
I just verified that 0.28.11 is required, see https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1327#issuecomment-1666364273 and https://github.com/KLayout/klayout/commit/f518d1aa1d974897cfeb1ef057057125eeceef40

0.28.11 is a bit annoying, because in Ubuntu 23.04 that I'm now using. Not by choice... The world moves on and non-OpenROAD requirements is pulling in the direction of the latest Ubuntu.

building klayout takes a long time and there are no scripts in ORFS or instructions to build and use klayout.
