### PR TITLE
scripts: DRY

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -57,12 +57,6 @@ if {[info exist ::env(DFF_LIB_FILE)]} {
 }
 opt
 
-
-set constr [open $::env(OBJECTS_DIR)/abc.constr w]
-puts $constr "set_driving_cell $::env(ABC_DRIVER_CELL)"
-puts $constr "set_load $::env(ABC_LOAD_IN_FF)"
-close $constr
-
 puts "abc [join $abc_args " "]"
 abc {*}$abc_args
 
@@ -86,11 +80,6 @@ insbuf -buf {*}$::env(MIN_BUF_CELL_AND_PORTS)
 # Reports
 tee -o $::env(REPORTS_DIR)/synth_check.txt check
 
-# Create argument list for stat
-set stat_libs ""
-foreach lib $::env(DONT_USE_LIBS) {
-  append stat_libs "-liberty $lib "
-}
 tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$stat_libs
 
 # Write synthesized design

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,10 +1,5 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-set constr [open $::env(OBJECTS_DIR)/abc.constr w]
-puts $constr "set_driving_cell $::env(ABC_DRIVER_CELL)"
-puts $constr "set_load $::env(ABC_LOAD_IN_FF)"
-close $constr
-
 # Hierarchical synthesis
 synth  -top $::env(DESIGN_NAME)
 if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
@@ -19,11 +14,6 @@ if {[info exist ::env(DFF_LIB_FILE)]} {
 puts "abc [join $abc_args " "]"
 abc {*}$abc_args
 
-# Create argument list for stat
-set stat_libs ""
-foreach lib $::env(DONT_USE_LIBS) {
-  append stat_libs "-liberty $lib "
-}
 tee -o $::env(REPORTS_DIR)/synth_hier_stat.txt stat {*}$stat_libs
 
 if { [info exist ::env(REPORTS_DIR)] && [file isfile $::env(REPORTS_DIR)/synth_hier_stat.txt] } {

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -87,3 +87,14 @@ if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CL
   }
   close $fp
 }
+
+# Create argument list for stat
+set stat_libs ""
+foreach lib $::env(DONT_USE_LIBS) {
+  append stat_libs "-liberty $lib "
+}
+
+set constr [open $::env(OBJECTS_DIR)/abc.constr w]
+puts $constr "set_driving_cell $::env(ABC_DRIVER_CELL)"
+puts $constr "set_load $::env(ABC_LOAD_IN_FF)"
+close $constr


### PR DESCRIPTION
reduce copy & paste for upcoming changes by extending the use of synth_preamble.tcl