### PR TITLE
make (MAX|MAX)_ROUTING_LAYER reassignable for nangate45 & sky130hd

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -79,8 +79,8 @@ Note:
 | `TNS_END_PERCENT`                    | ?=           | ?=           |               | ?=        | ?=        |
 | Routing                              |              |              |               |           |           |
 | `KLAYOUT_TECH_FILE`                  | =            | =            | =             | =         | =         |
-| `MAX_ROUTING_LAYER`                  | =            | =            | =             | =         | ?=        |
-| `MIN_ROUTING_LAYER`                  | =            | =            | =             | =         | ?=        |
+| `MAX_ROUTING_LAYER`                  | ?=           | ?=           | ?=            | ?=        | ?=        |
+| `MIN_ROUTING_LAYER`                  | ?=           | ?=           | ?=            | ?=        | ?=        |
 | `RCX_RULES`                          | =            | =            | =             | =         | =         |
 | `RECOVER_POWER`                      | ?=           | ?=           | ?=            | ?=        | ?=        |
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -84,8 +84,8 @@ export CTS_BUF_CELL   ?= BUF_X4
 #  Route
 # ---------------------------------------------------------
 # FastRoute options
-export MIN_ROUTING_LAYER = metal2
-export MAX_ROUTING_LAYER = metal10
+export MIN_ROUTING_LAYER ?= metal2
+export MAX_ROUTING_LAYER ?= metal10
 
 # Define fastRoute tcl
 export FASTROUTE_TCL = $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -83,8 +83,8 @@ export CTS_BUF_CELL   ?= sky130_fd_sc_hs__clkbuf_4
 #  Route
 # ---------------------------------------------------------
 # FastRoute options
-export MIN_ROUTING_LAYER = met1
-export MAX_ROUTING_LAYER = met5
+export MIN_ROUTING_LAYER ?= met1
+export MAX_ROUTING_LAYER ?= met5
 #
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl


### PR DESCRIPTION
As discussed in this [thread](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/discussions/1469), here a patch making MIN_ROUTING_LAYER and MAX_ROUTING_LAYER re-assignable.