### PR TITLE
rtlmp: add RTLMP_ARGS consistent with global/place/cts

### DIFF
--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -117,11 +117,14 @@ if {[find_macros] != ""} {
         append additional_rtlmp_args " -fence_uy $env(RTLMP_FENCE_UY)"
     }
 
+    set all_args $additional_rtlmp_args
 
-    puts "Call Macro Placer $additional_rtlmp_args"
+    if { [info exists ::env(RTLMP_ARGS)] } {
+      set all_args $::env(RTLMP_ARGS)
+    }
 
-    rtl_macro_placer \
-                 {*}$additional_rtlmp_args
+    puts "rtl_macro_placer [join $all_args " "]"
+    rtl_macro_placer {*}$all_args
 
     puts "Delete buffers for RTLMP flow..."
     remove_buffers


### PR DESCRIPTION
RTLMP has a lot of environment variables.

This change makes it possible to add and remove any current and future RTLMP argument, consistent with how this is done in global route, placement and cts.

The next step, once this is merged, would be to prune the disused RTLMP_ environment variables to reduce repetition and expose the OpenROAD interface directly through RTLMP_ARGS, rather than create an ORFS environment variable version of every current and future RTLMP argument.


https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/74c112eb3ab5a3fc8c703b428aa7386bd0cb3da1/flow/scripts/global_route.tcl#L32