### PR TITLE
makefile: klayout 0.28.5 understands OR_DEFAULT

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -363,7 +363,7 @@ $(OBJECTS_DIR)/lib/merged.lib:
 # ==============================================================================
 $(OBJECTS_DIR)/klayout_tech.lef: $(TECH_LEF)
 	@mkdir -p $(OBJECTS_DIR)
-	sed '/OR_DEFAULT/d' $< > $@
+	cp $< $@
 
 $(OBJECTS_DIR)/klayout.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
 	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(SC_LEF) $(ADDITIONAL_LEFS),<lef-files>$(shell realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>),g' $< > $@


### PR DESCRIPTION
@rovinski [mentioned](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1364#discussion_r1310859717) that OR_DEFAULT might be understood by klayout in newer versions. This PR seems to work fine in klayout 0.28.5.

https://www.klayout.de/forum/discussion/1546/support-for-properties-on-vias-in-lef


Near as I can see it is supported all the way back in June 4. 2020, and 0.27.1 if I read the github GUI correctly:

https://github.com/KLayout/klayout/commit/233574598b696eb73709ebd793f648b1f24e79dc
