### PR TITLE
makefile: remove generate_abstract dependencies

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -322,11 +322,11 @@ ifeq ($(wildcard $(3)),)
 # more global concerns instead of getting mired in the details of
 # each macro.
 block := $(patsubst ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/%,%,$(dir $(3)))
-$(1) $(2) &: ./designs/$$(PLATFORM)/$$(DESIGN_NICKNAME)/block.mk
-	$$(UNSET_AND_MAKE) DESIGN_NAME=${block} DESIGN_NICKNAME=$$(DESIGN_NICKNAME)_${block} DESIGN_CONFIG=$$< generate_abstract
+$(1) $(2) &:
+	$$(UNSET_AND_MAKE) DESIGN_NAME=${block} DESIGN_NICKNAME=$$(DESIGN_NICKNAME)_${block} DESIGN_CONFIG=./designs/$$(PLATFORM)/$$(DESIGN_NICKNAME)/block.mk generate_abstract
 else
 # There is a unqiue config.mk for this Verilog module
-$(1) $(2) &: $(3)
+$(1) $(2) &:
 	$$(UNSET_AND_MAKE) DESIGN_CONFIG=$$< generate_abstract
 endif
 endef

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -327,7 +327,7 @@ $(1) $(2) &:
 else
 # There is a unqiue config.mk for this Verilog module
 $(1) $(2) &:
-	$$(UNSET_AND_MAKE) DESIGN_CONFIG=$$< generate_abstract
+	$$(UNSET_AND_MAKE) DESIGN_CONFIG=$(3) generate_abstract
 endif
 endef
 


### PR DESCRIPTION
As long as the abstracts exist, then to regenerate an abstract is an explicit choice made by
the user, not a dependency to be checked.

The full set of dependencies for an abstract can only be checked by rebuilding the macro.