### PR TITLE
Change `/bin/bash` to `/usr/bin/env bash`.

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FLOW_ROOT=$(realpath "${FLOW_HOME}")

--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
While most scripts are already using `/usr/bin/env bash` to find bash, there are still a few left which reference `/bin/bash`.

This pull request updates;
 * `util/makeIssue.sh`
 * `util/generate-vars.sh`