### PR TITLE
Adjusted ihp-sg13g2 stdcell power stripe width to match standard cells

### DIFF
--- a/flow/platforms/ihp-sg13g2/pdn.tcl
+++ b/flow/platforms/ihp-sg13g2/pdn.tcl
@@ -16,7 +16,7 @@ set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
 ####################################
 define_pdn_grid -name {grid} -voltage_domains {CORE}
 add_pdn_ring -grid {grid} -layers {Metal5 TopMetal1} -widths {5.0} -spacings {2.0} -core_offsets {4.5} -connect_to_pads
-add_pdn_stripe -grid {grid} -layer {Metal1}     -width {0.48}  -pitch {7.56} -offset {0}      -followpins -extend_to_core_ring
+add_pdn_stripe -grid {grid} -layer {Metal1}     -width {0.44}  -pitch {7.56} -offset {0}      -followpins -extend_to_core_ring
 add_pdn_stripe -grid {grid} -layer {Metal5}     -width {2.200} -pitch {75.6} -offset {13.600}             -extend_to_core_ring
 add_pdn_stripe -grid {grid} -layer {TopMetal1}  -width {1.800} -pitch {75.6} -offset {13.570}             -extend_to_core_ring
 add_pdn_connect -grid {grid} -layers {Metal1 Metal5}


### PR DESCRIPTION
The stdcell power stripe width of `0.48` does not match the ihp-sg13g2 standard cells. By looking in the LEF file, I found `0.44` to be the correct width. Maybe @KrzysztofHerman could confirm this?