### PR TITLE
scripts: fix mpl2 options / include the ones that were missing

### DIFF
--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -56,8 +56,13 @@ if {[find_macros] != ""} {
   } elseif {[info exists ::env(RTLMP_FLOW)]} {
     puts "HierRTLMP Flow enabled..."
     set additional_rtlmp_args ""
-    if { [info exists ::env(RTLMP_MAX_LEVEL)]} {
-        append additional_rtlmp_args " -max_num_level $env(RTLMP_MAX_LEVEL)"
+
+    # Generic Parameters
+    if { [info exists ::env(RTLMP_MAX_MACRO)]} {
+        append additional_rtlmp_args " -max_num_macro $env(RTLMP_MAX_MACRO)"
+    }
+    if { [info exists ::env(RTLMP_MIN_MACRO)]} {
+        append additional_rtlmp_args " -min_num_macro $env(RTLMP_MIN_MACRO)"
     }
     if { [info exists ::env(RTLMP_MAX_INST)]} {
         append additional_rtlmp_args " -max_num_inst $env(RTLMP_MAX_INST)"
@@ -65,45 +70,25 @@ if {[find_macros] != ""} {
     if { [info exists ::env(RTLMP_MIN_INST)]} {
         append additional_rtlmp_args " -min_num_inst $env(RTLMP_MIN_INST)"
     }
-    if { [info exists ::env(RTLMP_MAX_MACRO)]} {
-        append additional_rtlmp_args " -max_num_macro $env(RTLMP_MAX_MACRO)"
+    if { [info exists ::env(RTLMP_TOLERANCE)]} {
+      append additional_rtlmp_args " -tolerance $env(RTLMP_TOLERANCE)"
     }
-    if { [info exists ::env(RTLMP_MIN_MACRO)]} {
-        append additional_rtlmp_args " -min_num_macro $env(RTLMP_MIN_MACRO)"
+    if { [info exists ::env(RTLMP_MAX_LEVEL)]} {
+      append additional_rtlmp_args " -max_num_level $env(RTLMP_MAX_LEVEL)"
     }
-    
+    if { [info exists ::env(RTLMP_COARSENING_RATIO)]} {
+      append additional_rtlmp_args " -coarsening_ratio $env(RTLMP_COARSENING_RATIO)"
+    }
+    if { [info exists ::env(RTLMP_NUM_BUNDLED_IOS)]} {
+      append additional_rtlmp_args " -num_bundled_ios $env(RTLMP_NUM_BUNDLED_IOS)"
+    }
+    if { [info exists ::env(RTLMP_LARGE_NET_THRESHOLD)]} {
+      append additional_rtlmp_args " -large_net_threshold $env(RTLMP_LARGE_NET_THRESHOLD)"
+    }
+    if { [info exists ::env(RTLMP_SIGNATURE_NET_THRESHOLD)]} {
+      append additional_rtlmp_args " -signature_net_threshold $env(RTLMP_SIGNATURE_NET_THRESHOLD)"
+    }
     append additional_rtlmp_args " -halo_width $halo_max"
-
-    if { [info exists ::env(RTLMP_MIN_AR)]} {
-        append additional_rtlmp_args " -min_ar $env(RTLMP_MIN_AR)"
-    }
-    if { [info exists ::env(RTLMP_AREA_WT)]} {
-        append additional_rtlmp_args " -area_weight $env(RTLMP_AREA_WT)"
-    }
-    if { [info exists ::env(RTLMP_WIRELENGTH_WT)]} {
-        append additional_rtlmp_args " -wirelength_weight $env(RTLMP_WIRELENGTH_WT)"
-    }
-    if { [info exists ::env(RTLMP_OUTLINE_WT)]} {
-        append additional_rtlmp_args " -outline_weight $env(RTLMP_OUTLINE_WT)"
-    }
-    if { [info exists ::env(RTLMP_BOUNDARY_WT)]} {
-        append additional_rtlmp_args " -boundary_weight $env(RTLMP_BOUNDARY_WT)"
-    }
-
-    if { [info exists ::env(RTLMP_NOTCH_WT)]} {
-        append additional_rtlmp_args " -notch_weight $env(RTLMP_NOTCH_WT)"
-    }
-
-    if { [info exists ::env(RTLMP_DEAD_SPACE)]} {
-        append additional_rtlmp_args " -dead_space $env(RTLMP_DEAD_SPACE)"
-    }
-    if { [info exists ::env(RTLMP_CONFIG_FILE)]} {
-        append additional_rtlmp_args " -config_file $env(RTLMP_CONFIG_FILE)"
-    }
-    if { [info exists ::env(RTLMP_RPT_DIR)]} {
-        append additional_rtlmp_args " -report_directory $env(RTLMP_RPT_DIR)"
-    }
-
     if { [info exists ::env(RTLMP_FENCE_LX)]} {
         append additional_rtlmp_args " -fence_lx $env(RTLMP_FENCE_LX)"
     }
@@ -116,7 +101,53 @@ if {[find_macros] != ""} {
     if { [info exists ::env(RTLMP_FENCE_UY)]} {
         append additional_rtlmp_args " -fence_uy $env(RTLMP_FENCE_UY)"
     }
+    if { [info exists ::env(RTLMP_TARGET_UTIL)]} {
+      append additional_rtlmp_args " -target_util $env(RTLMP_TARGET_UTIL)"
+    }
+    if { [info exists ::env(RTLMP_TARGET_DEAD_SPACE)]} {
+      append additional_rtlmp_args " -target_dead_space $env(RTLMP_TARGET_DEAD_SPACE)"
+    }
+    if { [info exists ::env(RTLMP_MIN_AR)]} {
+        append additional_rtlmp_args " -min_ar $env(RTLMP_MIN_AR)"
+    }
+    if { [info exists ::env(RTLMP_SNAP_LAYER)]} {
+      append additional_rtlmp_args " -snap_layer $env(RTLMP_SNAP_LAYER)"
+    }
+    if { [info exists ::env(RTLMP_BUS_PLANNING_ON)]} {
+      append additional_rtlmp_args " -bus_planning_on $env(RTLMP_BUS_PLANNING_ON)"
+    }
+    if { [info exists ::env(RTLMP_REPORT_DIRECTORY)]} {
+      append additional_rtlmp_args " -report_directory $env(RTLMP_REPORT_DIRECTORY)"
+    }
+    if { [info exists ::env(RTLMP_WRITE_PLACEMENT)]} {
+      append additional_rtlmp_args " -write_macro_placement $env(RTLMP_WRITE_PLACEMENT)"
+    }
 
+    # Simulated Annealing Weight Parameters
+    if { [info exists ::env(RTLMP_AREA_WT)]} {
+        append additional_rtlmp_args " -area_weight $env(RTLMP_AREA_WT)"
+    }
+    if { [info exists ::env(RTLMP_OUTLINE_WT)]} {
+        append additional_rtlmp_args " -outline_weight $env(RTLMP_OUTLINE_WT)"
+    }
+    if { [info exists ::env(RTLMP_WIRELENGTH_WT)]} {
+        append additional_rtlmp_args " -wirelength_weight $env(RTLMP_WIRELENGTH_WT)"
+    }
+    if { [info exists ::env(RTLMP_GUIDANCE_WT)]} {
+        append additional_rtlmp_args " -guidance_weight $env(RTLMP_GUIDANCE_WT)"
+    }
+    if { [info exists ::env(RTLMP_FENCE_WT)]} {
+        append additional_rtlmp_args " -fence_weight $env(RTLMP_FENCE_WT)"
+    }
+    if { [info exists ::env(RTLMP_BOUNDARY_WT)]} {
+        append additional_rtlmp_args " -boundary_weight $env(RTLMP_BOUNDARY_WT)"
+    }
+    if { [info exists ::env(RTLMP_NOTCH_WT)]} {
+        append additional_rtlmp_args " -notch_weight $env(RTLMP_NOTCH_WT)"
+    }
+    if { [info exists ::env(RTLMP_MACRO_BLOCKAGE_WT)]} {
+      append additional_rtlmp_args " -macro_blockage_weight $env(RTLMP_MACRO_BLOCKAGE_WT)"
+    }
 
     puts "Call Macro Placer $additional_rtlmp_args"
 

--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -114,7 +114,7 @@ if {[find_macros] != ""} {
       append additional_rtlmp_args " -snap_layer $env(RTLMP_SNAP_LAYER)"
     }
     if { [info exists ::env(RTLMP_BUS_PLANNING_ON)]} {
-      append additional_rtlmp_args " -bus_planning_on $env(RTLMP_BUS_PLANNING_ON)"
+      append additional_rtlmp_args " -bus_planning"
     }
     if { [info exists ::env(RTLMP_REPORT_DIRECTORY)]} {
       append additional_rtlmp_args " -report_directory $env(RTLMP_REPORT_DIRECTORY)"


### PR DESCRIPTION
I put the commands in the order we see them in the docs.

I'm opening this as a draft, because I'm changing bus_planning_flag to an actual flag in #[4339](https://github.com/The-OpenROAD-Project/OpenROAD/pull/4339) which needs to be merged first.

