### PR TITLE
power: handle empty PWR/GND_NETS_VOLTAGES variables

### DIFF
--- a/flow/scripts/final_report.tcl
+++ b/flow/scripts/final_report.tcl
@@ -37,7 +37,7 @@ if {[info exist ::env(RCX_RULES)]} {
   read_spef $::env(RESULTS_DIR)/6_final.spef
 
   # Static IR drop analysis
-  if {[info exist ::env(PWR_NETS_VOLTAGES)]} {
+  if {[info exist ::env(PWR_NETS_VOLTAGES)] && [string length $::env(PWR_NETS_VOLTAGES)] > 0} {
     dict for {pwrNetName pwrNetVoltage}  {*}$::env(PWR_NETS_VOLTAGES) {
         set_pdnsim_net_voltage -net ${pwrNetName} -voltage ${pwrNetVoltage}
         analyze_power_grid -net ${pwrNetName} \
@@ -46,7 +46,7 @@ if {[info exist ::env(RCX_RULES)]} {
   } else {
     puts "IR drop analysis for power nets is skipped because PWR_NETS_VOLTAGES is undefined"
   }
-  if {[info exist ::env(GND_NETS_VOLTAGES)]} {
+  if {[info exist ::env(GND_NETS_VOLTAGES)] && [string length $::env(GND_NETS_VOLTAGES)] > 0} {
     dict for {gndNetName gndNetVoltage}  {*}$::env(GND_NETS_VOLTAGES) {
         set_pdnsim_net_voltage -net ${gndNetName} -voltage ${gndNetVoltage}
         analyze_power_grid -net ${gndNetName} \

--- a/flow/scripts/save_images.tcl
+++ b/flow/scripts/save_images.tcl
@@ -34,7 +34,7 @@ gui::set_display_controls "Layers/*" visible false
 gui::set_display_controls "Instances/Physical/*" visible false
 save_image -resolution $resolution $::env(REPORTS_DIR)/final_placement.webp
 
-if {[info exist ::env(PWR_NETS_VOLTAGES)]} {
+if {[info exist ::env(PWR_NETS_VOLTAGES)] && [string length $::env(PWR_NETS_VOLTAGES)] > 0} {
   gui::set_display_controls "Heat Maps/IR Drop" visible true
   gui::set_heatmap IRDrop Layer $::env(IR_DROP_LAYER)
   gui::set_heatmap IRDrop ShowLegend 1


### PR DESCRIPTION
empty variables are used to skip this checking stage.

empty variables runs into "dict for" statements which tries to iterate over an empty key value list.