### PR TITLE
makefile: add ABSTRACT_SOURCE variable for generate-abstract

### DIFF
--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -1,8 +1,13 @@
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 6_final.odb 6_final.sdc "Starting generation of abstract views"
 
-read_spef $::env(RESULTS_DIR)/6_final.spef
-set_propagated_clock [all_clocks]
+set stem [expr {[info exists ::env(ABSTRACT_SOURCE)] ? $::env(ABSTRACT_SOURCE) : "6_final"}]
+
+load_design $stem.odb $stem.sdc "Starting generation of abstract views"
+
+if {[file exists $::env(RESULTS_DIR)/$stem.spef]} {
+  read_spef $::env(RESULTS_DIR)/$stem.spef
+  set_propagated_clock [all_clocks]
+}
 
 puts "Starting generation of abstract views"
 write_timing_model $::env(RESULTS_DIR)/$::env(DESIGN_NAME).lib
@@ -10,7 +15,7 @@ write_abstract_lef -bloat_occupied_layers $::env(RESULTS_DIR)/$::env(DESIGN_NAME
 
 if {[info exist ::env(CDL_FILES)]} {
   cdl read_masters $::env(CDL_FILES)
-  cdl out $::env(RESULTS_DIR)/6_final.cdl
+  cdl out $::env(RESULTS_DIR)/$stem.cdl
 }
 
 if {![info exists standalone] || $standalone} {

--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -2,10 +2,18 @@ source $::env(SCRIPTS_DIR)/load.tcl
 
 set stem [expr {[info exists ::env(ABSTRACT_SOURCE)] ? $::env(ABSTRACT_SOURCE) : "6_final"}]
 
+set design_stage [lindex [split [file tail $stem] "_"] 0]
+
 load_design $stem.odb $stem.sdc "Starting generation of abstract views"
 
-if {[file exists $::env(RESULTS_DIR)/$stem.spef]} {
+if {$design_stage >= 6 && [file exists $::env(RESULTS_DIR)/$stem.spef]} {
   read_spef $::env(RESULTS_DIR)/$stem.spef
+} elseif {$design_stage >= 3} {
+  puts "Estimating parasitics"
+  estimate_parasitics -placement
+}
+
+if {$design_stage >= 4} {
   set_propagated_clock [all_clocks]
 }
 


### PR DESCRIPTION
This can be used to generate an abstract using for instance 2_floorplan stage, which allows quickly previewing floorplan changes at the top level.

When I tested it with MegaBoom, I could view the floorplan after mpl2 in minutes instead of days.

I tried out putting all pins on the left edge of the macros and changing aspect ratio according to tip from @louiic, resulting floorplan preview:

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/fd3384ff-795f-4dd9-be73-01a4d8796a11)
