### PR TITLE
[Docs] clarity in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,8 +62,15 @@ Legend:
 | CentOS 8     | `Y` | `-` | `Y` | `-` |
 | Debian 10    | `Y` | `Y` | `Y` | `-` |
 | Debian 11    | `Y` | `Y` | `Y` | `-` |
-| RHEL         | `Y` | `-` | `-` | `-` |
+| RHEL         | `Y` | `-` | `Y` | `-` |
 | Windows 10 and above | `-` | `-` | `Y` | `Y` |
+| macOS*        | `Y` | `-` | `Y` | `-` |
+
+```{warning}
+For macOS, local compilation for the modules `par` and `mpl2` is not
+fully supported due to an upstream issue with `or-tools`. We recommend
+Docker installation wherever possible.
+```
 
 #### System Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,26 @@ See these [tips](user/FAQS.md#how-do-i-get-better-search-results) to help improv
 
 ### Setup
 
+#### Supported Operating Systems
+
+Note that depending on the installation method, we have varying levels of 
+support for various operating systems. 
+
+Legend:
+- `Y` for supported.
+- `-` for unsupported.
+
+| Operating System | Local Installation | Prebuilt Binaries | Docker Installation | Windows Subsystem for Linux | 
+| --- | --- | --- | --- | --- |
+| Ubuntu 20.04 | `Y` | `Y` | `Y` | `-` |  
+| Ubuntu 22.04 | `Y` | `Y` | `Y` | `-` |
+| CentOS 7     | `Y` | `-` | `Y` | `-` |
+| CentOS 8     | `Y` | `-` | `Y` | `-` |
+| Debian 10    | `Y` | `Y` | `Y` | `-` |
+| Debian 11    | `Y` | `Y` | `Y` | `-` |
+| RHEL         | `Y` | `-` | `-` | `-` |
+| Windows 10 and above | `-` | `-` | `Y` | `Y` |
+
 #### System Requirements
 
 To build the binaries and run `gcd` through the flow:

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,10 +64,10 @@ Legend:
 | Debian 11    | `Y` | `Y` | `Y` | `-` |
 | RHEL         | `Y` | `-` | `Y` | `-` |
 | Windows 10 and above | `-` | `-` | `Y` | `Y` |
-| macOS*        | `Y` | `-` | `Y` | `-` |
+| macOS        | `Y*` | `-` | `Y` | `-` |
 
 ```{warning}
-For macOS, local compilation for the modules `par` and `mpl2` is not
+For macOS, local compilation for the modules `par` and `mpl2` are not
 fully supported due to an upstream issue with `or-tools`. We recommend
 Docker installation wherever possible.
 ```

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -5,16 +5,16 @@ entries:
   title: User Guide
   entries:
   - file: user/BuildWithDocker
-    title: Build With Docker
+    title: Build Using Docker
     entries:
     - file: user/DockerShell.md
       title: Docker Shell utility
   - file: user/BuildWithPrebuilt.md
-    title: Build With Pre-built Binaries
+    title: Build Using Pre-built Binaries
   - file: user/BuildLocally.md
     title: Build Locally
   - file: user/BuildWithWSL.md
-    title: Build With WSL
+    title: Build Using WSL
   - file: user/FlowVariables.md
     title: Flow Variables
   - file: contrib/Metrics.md

--- a/docs/user/BuildWithDocker.md
+++ b/docs/user/BuildWithDocker.md
@@ -19,20 +19,42 @@ then is recommended that you restrict the number of CPUs used by the scripts
 docker run --rm ubuntu:22.04 nproc
 ```
 
-You can restrict the number of CPUs with the `-t|--threads N` argument:
+### Build Using Docker from pre-built binaries
 
-``` shell
-./build_openroad.sh --threads N
+Courtesy of Precision Innovations, they have released triweekly 
+releases of the OpenROAD binaries in Ubuntu and Debian. This greatly
+helps to reduce the compilation time needed. 
+
+We recommend a setup whereby you install the OS using Docker,
+followed by installing the prebuilt binaries for OpenROAD. 
+First clone the desired Docker image, in this case we use Ubuntu 22.04.
+Then, we can start the container in an interactive mode using 
+`docker run -it`, telling it to start the prompt `sh`. 
+
+```shell
+docker pull ubuntu:22.04
+docker run -it ubuntu:22.04 sh
 ```
 
-## Clone and Build
+Now you are ready to install the prebuilt binaries. 
+Please refer to the instructions for installing prebuilt binaries 
+[here](./BuildWithPrebuilt.md).
+
+### Build Using Docker from sources
+
+Alternatively, if you would like the latest commits from the OpenROAD repositories,
+do follow the instructions below. 
+
+
+#### Clone and Build
 
 The following instructions build the docker image with CentOS 7 as the base OS:
+You can restrict the number of CPUs with the `-t|--threads N` argument:
 
 ``` shell
 git clone --recursive https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
 cd OpenROAD-flow-scripts
-./build_openroad.sh
+./build_openroad.sh --threads N 
 ```
 
 ## Verify Installation

--- a/docs/user/BuildWithDocker.md
+++ b/docs/user/BuildWithDocker.md
@@ -26,15 +26,14 @@ they release `.deb` installers of OpenROAD for Ubuntu
 and Debian on a regular basis. 
 This greatly helps to reduce the compilation time needed. 
 
-We recommend a setup whereby you install the OS using Docker,
-followed by installing the prebuilt binaries for OpenROAD. 
-First clone the desired Docker image, in this case we use Ubuntu 22.04.
-Then, we can start the container in an interactive mode using 
-`docker run -it`, telling it to start the prompt `sh`. 
+We recommend to use a Docker image of a supported OS
+and install OpenROAD using the prebuilt binaries from
+Precision Innovations. 
+You can start the container in an interactive mode using 
+the command below. 
 
 ```shell
-docker pull ubuntu:22.04
-docker run -it ubuntu:22.04 sh
+docker run -it ubuntu:22.04
 ```
 
 Now you are ready to install the prebuilt binaries. 

--- a/docs/user/BuildWithDocker.md
+++ b/docs/user/BuildWithDocker.md
@@ -21,9 +21,10 @@ docker run --rm ubuntu:22.04 nproc
 
 ### Build Using Docker from pre-built binaries
 
-Courtesy of Precision Innovations, they have released triweekly 
-releases of the OpenROAD binaries in Ubuntu and Debian. This greatly
-helps to reduce the compilation time needed. 
+Courtesy of [Precision Innovations](https://precisioninno.com/), 
+they release `.deb` installers of OpenROAD for Ubuntu
+and Debian on a regular basis. 
+This greatly helps to reduce the compilation time needed. 
 
 We recommend a setup whereby you install the OS using Docker,
 followed by installing the prebuilt binaries for OpenROAD. 
@@ -49,12 +50,18 @@ do follow the instructions below.
 #### Clone and Build
 
 The following instructions build the docker image with CentOS 7 as the base OS:
-You can restrict the number of CPUs with the `-t|--threads N` argument:
+
 
 ``` shell
 git clone --recursive https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
 cd OpenROAD-flow-scripts
-./build_openroad.sh --threads N 
+./build_openroad.sh 
+```
+
+You can restrict the number of CPUs with the `-t|--threads N` argument:
+
+``` shell
+./build_openroad.sh --threads N
 ```
 
 ## Verify Installation

--- a/docs/user/UserGuide.md
+++ b/docs/user/UserGuide.md
@@ -4,7 +4,7 @@ The OpenROAD Project uses three tools to perform automated RTL-to-GDS layout gen
 
 1.  [yosys](https://github.com/The-OpenROAD-Project/yosys): Logic
     Synthesis
-2.  [OpenROAD App](https://github.com/The-OpenROAD-Project/OpenROAD):
+2.  [OpenROAD](https://github.com/The-OpenROAD-Project/OpenROAD):
     Floorplanning through Detailed Routing
 3.  [KLayout](https://www.klayout.de/): GDS merge, DRC and LVS (public
     PDKs)


### PR DESCRIPTION
Addresses these comments @dralabeing

1. In the Setup section here: https://openroad-flow-scripts.readthedocs.io/en/latest/index.html#setup Include a list of OS's that are supported preferably as part of System Requirements or after.
2. This section https://openroad-flow-scripts.readthedocs.io/en/latest/user/BuildWithDocker.html# does not describe building docker using pre-built binaries, only from sources. This is simply mentioned here: https://openroad-flow-scripts.readthedocs.io/en/latest/user/BuildWithPrebuilt.html
image.png
3.  These should say Build Using not With
image.png

Also, Building with Docker using pre-built binaries should be the recommended mode. After this building using docker locally with sources
4. Do not refer to OpenROAD as OpenROAD App. Standardize to OpenROAD for the application and the OpenROAD flow for OpenROAD-flow-scripts. People don't get the app part .
https://openroad-flow-scripts.readthedocs.io/en/latest/user/UserGuide.html#using-the-openroad-app
