### PR TITLE
Pinata fix gnd pwr syntax nit

### DIFF
--- a/flow/designs/asap7/aes-block/config.mk
+++ b/flow/designs/asap7/aes-block/config.mk
@@ -24,8 +24,8 @@ export MIN_ROUTING_LAYER      = M2
 export MAX_ROUTING_LAYER      = M9
 
 # Ignore power at this exploratory level
-export GND_NETS_VOLTAGES      = ""
-export PWR_NETS_VOLTAGES      = ""
+export GND_NETS_VOLTAGES      =
+export PWR_NETS_VOLTAGES      =
 
 # The macros are very small so use a smaller halo
 export MACRO_PLACE_HALO        ?= 5 5

--- a/flow/designs/asap7/megaboom/config.mk
+++ b/flow/designs/asap7/megaboom/config.mk
@@ -50,5 +50,5 @@ export SYNTH_ARGS            ?= -noshare
 export MIN_ROUTING_LAYER      = M2
 export MAX_ROUTING_LAYER      = M9
 
-export GND_NETS_VOLTAGES      = ""
-export PWR_NETS_VOLTAGES      = ""
+export GND_NETS_VOLTAGES      =
+export PWR_NETS_VOLTAGES      =

--- a/flow/designs/asap7/swerv_wrapper/config.mk
+++ b/flow/designs/asap7/swerv_wrapper/config.mk
@@ -30,6 +30,6 @@ export CELL_PAD_IN_SITES_DETAIL_PLACEMENT = 2
 export FASTROUTE_TCL = ./designs/$(PLATFORM)/swerv_wrapper/fastroute.tcl
 
 #Temporary until sta bug is fixed
-export PWR_NETS_VOLTAGES  = ""
-export GND_NETS_VOLTAGES  = ""
+export PWR_NETS_VOLTAGES  =
+export GND_NETS_VOLTAGES  =
 export TNS_END_PERCENT        = 100


### PR DESCRIPTION
The env var contains `""` (two double quotes)  instead of an empty string as intended
by these statements.

Fix these statements so that this incorrect idiom is not copied
and pasted elsewhere