### PR TITLE
Disable make's implicit rules.

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -115,6 +115,10 @@ endif
 #
 # ==============================================================================
 
+# Disable make's implicit rules
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
 #-------------------------------------------------------------------------------
 # Default target when invoking without specific target.
 .DEFAULT_GOAL := finish


### PR DESCRIPTION
By default `make` has a large number of "default implicit" rules, see https://www.gnu.org/software/make/manual/html_node/Implicit-Rules.html and https://www.gnu.org/software/make/manual/html_node/Catalogue-of-Rules.html

These significantly slow down make runs and increase the noise in output (particularly with `-d` / `--debug=all` on).