### PR TITLE
Memory report

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -458,12 +458,18 @@ synth-report: synth
 do-synth-report:
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_metrics.tcl) 2>&1 | tee -a $(LOG_DIR)/1_1_yosys.log
 
+.PHONY: memory
+memory: $(RESULTS_DIR)/mem.json
+	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
+
 # ==============================================================================
 
 
 # Run Synthesis using yosys
 #-------------------------------------------------------------------------------
-SYNTH_SCRIPT ?= $(SCRIPTS_DIR)/synth.tcl
+
+export SYNTH_SCRIPT ?= $(SCRIPTS_DIR)/synth.tcl
+export SYNTH_MEMORY_MAX_BITS ?= 4096
 
 $(SYNTH_STOP_MODULE_SCRIPT):
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
@@ -484,7 +490,7 @@ yosys-dependencies: $(DONT_USE_LIBS) $(WRAPPED_LIBS) $(DONT_USE_SC_LIB) $(DFF_LI
 
 .PHONY: do-yosys
 do-yosys: yosys-dependencies
-	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
+	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
 	($(TIME_CMD) $(YOSYS_CMD) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(LOG_DIR)/1_1_yosys.log
 
 $(RESULTS_DIR)/1_1_yosys.v: $(SDC_FILE_CLOCK_PERIOD)
@@ -504,7 +510,7 @@ $(RESULTS_DIR)/1_synth.v: $(RESULTS_DIR)/1_1_yosys.v
 
 .PHONY: clean_synth
 clean_synth:
-	rm -f $(RESULTS_DIR)/1_*.v $(RESULTS_DIR)/1_synth.sdc
+	rm -f $(RESULTS_DIR)/1_*.v $(RESULTS_DIR)/1_synth.sdc $(RESULTS_DIR)/mem.json
 	rm -f $(REPORTS_DIR)/synth_*
 	rm -f $(LOG_DIR)/1_*
 	rm -f $(SYNTH_STOP_MODULE_SCRIPT)

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -41,3 +41,7 @@ export SKIP_GATE_CLONING = 1
 export export SETUP_SLACK_MARGIN = 0.2
 
 export GLOBAL_ROUTE_ARGS=-congestion_iterations 100 -verbose
+
+# This is high, some SRAMs should probably be converted
+# to real SRAMs and not instantiated as flops
+export SYNTH_MEMORY_MAX_BITS ?= 42000

--- a/flow/scripts/mem_dump.py
+++ b/flow/scripts/mem_dump.py
@@ -1,0 +1,45 @@
+import argparse
+import json
+import os
+import sys
+
+
+def format_ram_table_from_json(data, max_bits=None):
+    formatting = "{:<15} | {:<15} | {:<15} | {:<50}\n"
+    table = formatting.format("Rows",
+                              "Width",
+                              "Total bits",
+                              "Name")
+    table += "-"*len(table) + "\n"
+    max_ok = True
+    for module_name, module_info in data["modules"].items():
+        cells = module_info["cells"]
+        for memory, cell in cells.items():
+            if not cell["type"].startswith("$mem"):
+                continue
+            parameters = cell["parameters"]
+            size = int(parameters["SIZE"], 2)
+            width = int(parameters["WIDTH"], 2)
+            bits = size * width
+            table += formatting.format(size,
+                                       width,
+                                       bits,
+                                       module_name + "." + memory)
+            if max_bits is not None and bits > max_bits:
+                max_ok = False
+    return table, max_ok
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file")
+    parser.add_argument("-m", "--max-bits", type=int, default=None)
+    args = parser.parse_args()
+
+    with open(args.file, 'r') as file:
+        json_data = json.load(file)
+    formatted_table, max_ok = format_ram_table_from_json(json_data, args.max_bits)
+    print()
+    print(formatted_table)
+    if not max_ok:
+        sys.exit("ERROR: Synthesized memory size exceeds maximum allowed bits " + str(args.max_bits))

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -12,10 +12,7 @@ if { [info exist ::env(SYNTH_GUT)] && $::env(SYNTH_GUT) == 1 } {
   delete $::env(DESIGN_NAME)/c:*
 }
 
-# Generic synthesis
-synth -top $::env(DESIGN_NAME) {*}$::env(SYNTH_ARGS)
-# Get rid of indigestibles
-chformal -remove
+synthesize_check $::env(SYNTH_ARGS)
 
 if { [info exists ::env(USE_LSORACLE)] } {
     set lso_script [open $::env(OBJECTS_DIR)/lso.script w]

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,7 +1,7 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-# Hierarchical synthesis
-synth  -top $::env(DESIGN_NAME)
+synthesize_check {}
+
 if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
   techmap -map $::env(ADDER_MAP_FILE)
 }

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -105,3 +105,14 @@ set constr [open $::env(OBJECTS_DIR)/abc.constr w]
 puts $constr "set_driving_cell $::env(ABC_DRIVER_CELL)"
 puts $constr "set_load $::env(ABC_LOAD_IN_FF)"
 close $constr
+
+proc synthesize_check {synth_args} {
+  # Generic synthesis
+  synth -top $::env(DESIGN_NAME) -run :fine {*}$synth_args
+  json -o $::env(RESULTS_DIR)/mem.json
+  # Run report and check here so as to fail early if this synthesis run is doomed
+  exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
+  synth -top $::env(DESIGN_NAME) -run fine: {*}$synth_args
+  # Get rid of indigestibles
+  chformal -remove
+}


### PR DESCRIPTION
Dusted off some code that @tajayi wrote to create a report of  memories in the design. https://github.com/The-OpenROAD-Project/OpenROAD-flow-original/commits/memGen/
    
Before even trying synthesis, it is useful to know what memories are in the design.
    
Running `make memory`, will do as little synthesis and optimizations  as possible to produce a table of memories.

For a MegaBoom, which would take several days to synthesize without considering memories, this report is generated in ca. 2 minutes:

```
$ make DESIGN_CONFIG=designs/asap7/mem/config.mk memory
[deleted]
Module Name          | Rows            | Width
------------------------------------------------------
mem_128x1            | 128             | 1
meta_128x30          | 128             | 30
```
