### PR TITLE
makefile: add open_ variants of gui_

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -903,21 +903,6 @@ RESULTS_OAS = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.oas)))
 $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): klayout_%: $(OBJECTS_DIR)/klayout.lyt
 	$(KLAYOUT_CMD) -nn $(OBJECTS_DIR)/klayout.lyt $(RESULTS_DIR)/$*
 
-.PHONY: gui_synth
-gui_synth:
-	$(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
-
-.PHONY: gui_floorplan
-gui_floorplan: gui_2_floorplan.odb
-.PHONY: gui_place
-gui_place: gui_3_place.odb
-.PHONY: gui_cts
-gui_cts: gui_4_cts.odb
-.PHONY: gui_route
-gui_route: gui_5_route.odb
-.PHONY: gui_final
-gui_final: gui_6_final.odb
-
 .PHONY: preview_macro_placement
 
 ifneq ($(or $(MACRO_PLACEMENT),$(MACRO_PLACEMENT_TCL)),)
@@ -930,13 +915,29 @@ preview_macro_placement:
 	@$(UNSET_AND_MAKE) $(RESULTS_DIR)/$(MACRO_PREVIEW_ODB)
 	@$(UNSET_AND_MAKE) gui_$(MACRO_PREVIEW_ODB)
 
-.PHONY: $(foreach file,$(RESULTS_DEF),gui_$(file))
-$(foreach file,$(RESULTS_DEF),gui_$(file)): gui_%:
-	DEF_FILE=$(RESULTS_DIR)/$* $(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/gui.tcl
+define OPEN_GUI_SHORTCUT
+.PHONY: gui_$(1) open_$(1)
+gui_$(1): gui_$(2)
+open_$(1): open_$(2)
+endef
 
-.PHONY: $(foreach file,$(RESULTS_ODB),gui_$(file))
-$(foreach file,$(RESULTS_ODB),gui_$(file)): gui_%:
-	ODB_FILE=$(RESULTS_DIR)/$* $(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/gui.tcl
+$(eval $(call OPEN_GUI_SHORTCUT,synth,))
+$(eval $(call OPEN_GUI_SHORTCUT,floorplan,2_floorplan.odb))
+$(eval $(call OPEN_GUI_SHORTCUT,place,3_place.odb))
+$(eval $(call OPEN_GUI_SHORTCUT,cts,4_cts.odb))
+$(eval $(call OPEN_GUI_SHORTCUT,route,5_route.odb))
+$(eval $(call OPEN_GUI_SHORTCUT,final,6_final.odb))
+
+define OPEN_GUI
+.PHONY: $(1)_$(2)
+$(1)_$(2):
+	$(3)=$(RESULTS_DIR)/$(2) $(4) $(SCRIPTS_DIR)/gui.tcl
+endef
+
+$(foreach file,$(RESULTS_DEF),$(eval $(call OPEN_GUI,gui,$(file),DEF_FILE,$(OPENROAD_GUI_CMD))))
+$(foreach file,$(RESULTS_ODB),$(eval $(call OPEN_GUI,gui,$(file),ODB_FILE,$(OPENROAD_GUI_CMD))))
+$(foreach file,$(RESULTS_DEF),$(eval $(call OPEN_GUI,open,$(file),DEF_FILE,$(OPENROAD_NO_EXIT_CMD))))
+$(foreach file,$(RESULTS_ODB),$(eval $(call OPEN_GUI,open,$(file),ODB_FILE,$(OPENROAD_NO_EXIT_CMD))))
 
 # Write a def for the corresponding odb
 $(foreach file,$(RESULTS_ODB),$(file).def): %.def:


### PR DESCRIPTION
the usecase is to run openroad in console mode.

This can be used by humans, but also for scripting.

For instance: inject a command or two and then parse the output. Convenient for quick and dirty Python scripts to plot something, for instance.

To start OpenROAD in console mode with the final result:

```
make open_final
```

Results in:

```
[INFO][FLOW] Using platform directory ./platforms/asap7
[INFO-FLOW] ASU ASAP7 - version 2
Default PVT selection: BC
[INFO][FLOW] Invoked hierarchical flow.
Block Element needs to be hardened.
ODB_FILE=./results/asap7/mock-array/base/6_final.odb /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init  ./scripts/gui.tcl
OpenROAD v2.0-9875-g7430f83d9 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING STA-0357] virtual clock clock_vir can not be propagated.
Loading spef
openroad> 
```