### PR TITLE
read_liberty: unsupress message after reading liberty file

### DIFF
--- a/flow/scripts/read_liberty.tcl
+++ b/flow/scripts/read_liberty.tcl
@@ -23,3 +23,7 @@ if {[info exists ::env(CORNERS)]} {
     read_liberty $libFile
   }
 }
+
+if {[info exists ::env(PLATFORM)] && $::env(PLATFORM) == "asap7"} {
+   unsuppress_message STA 164
+}


### PR DESCRIPTION
this is to get error messages and warnings for reading post synthesis Verilog files.

This suppression is overly broad, but there is only one message number in that neck of the woods.