### PR TITLE
[DO NOT MERGE] synthesis: minimal synthesis to drive MAX_UNGROUP_SIZE policy

### DIFF
--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,7 +1,20 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-# Hierarchical synthesis
-synth  -top $::env(DESIGN_NAME)
+# Minimal hierarchical synthesis to get rough area numbers to drive
+# the MAX_UNGROUP_SIZE policy.
+synth -run :coarse -top $::env(DESIGN_NAME)
+# These commands are cherry-picked from the "synth -run coarse:" list
+# of commands in the Yosys manual.
+#
+# 'proc' pass is called 'procs' to avoid conflict with tcl 'proc' command
+procs
+memory -nomap
+memory_map
+techmap
+hierarchy -check
+stat
+check
+
 if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
   techmap -map $::env(ADDER_MAP_FILE)
 }


### PR DESCRIPTION
As long as the technology map has to be run, which one has to do in order to get area estimates, there is no substantial gain in build times.
