### PR TITLE
makefile: add do-gds

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -376,8 +376,12 @@ $(OBJECTS_DIR)/lib/merged.lib:
 # Pre-process KLayout tech
 # ==============================================================================
 $(OBJECTS_DIR)/klayout_tech.lef: $(TECH_LEF)
+	$(UNSET_AND_MAKE) do-klayout_tech
+
+.PHONY: do-klayout_tech
+do-klayout_tech:
 	@mkdir -p $(OBJECTS_DIR)
-	cp $< $@
+	cp $(TECH_LEF) $(OBJECTS_DIR)/klayout_tech.lef
 
 KLAYOUT_ENV_VAR_IN_PATH_VERSION = 0.28.11
 KLAYOUT_VERSION = $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
@@ -392,16 +396,25 @@ KLAYOUT_ENV_VAR_IN_PATH = $(shell \
 	fi)
 
 $(OBJECTS_DIR)/klayout.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
+	$(UNSET_AND_MAKE) do-klayout
+
+.PHONY: do-klayout
+do-klayout:
 ifeq ($(KLAYOUT_ENV_VAR_IN_PATH),valid)
 	SC_LEF_RELATIVE_PATH="$$\(env('FLOW_HOME')\)/$(shell realpath --relative-to=$(FLOW_HOME) $(SC_LEF))"; \
 	OTHER_LEFS_RELATIVE_PATHS=$$(echo "$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(ADDITIONAL_LEFS),<lef-files>$$(realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>)"); \
-	sed 's,<lef-files>.*</lef-files>,<lef-files>'"$$SC_LEF_RELATIVE_PATH"'</lef-files>'"$$OTHER_LEFS_RELATIVE_PATHS"',g' $< > $@
+	sed 's,<lef-files>.*</lef-files>,<lef-files>'"$$SC_LEF_RELATIVE_PATH"'</lef-files>'"$$OTHER_LEFS_RELATIVE_PATHS"',g' $(KLAYOUT_TECH_FILE) > $(OBJECTS_DIR)/klayout.lyt
 else
-	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(SC_LEF) $(ADDITIONAL_LEFS),<lef-files>$(shell realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>),g' $< > $@
+	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(SC_LEF) $(ADDITIONAL_LEFS),<lef-files>$(shell realpath --relative-to=$(RESULTS_DIR) $(file))</lef-files>),g' $(KLAYOUT_TECH_FILE) > $(OBJECTS_DIR)/klayout.lyt
 endif
 
 $(OBJECTS_DIR)/klayout_wrap.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
-	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(WRAP_LEFS),<lef-files>$(shell realpath --relative-to=$(OBJECTS_DIR)/def $(file))</lef-files>),g' $< > $@
+	$(UNSET_AND_MAKE) do-klayout_wrap
+
+.PHONY: do-klayout_wrap
+do-klayout_wrap:
+	sed 's,<lef-files>.*</lef-files>,$(foreach file, $(OBJECTS_DIR)/klayout_tech.lef $(WRAP_LEFS),<lef-files>$(shell realpath --relative-to=$(OBJECTS_DIR)/def $(file))</lef-files>),g' $(KLAYOUT_TECH_FILE) > $(OBJECTS_DIR)/klayout_wrap.lyt
+
 # Create Macro wrappers (if necessary)
 # ==============================================================================
 WRAP_CFG = $(PLATFORM_DIR)/wrapper.cfg
@@ -788,11 +801,10 @@ $(eval $(call do-step,6_report,$(RESULTS_DIR)/6_1_fill.odb $(RESULTS_DIR)/6_1_fi
 
 $(RESULTS_DIR)/6_final.def: $(LOG_DIR)/6_report.log
 
-# NOTE! No GDS file for now
 .PHONY: do-finish
 do-finish:
 	mkdir -p $(LOG_DIR) $(REPORTS_DIR)
-	$(UNSET_AND_MAKE) do-6_1_fill do-6_1_fill.sdc do-6_final.sdc do-6_report elapsed
+	$(UNSET_AND_MAKE) do-6_1_fill do-6_1_fill.sdc do-6_final.sdc do-6_report do-gds elapsed
 
 .PHONY: skip_place
 skip_place: $(RESULTS_DIR)/2_floorplan.odb $(RESULTS_DIR)/2_floorplan.sdc
@@ -864,18 +876,27 @@ $(WRAPPED_GDSOAS): $(OBJECTS_DIR)/klayout_wrap.lyt $(WRAPPED_LEFS)
 #-------------------------------------------------------------------------------
 GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 $(GDS_MERGED_FILE): $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klayout.lyt $(GDSOAS_FILES) $(WRAPPED_GDSOAS) $(SEAL_GDSOAS)
+	$(UNSET_AND_MAKE) do-gds-merged
+
+.PHONY: do-gds-merged
+do-gds-merged:
 	$(call KLAYOUT_FOUND)
 	($(TIME_CMD) $(STDBUF_CMD) $(KLAYOUT_CMD) -zz -rd design_name=$(DESIGN_NAME) \
-	        -rd in_def=$< \
+	        -rd in_def=$(RESULTS_DIR)/6_final.def \
 	        -rd in_files="$(GDSOAS_FILES) $(WRAPPED_GDSOAS)" \
 	        -rd config_file=$(FILL_CONFIG) \
 	        -rd seal_file="$(SEAL_GDSOAS)" \
-	        -rd out_file=$@ \
+	        -rd out_file=$(GDS_MERGED_FILE) \
 	        -rd tech_file=$(OBJECTS_DIR)/klayout.lyt \
 	        -rd layer_map=$(GDS_LAYER_MAP) \
 	        -r $(UTILS_DIR)/def2stream.py) 2>&1 | tee $(LOG_DIR)/6_1_merge.log
 
 $(RESULTS_DIR)/6_final.v: $(LOG_DIR)/6_report.log
+
+.PHONY: do-gds
+do-gds:
+	$(UNSET_AND_MAKE) do-klayout_tech do-klayout do-klayout_wrap do-gds-merged
+	cp $(GDS_MERGED_FILE) $(GDS_FINAL_FILE)
 
 $(GDS_FINAL_FILE): $(GDS_MERGED_FILE)
 	cp $< $@


### PR DESCRIPTION
separate the concerns of checking dependencies and making the gds file.

Example use-case: make a wafer thin Bazel wrapper on top of ORFS to get artifact support for macros that can be in the hundreds of megabytes range.

There is a problem with testing do-wrapped-gdsoas as only gf12 uses WRAP_LEFS and gf12 is under NDA, but the code is written with the assumption that `$(WRAPPED_GDSOAS)` contains zero or more files.

W.r.t. the do-foo variants, only `$(WRAPPED_GDSOAS)` needs to be updated.

`$(WRAPPED_LEFS)` and `$(WRAPPED_LIBS)` also generates multiple targets, but this happens during synthesis. There is no "do-synth" as we can scrape by without a "do-synth" as it is the *first* target to be run and when making a  wafer thin Bazel wrapper, the Makefile target dependency checks do not cause a problem for the first target because we always want to run the full synth target within Bazel and generate all the dependencies of synth.
