### PR TITLE
designs: remove unused VERILOG_FILES_BLACKBOX

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -3,7 +3,6 @@ include designs/asap7/mock-array/defaults.mk
 export DESIGN_NAME            = MockArray
 export DESIGN_NICKNAME        = mock-array
 
-export VERILOG_FILES_BLACKBOX = designs/src/mock-array/Element.v
 export VERILOG_FILES          = designs/src/mock-array/*.v
 
 export SDC_FILE               = designs/asap7/mock-array/constraints.sdc

--- a/flow/designs/asap7/sram-64x16/config.mk
+++ b/flow/designs/asap7/sram-64x16/config.mk
@@ -1,7 +1,6 @@
 export DESIGN_NAME            = SramBridge
 export DESIGN_NICKNAME        = SramBridge
 
-export VERILOG_FILES_BLACKBOX = designs/src/sram-64x16/SRAM2RW16x32.v
 export VERILOG_FILES = designs/src/sram-64x16/*.sv
 
 export SDC_FILE               = designs/asap7/sram-64x16/constraints.sdc

--- a/flow/designs/gf180/uart-blocks/config.mk
+++ b/flow/designs/gf180/uart-blocks/config.mk
@@ -8,8 +8,6 @@ export SDC_FILE      = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 
 export BLOCKS = uart_rx
 
-export VERILOG_FILES_BLACKBOX = ./designs/src/uart-no-param/uart_rx.v
-
 export DIE_AREA = 0 0 430 430
 export CORE_AREA = 10 10 420 420
 


### PR DESCRIPTION
When I worked on these modules, I copied and pasted VERILOG_FILES_BLACKBOX, thinking this was needed, except it isn't.