### PR TITLE
Added tapcell.tcl calling `cut_rows` for ihp-sg13g2

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -63,6 +63,10 @@ export IO_PLACER_V = Metal3
 # Define default PDN config
 export PDN_TCL ?= $(PLATFORM_DIR)/pdn.tcl
 
+# There are no Endcap and Welltie cells in this PDK, so
+# `cut_rows` has to be called from the tapcell script.
+export TAPCELL_TCL = $(PLATFORM_DIR)/tapcell.tcl
+
 export MACRO_PLACE_HALO ?= 40 40
 export MACRO_PLACE_CHANNEL ?= 80 80
 

--- a/flow/platforms/ihp-sg13g2/tapcell.tcl
+++ b/flow/platforms/ihp-sg13g2/tapcell.tcl
@@ -1,0 +1,1 @@
+cut_rows


### PR DESCRIPTION
Since IHP's PDK doesn't use tapcells, standard cell rows are not cut during tapcell insertion, and `cut_rows` has to be called instead.