### PR TITLE
makefile: add make preview_macro_placement

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -522,6 +522,8 @@ endif
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,2_4_floorplan_macro,$(RESULTS_DIR)/2_3_floorplan_tdms.odb $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),macro_place))
 
+$(eval $(call do-step,2_floorplan_debug_macros,$(RESULTS_DIR)/2_1_floorplan.odb $(RESULTS_DIR)/1_synth.v $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),floorplan_debug_macros))
+
 # STEP 5: Tapcell and Welltie insertion
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,2_5_floorplan_tapcell,$(RESULTS_DIR)/2_4_floorplan_macro.odb $(TAPCELL_TCL),tapcell))
@@ -915,6 +917,18 @@ gui_cts: gui_4_cts.odb
 gui_route: gui_5_route.odb
 .PHONY: gui_final
 gui_final: gui_6_final.odb
+
+.PHONY: preview_macro_placement
+
+ifneq ($(or $(MACRO_PLACEMENT),$(MACRO_PLACEMENT_TCL)),)
+MACRO_PREVIEW_ODB = 2_floorplan_debug_macros.odb
+else
+MACRO_PREVIEW_ODB = 2_4_floorplan_macro.odb
+endif
+
+preview_macro_placement:
+	@$(UNSET_AND_MAKE) $(RESULTS_DIR)/$(MACRO_PREVIEW_ODB)
+	@$(UNSET_AND_MAKE) gui_$(MACRO_PREVIEW_ODB)
 
 .PHONY: $(foreach file,$(RESULTS_DEF),gui_$(file))
 $(foreach file,$(RESULTS_DEF),gui_$(file)): gui_%:

--- a/flow/scripts/floorplan_debug_macros.tcl
+++ b/flow/scripts/floorplan_debug_macros.tcl
@@ -1,8 +1,8 @@
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 2_3_floorplan_tdms.odb 1_synth.sdc "Starting macro placement"
+load_design 2_1_floorplan.odb 1_synth.sdc "Debug floorplan"
 
 source $::env(SCRIPTS_DIR)/macro_place_util.tcl
 
 if {![info exists save_checkpoint] || $save_checkpoint} {
-  write_db $::env(RESULTS_DIR)/2_4_floorplan_macro.odb
+  write_db $::env(RESULTS_DIR)/2_floorplan_debug_macros.odb
 }

--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -1,0 +1,136 @@
+proc find_macros {} {
+  set macros ""
+
+  set db [ord::get_db]
+  set block [[$db getChip] getBlock]
+  foreach inst [$block getInsts] {
+    set inst_master [$inst getMaster]
+
+    # BLOCK means MACRO cells
+    if { [string match [$inst_master getType] "BLOCK"] } {
+      append macros " " $inst
+    }
+  }
+  return $macros
+}
+
+if {[find_macros] != ""} {
+# If wrappers defined replace macros with their wrapped version
+# # ----------------------------------------------------------------------------
+  if {[info exists ::env(MACRO_WRAPPERS)]} {
+    source $::env(MACRO_WRAPPERS)
+
+    set wrapped_macros [dict keys [dict get $wrapper around]]
+    set db [ord::get_db]
+    set block [ord::get_db_block]
+
+    foreach inst [$block getInsts] {
+      if {[lsearch -exact $wrapped_macros [[$inst getMaster] getName]] > -1} {
+        set new_master [dict get $wrapper around [[$inst getMaster] getName]]
+        puts "Replacing [[$inst getMaster] getName] with $new_master for [$inst getName]"
+        $inst swapMaster [$db findMaster $new_master]
+      }
+    }
+  }
+
+  lassign $::env(MACRO_PLACE_HALO) halo_x halo_y
+  lassign $::env(MACRO_PLACE_CHANNEL) channel_x channel_y
+  set halo_max [expr max($halo_x, $halo_y)]
+  set channel_max [expr max($channel_x, $channel_y)]
+  set blockage_width [expr max($halo_max, $channel_max/2)]
+
+  
+  if {[info exists ::env(MACRO_BLOCKAGE_HALO)]} {
+    set blockage_width $::env(MACRO_BLOCKAGE_HALO)
+  }
+
+  if {[info exists ::env(MACRO_PLACEMENT_TCL)]} {
+    source $::env(MACRO_PLACEMENT_TCL)
+    puts "\[INFO\]\[FLOW-xxxx\] Using manual macro placement file $::env(MACRO_PLACEMENT_TCL)"
+  } elseif {[info exists ::env(MACRO_PLACEMENT)]} {
+    source $::env(SCRIPTS_DIR)/read_macro_placement.tcl
+    puts "\[INFO\]\[FLOW-xxxx\] Using manual macro placement file $::env(MACRO_PLACEMENT)"
+    read_macro_placement $::env(MACRO_PLACEMENT)
+  } elseif {[info exists ::env(RTLMP_FLOW)]} {
+    puts "HierRTLMP Flow enabled..."
+    set additional_rtlmp_args ""
+    if { [info exists ::env(RTLMP_MAX_LEVEL)]} {
+        append additional_rtlmp_args " -max_num_level $env(RTLMP_MAX_LEVEL)"
+    }
+    if { [info exists ::env(RTLMP_MAX_INST)]} {
+        append additional_rtlmp_args " -max_num_inst $env(RTLMP_MAX_INST)"
+    }
+    if { [info exists ::env(RTLMP_MIN_INST)]} {
+        append additional_rtlmp_args " -min_num_inst $env(RTLMP_MIN_INST)"
+    }
+    if { [info exists ::env(RTLMP_MAX_MACRO)]} {
+        append additional_rtlmp_args " -max_num_macro $env(RTLMP_MAX_MACRO)"
+    }
+    if { [info exists ::env(RTLMP_MIN_MACRO)]} {
+        append additional_rtlmp_args " -min_num_macro $env(RTLMP_MIN_MACRO)"
+    }
+    
+    append additional_rtlmp_args " -halo_width $halo_max"
+
+    if { [info exists ::env(RTLMP_MIN_AR)]} {
+        append additional_rtlmp_args " -min_ar $env(RTLMP_MIN_AR)"
+    }
+    if { [info exists ::env(RTLMP_AREA_WT)]} {
+        append additional_rtlmp_args " -area_weight $env(RTLMP_AREA_WT)"
+    }
+    if { [info exists ::env(RTLMP_WIRELENGTH_WT)]} {
+        append additional_rtlmp_args " -wirelength_weight $env(RTLMP_WIRELENGTH_WT)"
+    }
+    if { [info exists ::env(RTLMP_OUTLINE_WT)]} {
+        append additional_rtlmp_args " -outline_weight $env(RTLMP_OUTLINE_WT)"
+    }
+    if { [info exists ::env(RTLMP_BOUNDARY_WT)]} {
+        append additional_rtlmp_args " -boundary_weight $env(RTLMP_BOUNDARY_WT)"
+    }
+
+    if { [info exists ::env(RTLMP_NOTCH_WT)]} {
+        append additional_rtlmp_args " -notch_weight $env(RTLMP_NOTCH_WT)"
+    }
+
+    if { [info exists ::env(RTLMP_DEAD_SPACE)]} {
+        append additional_rtlmp_args " -dead_space $env(RTLMP_DEAD_SPACE)"
+    }
+    if { [info exists ::env(RTLMP_CONFIG_FILE)]} {
+        append additional_rtlmp_args " -config_file $env(RTLMP_CONFIG_FILE)"
+    }
+    if { [info exists ::env(RTLMP_RPT_DIR)]} {
+        append additional_rtlmp_args " -report_directory $env(RTLMP_RPT_DIR)"
+    }
+
+    if { [info exists ::env(RTLMP_FENCE_LX)]} {
+        append additional_rtlmp_args " -fence_lx $env(RTLMP_FENCE_LX)"
+    }
+    if { [info exists ::env(RTLMP_FENCE_LY)]} {
+        append additional_rtlmp_args " -fence_ly $env(RTLMP_FENCE_LY)"
+    }
+    if { [info exists ::env(RTLMP_FENCE_UX)]} {
+        append additional_rtlmp_args " -fence_ux $env(RTLMP_FENCE_UX)"
+    }
+    if { [info exists ::env(RTLMP_FENCE_UY)]} {
+        append additional_rtlmp_args " -fence_uy $env(RTLMP_FENCE_UY)"
+    }
+
+
+    puts "Call Macro Placer $additional_rtlmp_args"
+
+    rtl_macro_placer \
+                 {*}$additional_rtlmp_args
+
+    puts "Delete buffers for RTLMP flow..."
+    remove_buffers
+  } else {
+    macro_placement \
+      -halo $::env(MACRO_PLACE_HALO) \
+      -channel $::env(MACRO_PLACE_CHANNEL)
+  }
+
+  source $::env(SCRIPTS_DIR)/placement_blockages.tcl
+  block_channels $blockage_width 
+} else {
+  puts "No macros found: Skipping macro_placement"
+}


### PR DESCRIPTION
This allows viewing illegally laid out macros to debug manual macro placement. It also works on automatic placement.

```
make clean_floorplan preview_macro_placement
```

If I break the floorplan for mock-array, I can quickly see what is going wrong. Running the command above takes a few seconds, fast iterations:

```
$ git diff
diff --git a/flow/designs/asap7/mock-array/macro-placement.tcl b/flow/designs/asap7/mock-array/macro-placement.tcl
index aed383e5..fe26eb06 100644
--- a/flow/designs/asap7/mock-array/macro-placement.tcl
+++ b/flow/designs/asap7/mock-array/macro-placement.tcl
@@ -9,7 +9,7 @@ for {set row 0} {$row < $rows} {incr row} {
   for {set col 0} {$col < $cols} {incr col} {
     set inst [$block findInst [format "ces_%d_%d" $row $col]]
 
-    set x [expr round((($array_offset_x + (($placement_grid_x * $pitch_x) * $col)) * $units))]
+    set x [expr round((($array_offset_x + (($placement_grid_x * $pitch_x) * ($col + 1))) * $units))]
     set y [expr round((($array_offset_y + (($placement_grid_y * $pitch_y) * $row)) * $units))]
 
     # belt and suspenders check... ASAP7 macro placement must be aligned to 0.048um
```

Here we can see that the macros are positions too far to the right, outside of the diea area:

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/b4d4739e-34c2-4819-8e9a-be5177cf9728)
