### PR TITLE
makefile: reproducible/idempotent .sdc files

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -21,7 +21,7 @@ if {[info exist ::env(CTS_CLUSTER_DIAMETER)]} {
 proc save_progress {stage} {
   puts "Run 'make gui_$stage.odb' to load progress snapshot"
   write_db $::env(RESULTS_DIR)/$stage.odb
-  write_sdc $::env(RESULTS_DIR)/$stage.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/$stage.sdc
 }
 
 set cts_args [list \
@@ -130,5 +130,5 @@ if {![info exists save_checkpoint] || $save_checkpoint} {
       write_def $::env(RESULTS_DIR)/4_1_cts.def
   }
   write_db $::env(RESULTS_DIR)/4_1_cts.odb
-  write_sdc $::env(RESULTS_DIR)/4_cts.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/4_cts.sdc
 }

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -164,5 +164,5 @@ if {![info exists save_checkpoint] || $save_checkpoint} {
       write_def $::env(RESULTS_DIR)/2_1_floorplan.def
   }
   write_db $::env(RESULTS_DIR)/2_1_floorplan.odb
-  write_sdc $::env(RESULTS_DIR)/2_floorplan.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/2_floorplan.sdc
 }

--- a/flow/scripts/write_ref_sdc.tcl
+++ b/flow/scripts/write_ref_sdc.tcl
@@ -25,7 +25,7 @@ if { [llength $clks] == 0 } {
       create_clock -name $clk_name -period $ref_period $sources
       # Undo the set_propagated_clock so SDC at beginning of flow uses ideal clocks.
       unset_propagated_clock [all_clocks]
-      write_sdc [file join $env(RESULTS_DIR) "updated_clks.sdc"]
+      write_sdc -no_timestamp [file join $env(RESULTS_DIR) "updated_clks.sdc"]
       # Reset
       create_clock -name $clk_name -period $period $sources
       set_propagated_clock [all_clocks]


### PR DESCRIPTION
This speeds up builds enormously when .sdc file hasn't actually changed in bazel, such as when fixing comments in the SDC_FILE, those comments are not in the canonical .sdc file form written out by write_sdc.