### PR TITLE
asap7: move BLOCK level pdn file into platform folder

### DIFF
--- a/flow/designs/asap7/mock-array/Element/config.mk
+++ b/flow/designs/asap7/mock-array/Element/config.mk
@@ -24,7 +24,7 @@ export DIE_AREA = $(shell \
 
 export IO_CONSTRAINTS         = designs/asap7/mock-array/Element/io.tcl
 
-export PDN_TCL                = designs/asap7/mock-array/Element/pdn.tcl
+export PDN_TCL                = $(FLOW_HOME)/platforms/asap7/openRoad/pdn/BLOCK_grid_strategy.tcl
 
 # If this design isn't quickly done in detailed routing, something is wrong.
 # At time of adding this option, only 3 iterations were needed for 0

--- a/flow/platforms/asap7/openRoad/pdn/BLOCKS_grid_strategy.tcl
+++ b/flow/platforms/asap7/openRoad/pdn/BLOCKS_grid_strategy.tcl
@@ -1,3 +1,5 @@
+# Top level PDN for macros using BLOCK_grid_strategy.tcl
+
 ####################################
 # global connections
 ####################################

--- a/flow/platforms/asap7/openRoad/pdn/BLOCK_grid_strategy.tcl
+++ b/flow/platforms/asap7/openRoad/pdn/BLOCK_grid_strategy.tcl
@@ -1,3 +1,5 @@
+# macro level counterpart to BLOCKS_grid_strategy.tcl
+
 ####################################
 # global connections
 ####################################


### PR DESCRIPTION
@maliberty @louiic My guess here is that this is mock-array implemented a generic BLOCKS (top) and BLOCK (macro) PDN strategy, so moving the BLOCK level PDN strategy into platforms/asap7 alongside the corresponding BLOCKS level PDN strategy file.

If I understand correctly, then the default PDN strategy in asap7 is for a design that does not contain macros, beyond SRAMs.