### PR TITLE
make issue: default to full issue

### DIFF
--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -92,10 +92,10 @@ fi
 echo "Using $COMPRESS to compress tar file"
 
 # Save all files inside design and platform folders
-if [ -v FULL_ISSUE ]; then
-    DESIGN_PLATFORM_FILES="$DESIGN_DIR $PLATFORM_DIR"
-else
+if [ -v SMALL_ISSUE ]; then
     DESIGN_PLATFORM_FILES="$DESIGN_DIR/config.mk $PLATFORM_DIR/config.mk"
+else
+    DESIGN_PLATFORM_FILES="$DESIGN_DIR $PLATFORM_DIR"
 fi
 
 set -x


### PR DESCRIPTION
There are very few small uncomplicated test-cases these days.

The biggest size saver is to manually prune .odb files that are not needed, which has to be done manually anyway.