### PR TITLE
Mock array insertion delay

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -56,3 +56,11 @@ export FASTROUTE_TCL = ./designs/$(PLATFORM)/mock-array/fastroute.tcl
 # ensure we have some rows, so we don't get a bad clock skew.
 export MACRO_HALO_X            = 0.5
 export MACRO_HALO_Y            = 0.5
+
+export GND_NETS_VOLTAGES      =
+export PWR_NETS_VOLTAGES      =
+
+export CTS_ARGS=-root_buf BUFx4_ASAP7_75t_R -buf_list BUFx4_ASAP7_75t_R \
+  -sink_clustering_enable -sink_clustering_size 30 \
+  -sink_clustering_max_diameter 100 -balance_levels \
+  -distance_between_buffers 60 -insertion_delay

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -24,20 +24,23 @@ proc save_progress {stage} {
   write_sdc $::env(RESULTS_DIR)/$stage.sdc
 }
 
+set cts_args [list -root_buf "$::env(CTS_BUF_CELL)" -buf_list "$::env(CTS_BUF_CELL)" \
+          -sink_clustering_enable \
+          -sink_clustering_size $cluster_size \
+          -sink_clustering_max_diameter $cluster_diameter \
+          -balance_levels]
+
 if {[info exist ::env(CTS_BUF_DISTANCE)]} {
-  clock_tree_synthesis -root_buf "$::env(CTS_BUF_CELL)" -buf_list "$::env(CTS_BUF_CELL)" \
-                      -sink_clustering_enable \
-                      -sink_clustering_size $cluster_size \
-                      -sink_clustering_max_diameter $cluster_diameter \
-                      -distance_between_buffers "$::env(CTS_BUF_DISTANCE)" \
-                      -balance_levels
-} else {
-  clock_tree_synthesis -root_buf "$::env(CTS_BUF_CELL)" -buf_list "$::env(CTS_BUF_CELL)" \
-                      -sink_clustering_enable \
-                      -sink_clustering_size $cluster_size \
-                      -sink_clustering_max_diameter $cluster_diameter \
-                      -balance_levels
+  lappend cts_args -distance_between_buffers "$::env(CTS_BUF_DISTANCE)"
 }
+
+if {[info exist ::env(CTS_ARGS)]} {
+  set cts_args $::env(CTS_ARGS)
+}
+
+puts "clock_tree_synthesis [join $cts_args " "]"
+
+clock_tree_synthesis {*}$cts_args
 
 if {[info exist ::env(CTS_SNAPSHOTS)]} {
   save_progress 4_1_pre_repair_clock_nets


### PR DESCRIPTION
@precisionmoon I need a bit of help to figure out what is going on here...

With `-insertion_delay`, I get the same result as without. This is seen both in the prerepair details, but also in the clock tree viewer. I had expected to see the macros higher up in the tree than the flip-flops:

```
Repair setup and hold violations...
TNS end percent 5
[INFO RSZ-0094] Found 1584 endpoints with setup violations.
[INFO RSZ-0041] Resized 82 instances.
[WARNING RSZ-0062] Unable to repair all setup violations.
[INFO RSZ-0046] Found 117 endpoints with hold violations.
[WARNING RSZ-0066] Unable to repair all hold violations.
Placement Analysis
```

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/3d9df3ae-8355-4622-9c11-a2565feb8bc6)



Without `-insertion_delay`, I get apparently the same result:

```
Repair setup and hold violations...
TNS end percent 5
[INFO RSZ-0094] Found 1584 endpoints with setup violations.
[INFO RSZ-0041] Resized 82 instances.
[WARNING RSZ-0062] Unable to repair all setup violations.
[INFO RSZ-0046] Found 117 endpoints with hold violations.
[WARNING RSZ-0066] Unable to repair all hold violations.
Placement Analysis
```

