### PR TITLE
Makefile floorplan sdc canonical form

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -490,9 +490,15 @@ do-yosys: yosys-dependencies
 $(RESULTS_DIR)/1_1_yosys.v: $(SDC_FILE_CLOCK_PERIOD)
 	$(UNSET_AND_MAKE) do-yosys
 
-$(RESULTS_DIR)/1_synth.sdc: $(SDC_FILE)
-	mkdir -p $(REPORTS_DIR)
-	cp $(SDC_FILE) $(RESULTS_DIR)/1_synth.sdc
+$(RESULTS_DIR)/1_synth.sdc: $(SDC_FILE) $(RESULTS_DIR)/1_1_yosys.v
+	$(UNSET_AND_MAKE) do-synth-sdc
+
+.PHONY: do-synth-sdc
+do-synth-sdc:
+	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
+	cp $(RESULTS_DIR)/1_1_yosys.v $(RESULTS_DIR)/1_synth.v
+	cp $(SDC_FILE) $(RESULTS_DIR)/1_1_yosys.sdc
+	$(OPENROAD_CMD) $(SCRIPTS_DIR)/write-sdc.tcl
 
 .PHONY: do-synth
 do-synth:

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -21,7 +21,7 @@ if {[info exist ::env(CTS_CLUSTER_DIAMETER)]} {
 proc save_progress {stage} {
   puts "Run 'make gui_$stage.odb' to load progress snapshot"
   write_db $::env(RESULTS_DIR)/$stage.odb
-  write_sdc $::env(RESULTS_DIR)/$stage.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/$stage.sdc
 }
 
 set cts_args [list \
@@ -130,5 +130,5 @@ if {![info exists save_checkpoint] || $save_checkpoint} {
       write_def $::env(RESULTS_DIR)/4_1_cts.def
   }
   write_db $::env(RESULTS_DIR)/4_1_cts.odb
-  write_sdc $::env(RESULTS_DIR)/4_cts.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/4_cts.sdc
 }

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -164,5 +164,5 @@ if {![info exists save_checkpoint] || $save_checkpoint} {
       write_def $::env(RESULTS_DIR)/2_1_floorplan.def
   }
   write_db $::env(RESULTS_DIR)/2_1_floorplan.odb
-  write_sdc $::env(RESULTS_DIR)/2_floorplan.sdc
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/2_floorplan.sdc
 }

--- a/flow/scripts/write-sdc.tcl
+++ b/flow/scripts/write-sdc.tcl
@@ -1,0 +1,3 @@
+source $::env(SCRIPTS_DIR)/load.tcl
+load_design 1_1_yosys.v 1_1_yosys.sdc
+write_sdc -no_timestamp $::env(RESULTS_DIR)/1_synth.sdc

--- a/flow/scripts/write_ref_sdc.tcl
+++ b/flow/scripts/write_ref_sdc.tcl
@@ -25,7 +25,7 @@ if { [llength $clks] == 0 } {
       create_clock -name $clk_name -period $ref_period $sources
       # Undo the set_propagated_clock so SDC at beginning of flow uses ideal clocks.
       unset_propagated_clock [all_clocks]
-      write_sdc [file join $env(RESULTS_DIR) "updated_clks.sdc"]
+      write_sdc -no_timestamp [file join $env(RESULTS_DIR) "updated_clks.sdc"]
       # Reset
       create_clock -name $clk_name -period $period $sources
       set_propagated_clock [all_clocks]


### PR DESCRIPTION
This speeds up builds because it avoids unecessary rebuilds and also removes any source dependencies that SDC_FILE has, such as a utility.tcl are not then also source file dependencies for floorplan.
    
