### PR TITLE
cts: fix Error: cts.tcl, 117 invoked return outside of a proc.

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -113,7 +113,7 @@ set result [catch {detailed_placement} msg]
 if {$result != 0} {
   save_progress 4_1_error
   puts "Detailed placement failed in CTS: $msg"
-  return -code $result
+  exit $result
 }
 
 check_placement -verbose


### PR DESCRIPTION
Needs testing and review...

Stab in the dark to try to fix:

```
Detailed placement failed in CTS: DPL-0046
Error: cts.tcl, 117 invoked "return" outside of a proc.
```

