### PR TITLE
makefile: reduce noise

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -174,9 +174,6 @@ else
   $(error [ERROR][FLOW] Platform '$(PLATFORM)' not found.)
 endif
 
-ifeq ($(MAKELEVEL),0)
-$(info [INFO][FLOW] Using platform directory $(PLATFORM_DIR))
-endif
 include $(PLATFORM_DIR)/config.mk
 
 export GALLERY_REPORT ?= 0


### PR DESCRIPTION
removed what was really debug-output.

When running commands like the below, removing debug output matters.

$ make print-CORE_UTILIZATION
CORE_UTILIZATION = 55

To display PLATFORM_DIR:

$ make print-PLATFORM_DIR
PLATFORM_DIR = /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45