### PR TITLE
Set FLOW_HOME only once.

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -133,7 +133,10 @@ SHELL          := /usr/bin/env bash
 # - the following settings allowed user to point OpenROAD binaries to different
 #   location
 # - default is current install / clone directory
-export FLOW_HOME ?= $(shell pwd)
+ifeq ($(origin FLOW_HOME), undefined)
+FLOW_HOME := $(shell pwd)
+endif
+export FLOW_HOME
 
 #-------------------------------------------------------------------------------
 # Setup variables to point to other location for the following sub directory


### PR DESCRIPTION
`export FLOW_HOME ?= $(shell pwd)` causes `pwd` to be executed a couple of hundred times during the Makefile.

Instead using `:=` causes `pwd` to be executed a single time. To allow still overriding `FLOW_HOME`, we use the `$(origin)` function.

As described at https://www.gnu.org/software/make/manual/html_node/Setting.html

> If you’d like a variable to be set to a value only if it’s not already
> set, then you can use the shorthand operator ‘?=’ instead of ‘=’.
> These two settings of the variable ‘FOO’ are identical (see The origin
> Function):
>
> `FOO ?= bar`
>
> and
>
> ```Makefile
> ifeq ($(origin FOO), undefined)
> FOO = bar
> endif
> ```