### PR TITLE
mock-array: move util.tcl into source

### DIFF
--- a/flow/designs/asap7/mock-array/Element/io.tcl
+++ b/flow/designs/asap7/mock-array/Element/io.tcl
@@ -1,4 +1,4 @@
-source designs/asap7/mock-array/util.tcl
+source designs/src/mock-array/util.tcl
 
 set assignments [list \
     top bottom \

--- a/flow/designs/asap7/mock-array/io.tcl
+++ b/flow/designs/asap7/mock-array/io.tcl
@@ -1,4 +1,4 @@
-source designs/asap7/mock-array/util.tcl
+source designs/src/mock-array/util.tcl
 
 set assignments [list \
     top \

--- a/flow/designs/src/mock-array/util.tcl
+++ b/flow/designs/src/mock-array/util.tcl
@@ -35,13 +35,19 @@ proc natural_sort {list} {
     return [lsort -command natural_compare $list]
 }
 
-proc match_pins { regex } {
+proc match_pins { regex {direction .*} {is_clock 0}} {
     set pins {}
     # The regex for get_ports is not the tcl regex
     foreach pin [get_ports -regex .*] {
         set input [get_property $pin name]
         # We want the Tcl regex
         if {![regexp $regex $input]} {
+            continue
+        }
+        if {![regexp $direction [get_property $pin direction]]} {
+            continue
+        }
+        if {[expr $is_clock != [sta::is_clock_src [sta::get_port_pin $pin]]]} {
             continue
         }
         lappend pins [get_property $pin name]


### PR DESCRIPTION
This reduces complexity of upcoming pull requests and is congruent with placing all non-asap7 specific code in designs/src.