### PR TITLE
makefile: remove 4_2_cts_fillcell.odb vestige

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -839,7 +839,6 @@ skip_resize: $(RESULTS_DIR)/3_3_place_gp.odb
 skip_cts: $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/3_place.sdc
 	# mock all intermediate results
 	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_1_cts.odb
-	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_2_cts_fillcell.odb
 	cp $(RESULTS_DIR)/3_place.sdc $(RESULTS_DIR)/4_cts.sdc
 	cp $(RESULTS_DIR)/3_place.odb $(RESULTS_DIR)/4_cts.odb
 


### PR DESCRIPTION
@eder-matheus In 776143b456274f5e2c8a3d70469a205950a1b40e, 4_2_cts_fillcell was moved to 5_2_fillcell