### PR TITLE
make: elapsed prints times for BLOCKS

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -210,6 +210,7 @@ ifdef BLOCKS
   $(foreach block,$(BLOCKS),$(eval BLOCK_LIBS += ./results/$(PLATFORM)/$(DESIGN_NICKNAME)_$(block)/$(FLOW_VARIANT)/${block}.lib))
   $(foreach block,$(BLOCKS),$(eval BLOCK_GDS += ./results/$(PLATFORM)/$(DESIGN_NICKNAME)_$(block)/$(FLOW_VARIANT)/6_final.gds))
   $(foreach block,$(BLOCKS),$(eval BLOCK_CDL += ./results/$(PLATFORM)/$(DESIGN_NICKNAME)_$(block)/$(FLOW_VARIANT)/6_final.cdl))
+  $(foreach block,$(BLOCKS),$(eval BLOCK_LOG_FOLDERS += ./logs/$(PLATFORM)/$(DESIGN_NICKNAME)_$(block)/$(FLOW_VARIANT)/))
   export ADDITIONAL_LEFS += $(BLOCK_LEFS)
   export ADDITIONAL_LIBS += $(BLOCK_LIBS)
   export ADDITIONAL_GDS += $(BLOCK_GDS)
@@ -719,7 +720,7 @@ finish: $(LOG_DIR)/6_report.log \
 
 .PHONY: elapsed
 elapsed:
-	-@$(UTILS_DIR)/genElapsedTime.py -d "$(LOG_DIR)"
+	-@$(UTILS_DIR)/genElapsedTime.py -d $(BLOCK_LOG_FOLDERS) $(LOG_DIR)
 
 # ==============================================================================
 

--- a/flow/test/test_genElapsedTime.py
+++ b/flow/test/test_genElapsedTime.py
@@ -31,7 +31,7 @@ class TestElapsedTime(unittest.TestCase):
         with patch.object(sys, 'argv', sys.argv):
             module = importlib.import_module(self.module_name)
         # check if output is correct
-        expected_output = "1_test                          5400\n"
+        expected_output = self.tmp_dir.name + "\n1_test                          5400\n"
         self.assertEqual(mock_stdout.getvalue(), expected_output)
 
     @patch("sys.stdout", new_callable=StringIO)
@@ -61,7 +61,7 @@ class TestElapsedTime(unittest.TestCase):
             module = importlib.import_module(self.module_name)
             importlib.reload(module)
         # check if output is correct
-        expected_output = "1_test                           744\n"
+        expected_output = self.tmp_dir.name + "\n1_test                           744\n"
         self.assertEqual(mock_stdout.getvalue(), expected_output)
 
     def test_missing_arg(self):

--- a/flow/util/genElapsedTime.py
+++ b/flow/util/genElapsedTime.py
@@ -13,8 +13,8 @@ import sys
 # ==============================================================================
 parser = argparse.ArgumentParser(
     description='Print elapsed time for every step in the flow')
-parser.add_argument('--logDir', '-d', required=True,
-                    help='Log files directory')
+parser.add_argument('--logDir', '-d', required=True, nargs='+',
+                    help='Log files directories')
 parser.add_argument('--noHeader', action='store_true',
                     help='Skip the header')
 args = parser.parse_args()
@@ -25,41 +25,46 @@ if not args.logDir:
     parser.print_help()
     sys.exit(1)
 
-first = True
-    
-# Loop on all log files in the directory
-for f in sorted(pathlib.Path(args.logDir).glob('**/[0-9]_*.log')):
-    # Extract Elapsed Time line from log file
-    with open(str(f)) as logfile:
-        found = False
-        for line in logfile:
-            elapsedTime = 0
-            
-            if 'Elapsed time' in line:
-                found = True
-                # Extract the portion that has the time
-                timePor = line.strip().replace('Elapsed time: ', '')
-                # Remove the units from the time portion
-                timePor = timePor.split('[h:]', 1)[0]
-                # Remove any fraction of a second
-                timePor = timePor.split('.', 1)[0]
-                # Calculate elapsed time that has this format 'h:m:s'
-                timeList = timePor.split(':')
-                if len(timeList) == 2:
-                    # Only minutes and seconds are present
-                    elapsedTime = int(timeList[0])*60 + int(timeList[1])
-                elif len(timeList) == 3:
-                    # Hours, minutes, and seconds are present
-                    elapsedTime = int(timeList[0])*3600 + int(timeList[1])*60 + int(timeList[2])
-                else:
-                    print('Elapsed time not understood in',  str(line), file=sys.stderr)
+def print_log_dir_times(logdir):
+    first = True
+    print(logdir)
 
-        if not found:
-            print('No elapsed time found in',  str(f), file=sys.stderr)
-    
-    # Print the name of the step and the corresponding elapsed time
-    if elapsedTime != 0:
-        if first and not args.noHeader:
-            print("%-25s %10s" % ("Log", "Elapsed seconds"))
-            first = False
-        print('%-25s %10s' % (os.path.splitext(os.path.basename(str(f)))[0], elapsedTime))
+    # Loop on all log files in the directory
+    for f in sorted(pathlib.Path(logdir).glob('**/[0-9]_*.log')):
+        # Extract Elapsed Time line from log file
+        with open(str(f)) as logfile:
+            found = False
+            for line in logfile:
+                elapsedTime = 0
+
+                if 'Elapsed time' in line:
+                    found = True
+                    # Extract the portion that has the time
+                    timePor = line.strip().replace('Elapsed time: ', '')
+                    # Remove the units from the time portion
+                    timePor = timePor.split('[h:]', 1)[0]
+                    # Remove any fraction of a second
+                    timePor = timePor.split('.', 1)[0]
+                    # Calculate elapsed time that has this format 'h:m:s'
+                    timeList = timePor.split(':')
+                    if len(timeList) == 2:
+                        # Only minutes and seconds are present
+                        elapsedTime = int(timeList[0])*60 + int(timeList[1])
+                    elif len(timeList) == 3:
+                        # Hours, minutes, and seconds are present
+                        elapsedTime = int(timeList[0])*3600 + int(timeList[1])*60 + int(timeList[2])
+                    else:
+                        print('Elapsed time not understood in',  str(line), file=sys.stderr)
+
+            if not found:
+                print('No elapsed time found in',  str(f), file=sys.stderr)
+
+        # Print the name of the step and the corresponding elapsed time
+        if elapsedTime != 0:
+            if first and not args.noHeader:
+                print("%-25s %10s" % ("Log", "Elapsed seconds"))
+                first = False
+            print('%-25s %10s' % (os.path.splitext(os.path.basename(str(f)))[0], elapsedTime))
+
+for log_dir in args.logDir:
+    print_log_dir_times(log_dir)


### PR DESCRIPTION
github displays this misleadingly. There are actually very few changes, this PR refactors the code into a function and makes a few tweaks, run with `git show -w` locally to see that there are very few changes:

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/ed33ae93-4dc1-45b1-adaf-d4b4065dd6d4)
