### PR TITLE
Makefile fix print

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1078,7 +1078,7 @@ handoff : all_defs all_verilog
 
 .PHONY: print-%
 # Print any variable, for instance: make print-DIE_AREA
-print-%  : ; @echo $* = $($*)
+print-%  : ; @echo "$* = $($*)"
 
 .PHONY: test-unset-and-make-%
 test-unset-and-make-%: ; $(UNSET_AND_MAKE) $*


### PR DESCRIPTION
Works now:

```    
$ make GDS_ALLOW_EMPTY="(asdf|asdfj)" print-GDS_ALLOW_EMPTY
[INFO][FLOW] Using platform directory /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45
GDS_ALLOW_EMPTY = (asdf|asdfj)
```

Used to fail:

```    
make GDS_ALLOW_EMPTY='(asdf|asdfj)' print-GDS_ALLOW_EMPTY
[INFO][FLOW] Using platform directory /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45
bash: -c: line 1: syntax error near unexpected token `('
bash: -c: line 1: `echo GDS_ALLOW_EMPTY = (asdf|asdfj)'
make: *** [Makefile:1133: print-GDS_ALLOW_EMPTY] Error 2   
```
