### PR TITLE
Use relative paths for submodules so they use the same protocol as the top one.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "tools/yosys"]
 	path = tools/yosys
-	url = https://github.com/The-OpenROAD-Project/yosys.git
+	url = ../../The-OpenROAD-Project/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
 	url = ../OpenROAD.git
 [submodule "tools/LSOracle"]
 	path = tools/LSOracle
-	url = https://github.com/The-OpenROAD-Project/LSOracle.git
+	url = ../../The-OpenROAD-Project/LSOracle.git


### PR DESCRIPTION
My proxy only supports git over ssh so I have to clone the repo with ssh but cloning submodules fails are they are explicitly using https. This PR makes paths relative so the same protocol is used.

Same as https://github.com/The-OpenROAD-Project/OpenROAD/pull/3764 which has been merged.
