### PR TITLE
Added aarch64 architecture support for Ubuntu 22.04

### DIFF
--- a/docs/user/BuildLocally.md
+++ b/docs/user/BuildLocally.md
@@ -4,7 +4,7 @@
 
 The `setup.sh` script installs all of the dependencies, including OpenROAD dependencies, if they are not already installed.
 
-Supported configurations are: CentOS 7, Ubuntu 20.04, Ubuntu 22.04, RHEL 8,
+Supported configurations are: CentOS 7, Ubuntu 20.04, Ubuntu 22.04, Ubuntu 22.04(aarch64), RHEL 8,
 Debian 10 and Debian 11.
 
 ``` shell

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -86,20 +86,29 @@ _installUbuntuPackages() {
     if _versionCompare $1 -ge 23.04; then
         apt-get install klayout python3-pandas
     else
-        if [[ $1 == 20.04 ]]; then
-            klayoutChecksum=15a26f74cf396d8a10b7985ed70ab135
-        else
-            klayoutChecksum=db751264399706a23d20455bb7624264
-        fi
+        arch=$(uname -m)
         lastDir="$(pwd)"
         # temp dir to download and compile
         baseDir=/tmp/installers
         mkdir -p "${baseDir}"
-        cd ${baseDir}
-        wget https://www.klayout.org/downloads/Ubuntu-${1%.*}/klayout_${klayoutVersion}-1_amd64.deb
-        md5sum -c <(echo "${klayoutChecksum} klayout_${klayoutVersion}-1_amd64.deb") || exit 1
-        dpkg -i klayout_${klayoutVersion}-1_amd64.deb
-        cd ${lastDir}
+        cd "${baseDir}"
+        if [[ $arch == "aarch64" ]]; then
+            echo "Installing KLayout for aarch64 architecture"
+            installDir="/usr/local/bin"
+            git clone https://github.com/KLayout/klayout.git
+            cd klayout
+            ./build.sh -bin "${installDir}"
+        else
+            if [[ $1 == 20.04 ]]; then
+                klayoutChecksum=15a26f74cf396d8a10b7985ed70ab135
+            else
+                klayoutChecksum=db751264399706a23d20455bb7624264
+            fi
+            wget https://www.klayout.org/downloads/Ubuntu-${1%.*}/klayout_${klayoutVersion}-1_amd64.deb
+            md5sum -c <(echo "${klayoutChecksum} klayout_${klayoutVersion}-1_amd64.deb") || exit 1
+            dpkg -i klayout_${klayoutVersion}-1_amd64.deb
+        fi
+        cd "${lastDir}"
         rm -rf "${baseDir}"
     fi
 }

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -67,6 +67,19 @@ _installUbuntuCleanUp() {
     apt-get autoremove -y
 }
 
+_installKlayoutDependenciesUbuntuAarch64() {
+    echo "Updating package lists"
+    sudo apt-get update
+    export DEBIAN_FRONTEND=noninteractive
+    sudo apt-get install -y build-essential
+    sudo apt-get install -y qtbase5-dev qttools5-dev libqt5xmlpatterns5-dev qtmultimedia5-dev libqt5multimediawidgets5 libqt5svg5-dev
+    sudo apt-get install -y ruby ruby-dev
+    sudo apt-get install -y python3 python3-dev
+    sudo apt-get install -y libz-dev
+    sudo apt-get install -y libgit2-dev
+    echo "All dependencies installed successfully"
+}
+
 _installUbuntuPackages() {
     export DEBIAN_FRONTEND="noninteractive"
     apt-get -y update
@@ -90,15 +103,16 @@ _installUbuntuPackages() {
         lastDir="$(pwd)"
         # temp dir to download and compile
         baseDir=/tmp/installers
+        klayoutPrefix=${PREFIX:-"/usr/local"}
         mkdir -p "${baseDir}"
         cd "${baseDir}"
         if [[ $arch == "aarch64" ]]; then
-        if [ ! -f /usr/local/bin/klayout ]; then
+        if [ ! -f ${klayoutPrefix}/klayout ]; then
+            _installKlayoutDependenciesUbuntuAarch64
             echo "Installing KLayout for aarch64 architecture"
-            installDir="/usr/local/bin"
             git clone https://github.com/KLayout/klayout.git
             cd klayout
-            ./build.sh -bin "${installDir}"
+            ./build.sh -bin "${klayoutPrefix}"
         else
             echo "Klayout is already installed"
         fi

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -93,11 +93,15 @@ _installUbuntuPackages() {
         mkdir -p "${baseDir}"
         cd "${baseDir}"
         if [[ $arch == "aarch64" ]]; then
+        if [ ! -f /usr/local/bin/klayout ]; then
             echo "Installing KLayout for aarch64 architecture"
             installDir="/usr/local/bin"
             git clone https://github.com/KLayout/klayout.git
             cd klayout
             ./build.sh -bin "${installDir}"
+        else
+            echo "Klayout is already installed"
+        fi
         else
             if [[ $1 == 20.04 ]]; then
                 klayoutChecksum=15a26f74cf396d8a10b7985ed70ab135

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -68,15 +68,15 @@ _installUbuntuCleanUp() {
 }
 
 _installKlayoutDependenciesUbuntuAarch64() {
-    echo "Updating package lists"
-    sudo apt-get update
+    echo "Installing Klayout dependancies"
     export DEBIAN_FRONTEND=noninteractive
-    sudo apt-get install -y build-essential
-    sudo apt-get install -y qtbase5-dev qttools5-dev libqt5xmlpatterns5-dev qtmultimedia5-dev libqt5multimediawidgets5 libqt5svg5-dev
-    sudo apt-get install -y ruby ruby-dev
-    sudo apt-get install -y python3 python3-dev
-    sudo apt-get install -y libz-dev
-    sudo apt-get install -y libgit2-dev
+    apt-get -y update
+    apt-get -y install  build-essential \
+                        qtbase5-dev qttools5-dev libqt5xmlpatterns5-dev qtmultimedia5-dev libqt5multimediawidgets5 libqt5svg5-dev \
+                        ruby ruby-dev \
+                        python3 python3-dev \
+                        libz-dev\
+                        libgit2-dev
     echo "All dependencies installed successfully"
 }
 
@@ -107,14 +107,14 @@ _installUbuntuPackages() {
         mkdir -p "${baseDir}"
         cd "${baseDir}"
         if [[ $arch == "aarch64" ]]; then
-        if [ ! -f ${klayoutPrefix}/klayout ]; then
-            _installKlayoutDependenciesUbuntuAarch64
-            echo "Installing KLayout for aarch64 architecture"
-            git clone https://github.com/KLayout/klayout.git
-            cd klayout
-            ./build.sh -bin "${klayoutPrefix}"
-        else
-            echo "Klayout is already installed"
+            if [ ! -f ${klayoutPrefix}/klayout ]; then
+                _installKlayoutDependenciesUbuntuAarch64
+                echo "Installing KLayout for aarch64 architecture"
+                git clone https://github.com/KLayout/klayout.git
+                cd klayout
+                ./build.sh -bin "${klayoutPrefix}"
+            else
+                echo "Klayout is already installed"
         fi
         else
             if [[ $1 == 20.04 ]]; then


### PR DESCRIPTION
The following has been done:

- Modified the Klayout tools installation process to dynamically clone and build it from source since there are no prebuilt binaries available for the "aarch64" architecture.

- The modification has been developed and tested successfully on an AWS Graviton (aarch64) instance using the following specifications: Instance type - t4g.xlarge (4 vCPU, 16 GiB Memory), Storage - 128 GiB.

Integration with Other Changes:

This pull request is associated with another changes in the OpenROAD  repository. Specifically, adjustments were made in the DependancyInstaller.sh script to accommodate dependencies for the aarch64 architecture. Further details and the link to the related pull request will be provided in the comments.