### PR TITLE
detailed route: remove ORFS vars that are unused

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -151,6 +151,7 @@ Note:
 | `CELL_PAD_IN_SITES_DETAIL_PLACEMENT` | Cell padding on both sides in site widths to ease routability in detail placement.			                                       |
 | `PLACE_DENSITY`                      | The desired placement density of cells. It reflects how spread the cells would be on the core area. 1.0 = closely dense. 0.0 = widely spread. |
 | `PLACE_DENSITY_LB_ADDON`             | Check the lower boundary of the PLACE_DENSITY and add PLACE_DENSITY_LB_ADDON if it exists.                                                    |
+| `REPAIR_PDN_VIA_LAYER`               | Remove power grid vias which generate DRC violations after detailed routing.                                                                  |
 | `GLOBAL_PLACEMENT_ARGS`              | Use additional tuning parameters during global placement other than default args defined in gloabl_place.tcl.                                 |
 | `ENABLE_DPO`                         | Enable detail placement with improve_placement feature.                                                                                       |
 | `DPO_MAX_DISPLACEMENT`               | Specifies how far an instance can be moved when optimizing.                                                                                   |

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -151,7 +151,6 @@ Note:
 | `CELL_PAD_IN_SITES_DETAIL_PLACEMENT` | Cell padding on both sides in site widths to ease routability in detail placement.			                                       |
 | `PLACE_DENSITY`                      | The desired placement density of cells. It reflects how spread the cells would be on the core area. 1.0 = closely dense. 0.0 = widely spread. |
 | `PLACE_DENSITY_LB_ADDON`             | Check the lower boundary of the PLACE_DENSITY and add PLACE_DENSITY_LB_ADDON if it exists.                                                    |
-| `REPAIR_PDN_VIA_LAYER`               | Remove power grid vias which generate DRC violations after detailed routing.                                                                  |
 | `GLOBAL_PLACEMENT_ARGS`              | Use additional tuning parameters during global placement other than default args defined in gloabl_place.tcl.                                 |
 | `ENABLE_DPO`                         | Enable detail placement with improve_placement feature.                                                                                       |
 | `DPO_MAX_DISPLACEMENT`               | Specifies how far an instance can be moved when optimizing.                                                                                   |

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -10,14 +10,7 @@ set_propagated_clock [all_clocks]
 
 set_thread_count $::env(NUM_CORES)
 
-if { [info exists ::env(PRE_DETAIL_ROUTE_TCL)] } {
-  source $::env(PRE_DETAIL_ROUTE_TCL)
-}
-
 set additional_args ""
-if { [info exists ::env(dbProcessNode)]} {
-  append additional_args " -db_process_node $::env(dbProcessNode)"
-}
 if { [info exists ::env(OR_SEED)]} {
   append additional_args " -or_seed $::env(OR_SEED)"
 }
@@ -39,9 +32,6 @@ if { [info exists ::env(VIA_IN_PIN_MAX_LAYER)]} {
 }
 if { [info exists ::env(DISABLE_VIA_GEN)]} {
   append additional_args " -disable_via_gen"
-}
-if { [info exists ::env(REPAIR_PDN_VIA_LAYER)]} {
-  append additional_args " -repair_pdn_vias $::env(REPAIR_PDN_VIA_LAYER)"
 }
 
 append additional_args " -save_guide_updates -verbose 1"

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -11,6 +11,9 @@ set_propagated_clock [all_clocks]
 set_thread_count $::env(NUM_CORES)
 
 set additional_args ""
+if { [info exists ::env(dbProcessNode)]} {
+  append additional_args " -db_process_node $::env(dbProcessNode)"
+}
 if { [info exists ::env(OR_SEED)]} {
   append additional_args " -or_seed $::env(OR_SEED)"
 }
@@ -32,6 +35,9 @@ if { [info exists ::env(VIA_IN_PIN_MAX_LAYER)]} {
 }
 if { [info exists ::env(DISABLE_VIA_GEN)]} {
   append additional_args " -disable_via_gen"
+}
+if { [info exists ::env(REPAIR_PDN_VIA_LAYER)]} {
+  append additional_args " -repair_pdn_vias $::env(REPAIR_PDN_VIA_LAYER)"
 }
 
 append additional_args " -save_guide_updates -verbose 1"


### PR DESCRIPTION
Detailed route allows passing any option directly to the detailed_route openroad command via the DETAILED_ROUTE_ARGS environment variable. This allows config.mk to pass any option to detailed routing and also external tools, like Autotuner.

The ORFS variables that are in detail_route.tcl now are used by the PDK to provide defaults or from config.mk project files.

This commit was written after a discussion about what ORFS should expose and serves as an example of some careful "Bonasai pruning".

This commit follows the principle that simple common usage should be simple, complicated or uncommon use-cases should be possible.