### PR TITLE
s/commercial/proprietary/

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -182,7 +182,7 @@ These platforms have a permissive license which allows us to
 redistribute the PDK and OpenROAD platform-specific files. The platform
 files and license(s) are located in `platforms/{platform}`.
 
-OpenROAD-flow-scripts also supports the following commercial platforms:
+OpenROAD-flow-scripts also supports the following proprietary platforms:
 
 - GF12
 - TSMC65LP


### PR DESCRIPTION
Both `sky130` and `gf180mcu` are commercial platforms. 

The actually difference is that `GF12LP` and `TSMC65LP` are proprietary / non-open platforms.