### PR TITLE
makefile: avoid 6_report.log being written when that step fails

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -475,8 +475,8 @@ $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 
 .PHONY: do-$(1)
 do-$(1):
-	{ $(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json && cp $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log; } 2>&1 | tee $(LOG_DIR)/$(1).tmp.log
-	rm -f $(LOG_DIR)/$(1).tmp.log
+	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json) 2>&1 | tee $(LOG_DIR)/$(1).tmp.log
+	mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log
 endef
 
 # generate make rules to copy a file, if a dependency change and

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -475,7 +475,8 @@ $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 
 .PHONY: do-$(1)
 do-$(1):
-	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json) 2>&1 | tee $(LOG_DIR)/$(1).log
+	{ $(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json && cp $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log; } 2>&1 | tee $(LOG_DIR)/$(1).tmp.log
+	rm -f $(LOG_DIR)/$(1).tmp.log
 endef
 
 # generate make rules to copy a file, if a dependency change and


### PR DESCRIPTION
this avoids a situation where if you run `make finish` twice, and it fails the first time, it succeeds(false negative) the second time.