### PR TITLE
Updated ihp-sg13g2's fill.json

### DIFF
--- a/flow/platforms/ihp-sg13g2/fill.json
+++ b/flow/platforms/ihp-sg13g2/fill.json
@@ -1,113 +1,106 @@
 {
     "layers" : {
         "Metal1" : {
-            "layer":                    8,
-            "name":                    "Metal1",
-            "dir":                     "V",
-            "datatype":                 0,
-            "space_to_outline":         70,
+            "layer": 8,
+            "datatype": 0,
+            "name": "Metal1",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [2.00, 1.00, 0.58, 0.3],
-                "height":               [2.00, 1.00, 0.58, 0.3],
-                "space_to_fill":        0.3,
-                "space_to_non_fill":    3
-            }
-        },
-        
-        "Metal2" : {
-            "layer":                   10,
-            "name":                    "Metal2",
-            "dir":                     "H",
-            "datatype":                 0,
-            "space_to_outline":         70,
-            "non-opc": {
-                "datatype":             0,
-                "width":                [2.00, 1.00, 0.58, 0.3],
-                "height":               [2.00, 1.00, 0.58, 0.3],
-                "space_to_fill":        0.3,
-                "space_to_non_fill":    3
+                "datatype":             22,
+                "width":                [2.0],
+                "height":               [5.0],
+                "space_to_fill":        1.2,
+                "space_to_non_fill":    1.0
             }
         },
 
-        "Metal3" : {
-            "layer":                   30,
-            "name":                    "Metal3",
-            "dir":                     "V",
-            "datatype":                 0,
-            "space_to_outline":         70,
+        "Metal2" : {
+            "layer": 10,
+            "datatype": 0,
+            "name": "Metal2",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [2.00, 1.00, 0.58, 0.4],
-                "height":               [2.00, 1.00, 0.58, 0.4],
-                "space_to_fill":        0.3,
-                "space_to_non_fill":    3
+                "datatype":             22,
+                "width":                [5.0],
+                "height":               [2.0],
+                "space_to_fill":        1.2,
+                "space_to_non_fill":    1.0
+            }
+        },
+        
+        "Metal3" : {
+            "layer": 30,
+            "datatype": 0,
+            "name": "Metal3",
+            "space_to_outline": 60,
+            "non-opc": {
+                "datatype":             22,
+                "width":                [2.0],
+                "height":               [5.0],
+                "space_to_fill":        1.2,
+                "space_to_non_fill":    1.0
             }
         },
         
         "Metal4" : {
-            "layer":                   50,
-            "name":                    "Metal4",
-            "dir":                     "H",
-            "datatype":                 0,
-            "space_to_outline":         70,
+            "layer": 50,
+            "datatype": 0,
+            "name": "Metal4",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [2.00, 1.00, 0.58, 0.4],
-                "height":               [2.00, 1.00, 0.58, 0.4],
-                "space_to_fill":        0.3,
-                "space_to_non_fill":    3.0
+                "datatype":             22,
+                "width":                [5.0],
+                "height":               [2.0],
+                "space_to_fill":        1.2,
+                "space_to_non_fill":    1.0
             }
         },
 
         "Metal5" : {
-            "layer":                   67,
-            "name":                    "Metal5",
-            "dir":                     "V",
-            "datatype":                 0,
-            "space_to_outline":         70,
+            "layer": 67,
+            "datatype": 0,
+            "name": "Metal5",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [3.00],
-                "height":               [3.00],
-                "space_to_fill":        1.6,
-                "space_to_non_fill":    3.0
+                "datatype":             22,
+                "width":                [2.0],
+                "height":               [5.0],
+                "space_to_fill":        1.2,
+                "space_to_non_fill":    1.0
             }
         },
 
         "TopMetal1" : {
-            "layer":                   126,
-            "name":                    "TopMetal1",
-            "dir":                     "H",
-            "datatype":                 0,
-            "space_to_outline":         70,
+            "layer": 126,
+            "datatype": 0,
+            "name": "TopMetal1",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [3.00],
-                "height":               [3.00],
-                "space_to_fill":        1.6,
-                "space_to_non_fill":    3.0
+                "datatype":             22,
+                "width":                [10.0],
+                "height":               [ 5.0],
+                "space_to_fill":        3.0,
+                "space_to_non_fill":    4.9
             }
         },
         
         "TopMetal2" : {
-            "layer":                   134,
-            "name":                    "TopMetal2",
-            "dir":                     "V",
-            "datatype":                 0,
-            "space_to_outline":         70,
+            "layer": 134,
+            "datatype": 0,
+            "name": "TopMetal2",
+            "space_to_outline": 60,
             "non-opc": {
-                "datatype":             0,
-                "width":                [3.00],
-                "height":               [3.00],
-                "space_to_fill":        1.6,
-                "space_to_non_fill":    3.0
+                "datatype":             22,
+                "width":                [ 5.0],
+                "height":               [10.0],
+                "space_to_fill":        3.0,
+                "space_to_non_fill":    4.9
             }
         }
     },
     "outline" : {
-        "layer":                     237,
-        "datatype":                  0
+        "layer": 237,
+        "datatype": 0
     }
 }
 

--- a/flow/platforms/ihp-sg13g2/fill.json
+++ b/flow/platforms/ihp-sg13g2/fill.json
@@ -4,7 +4,7 @@
             "layer": 8,
             "datatype": 0,
             "name": "Metal1",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [2.0],
@@ -18,7 +18,7 @@
             "layer": 10,
             "datatype": 0,
             "name": "Metal2",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [5.0],
@@ -32,7 +32,7 @@
             "layer": 30,
             "datatype": 0,
             "name": "Metal3",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [2.0],
@@ -46,7 +46,7 @@
             "layer": 50,
             "datatype": 0,
             "name": "Metal4",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [5.0],
@@ -60,7 +60,7 @@
             "layer": 67,
             "datatype": 0,
             "name": "Metal5",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [2.0],
@@ -74,7 +74,7 @@
             "layer": 126,
             "datatype": 0,
             "name": "TopMetal1",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [10.0],
@@ -88,7 +88,7 @@
             "layer": 134,
             "datatype": 0,
             "name": "TopMetal2",
-            "space_to_outline": 60,
+            "space_to_outline": 0,
             "non-opc": {
                 "datatype":             22,
                 "width":                [ 5.0],
@@ -99,8 +99,8 @@
         }
     },
     "outline" : {
-        "layer": 237,
-        "datatype": 0
+        "layer": 39,
+        "datatype": 4
     }
 }
 


### PR DESCRIPTION
The `fill.json` for ihp-sg13g2 seemed to just be a copy of sky130hd's for the most part. This pr adjusts the rules to actually follow ihp-sg13g2's design rules:

- ihp-sg13g2 has a GDS layer/datatype specifically for filler shapes: \<layer\>/22
- ihp-sg13g2 recommends "brick"-shaped fillers, i.e. not perfect squares. The exact shapes used now are from IHP's design rule recommendations.
- Adjusted the space to fill/non-fill according to IHP's design rules.
- Removed `dir` from all layers, since that seems to be unused now.

I couldn't figure out what the `outline` & `space_to_outline` stuff does. Before merging, I would like to:

- Confirm that `dir` is actually unused now
- Understand what `outline` is and adjust the rules accordingly