### PR TITLE
[Docs] Fix Show source bug

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,6 +12,7 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 # Optional but recommended, declare the Python requirements required

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,6 @@ build:
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
-  builder: dirhtml
   configuration: docs/conf.py
 
 # Optional but recommended, declare the Python requirements required

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts",
     "repository_branch": "master",
+    "path_to_docs": "docs",
     "show_navbar_depth": 2,
     "use_edit_page_button": True,
     "use_source_button": True,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,10 +92,7 @@ html_theme = "sphinx_book_theme"
 html_theme_options = {
     "repository_url": "https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts",
     "repository_branch": "master",
-    "path_to_docs": "docs",
     "show_navbar_depth": 2,
-    "use_edit_page_button": True,
-    "use_source_button": True,
     "use_issues_button": True,
     "use_download_button": True,
 


### PR DESCRIPTION
E.g. When you click `Show source` on the top bar (hover github logo) 

https://openroad-flow-scripts.readthedocs.io/en/latest/

You will be led to this file in repo, which does not exist.

https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/index.md?plain=1