### PR TITLE
Fixes for `KLAYOUT` in Makefile

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -287,12 +287,17 @@ YOSYS_CMD               ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yos
 KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)
 KLAYOUT_BIN_FROM_DIR = $(KLAYOUT_DIR)/klayout
 
+ifeq ($(origin KLAYOUT_CMD), undefined)
 ifeq ($(wildcard $(KLAYOUT_BIN_FROM_DIR)), $(KLAYOUT_BIN_FROM_DIR))
-KLAYOUT_CMD ?= sh -c 'LD_LIBRARY_PATH=$(dir $(KLAYOUT_BIN_FROM_DIR)) $$0 "$$@"' $(KLAYOUT_BIN_FROM_DIR)
+KLAYOUT_CMD := sh -c 'LD_LIBRARY_PATH=$(dir $(KLAYOUT_BIN_FROM_DIR)) $$0 "$$@"' $(KLAYOUT_BIN_FROM_DIR)
 else
-KLAYOUT_CMD ?= $(shell command -v klayout)
+KLAYOUT_CMD := $(shell command -v klayout)
 endif
-KLAYOUT_FOUND            = $(if $(KLAYOUT_CMD),,$(error KLayout not found in PATH))
+endif
+
+ifeq ($(KLAYOUT_CMD),)
+$(error KLayout not found in PATH))
+endif
 
 ifneq ($(shell command -v stdbuf),)
   STDBUF_CMD = stdbuf -o L

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -382,9 +382,9 @@ $(OBJECTS_DIR)/klayout_tech.lef: $(TECH_LEF)
 	cp $< $@
 
 KLAYOUT_ENV_VAR_IN_PATH_VERSION = 0.28.11
-KLAYOUT_VERSION = $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
+KLAYOUT_VERSION := $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
 
-KLAYOUT_ENV_VAR_IN_PATH = $(shell \
+KLAYOUT_ENV_VAR_IN_PATH := $(shell \
 	if [ -z "$(KLAYOUT_VERSION)" ]; then \
 		echo "not_found"; \
 	elif [ "$$(echo -e "$(KLAYOUT_VERSION)\n$(KLAYOUT_ENV_VAR_IN_PATH_VERSION)" | sort -V | head -n1)" = "$(KLAYOUT_VERSION)" ] && [ "$(KLAYOUT_VERSION)" != "$(KLAYOUT_ENV_VAR_IN_PATH_VERSION)" ]; then \


### PR DESCRIPTION
Two fixes to the `KLAYOUT` in Makefile stuff;

 * Fix the discovery of the KLayout binary (fixes #1494).
 * Expand the `$(shell)` usage straight away.