### PR TITLE
mock-array: remove -distance_between_buffers 60

### DIFF
--- a/flow/designs/asap7/mock-array/Element/config.mk
+++ b/flow/designs/asap7/mock-array/Element/config.mk
@@ -44,4 +44,4 @@ export PLACE_PINS_ARGS = -annealing
 export GND_NETS_VOLTAGES      =
 export PWR_NETS_VOLTAGES      =
 
-export CTS_ARGS = -insertion_delay -sink_clustering_enable -balance_levels -distance_between_buffers 60
+export CTS_ARGS = -insertion_delay -sink_clustering_enable -balance_levels

--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -60,4 +60,4 @@ export MACRO_HALO_Y            = 0.5
 export GND_NETS_VOLTAGES      =
 export PWR_NETS_VOLTAGES      =
 
-export CTS_ARGS = -insertion_delay -sink_clustering_enable -balance_levels -distance_between_buffers 60
+export CTS_ARGS = -insertion_delay -sink_clustering_enable -balance_levels


### PR DESCRIPTION
picked up by accident, asap7 no longer has this as a default