### PR TITLE
ci: disable macos installer due to issues upstream

### DIFF
--- a/.github/workflows/github-actions-cron-test-installer.yml
+++ b/.github/workflows/github-actions-cron-test-installer.yml
@@ -58,24 +58,3 @@ jobs:
             cmd="source /opt/rh/rh-python38/enable; ${cmd}"
           fi
           docker run openroad/flow-${{ matrix.os }}-builder /bin/bash -c "${cmd}"
-  testInstaller-macos:
-    strategy:
-      fail-fast: false
-    runs-on: macos-latest
-    steps:
-      - name: Setup xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: latest-stable
-      - name: Check out repository code
-        uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - name: Run installer
-        shell: bash
-        run: |
-          ./etc/DependencyInstaller.sh
-      - name: Build project
-        shell: bash
-        run: |
-          ./build_openroad.sh --local


### PR DESCRIPTION
The problem is with the linker order and or-tools