### PR TITLE
Flow: Use Yosys/abc native functions for dont_use

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -313,10 +313,12 @@ endif
 WRAPPED_LEFS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/lef/$(lef:.lef=_mod.lef))
 WRAPPED_LIBS = $(foreach lib,$(notdir $(WRAP_LIBS)),$(OBJECTS_DIR)/$(lib:.lib=_mod.lib))
 export ADDITIONAL_LEFS += $(WRAPPED_LEFS) $(WRAP_LEFS)
-export LIB_FILES += $(WRAP_LIBS) $(WRAPPED_LIBS)
 
-export DONT_USE_LIBS   = $(patsubst %.lib.gz, %.lib, $(addprefix $(OBJECTS_DIR)/lib/, $(notdir $(LIB_FILES))))
-export DONT_USE_SC_LIB ?= $(firstword $(DONT_USE_LIBS))
+export LIB_FILES += $(WRAP_LIBS) $(WRAPPED_LIBS)
+export DECOMPRESSED_LIBS = $(patsubst %.lib.gz, %.lib, $(addprefix $(OBJECTS_DIR)/lib/, $(notdir $(LIB_FILES))))
+
+# Assume the first lib file is the standard cell lib
+export DECOMPRESSED_SC_LIB ?= $(firstword $(DECOMPRESSED_LIBS))
 
 # Stream system used for final result (GDS is default): GDS, GSDII, GDS2, OASIS, or OAS
 STREAM_SYSTEM ?= GDS
@@ -371,15 +373,19 @@ versions.txt:
 # Pre-process libraries
 # ==============================================================================
 
-# Create temporary Liberty files which have the proper dont_use properties set
-# For use with Yosys and ABC
+# Unzip any compressed Liberty files
 .SECONDEXPANSION:
-$(DONT_USE_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
-	@mkdir -p $(OBJECTS_DIR)/lib
-	$(UTILS_DIR)/markDontUse.py -p "$(DONT_USE_CELLS)" -i $^ -o $@
+$(DECOMPRESSED_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
+	mkdir -p $(OBJECTS_DIR)/lib
+	if [[ $^ == *.gz ]]; then \
+	  gunzip -c $^ > $@; \
+	else \
+	  ln -s $$(realpath --relative-to=$(dir $@) $^) $@; \
+	fi
 
-$(OBJECTS_DIR)/lib/merged.lib:
-	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $(DONT_USE_LIBS) > $@
+# Create merged Liberty file for use with Yosys and ABC
+$(OBJECTS_DIR)/lib/merged.lib: $(DECOMPRESSED_LIBS)
+	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $^ > $@
 
 # Pre-process KLayout tech
 # ==============================================================================
@@ -480,7 +486,7 @@ $(SDC_FILE_CLOCK_PERIOD): $(SDC_FILE)
 	echo $(ABC_CLOCK_PERIOD_IN_PS) > $@
 
 .PHONY: yosys-dependencies
-yosys-dependencies: $(DONT_USE_LIBS) $(WRAPPED_LIBS) $(DONT_USE_SC_LIB) $(DFF_LIB_FILE) $(VERILOG_FILES) $(CACHED_NETLIST) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE)
+yosys-dependencies: $(DECOMPRESSED_LIBS) $(WRAPPED_LIBS) $(DECOMPRESSED_SC_LIB) $(DFF_LIB_FILE) $(VERILOG_FILES) $(CACHED_NETLIST) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE)
 
 .PHONY: do-yosys
 do-yosys: yosys-dependencies

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -275,7 +275,8 @@ export LIB_DIRS              += $($(CORNER)_LIB_DIRS)
 export DB_FILES              += $(realpath $($(CORNER)_DB_FILES))
 export TEMPERATURE            = $($(CORNER)_TEMPERATURE)
 export VOLTAGE                = $($(CORNER)_VOLTAGE)
-export DONT_USE_SC_LIB        = $(OBJECTS_DIR)/lib/merged.lib
+export DECOMPRESSED_SC_LIB    = $(OBJECTS_DIR)/lib/merged.lib
+export DFF_LIB_FILE           = $($(CORNER)_DFF_LIB_FILE)
 
 # ---------------------------------------------------------
 #  IR Drop

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -90,7 +90,7 @@ if { [info exist ::env(RESYNTH_TIMING_RECOVER)] && $::env(RESYNTH_TIMING_RECOVER
 
   write_verilog $::env(RESULTS_DIR)/2_pre_abc_timing.v
 
-  restructure -target timing -liberty_file $::env(DONT_USE_SC_LIB) \
+  restructure -target timing -liberty_file $::env(DECOMPRESSED_SC_LIB) \
               -work_dir $::env(RESULTS_DIR)
 
   write_verilog $::env(RESULTS_DIR)/2_post_abc_timing.v
@@ -136,7 +136,7 @@ if { [info exist ::env(RESYNTH_AREA_RECOVER)] && $::env(RESYNTH_AREA_RECOVER) ==
   set tiehi_lib_name [get_name [get_property [lindex [get_lib_cell $tiehi_cell_name] 0] library]]
   set tiehi_port $tiehi_lib_name/$tiehi_cell_name/[lindex $env(TIEHI_CELL_AND_PORT) 1]
 
-  restructure -liberty_file $::env(DONT_USE_SC_LIB) -target "area" \
+  restructure -liberty_file $::env(DECOMPRESSED_SC_LIB) -target "area" \
         -tiehi_port $tiehi_port \
         -tielo_port $tielo_port \
         -work_dir $::env(RESULTS_DIR)

--- a/flow/scripts/sc/tools/openroad/sc_apr.tcl
+++ b/flow/scripts/sc/tools/openroad/sc_apr.tcl
@@ -27,13 +27,17 @@ set inputs [list]
 # Step-specific pre-processing step(s)
 #if {$sc_step == "or_synth_hier_report"} {
 if {$sc_step == "or_synth"} {
-    # Pre-synthesis: mark dont-use cells in liberty files, and merge them.
+    # Pre-synthesis: decompress liberty files, and merge them.
     foreach f [split $::env(LIB_FILES)] {
-        exec $::env(UTILS_DIR)/markDontUse.py -p $::env(DONT_USE_CELLS) -i $f -o "../../[file tail $f]-mod.lib"
+        if {[file extension $f] == .gz} {
+            exec gunzip -c $f > "../../[file tail $f]-mod.lib"
+        } else {
+            file link -symbolic $f "../../[file tail $f]-mod.lib"
+        }
     }
     set merge_cmd $::env(UTILS_DIR)/mergeLib.pl
     lappend merge_cmd $::env(PLATFORM)_merged
-    foreach ff [regexp -all -inline {\S+} $::env(DONT_USE_LIBS)] {
+    foreach ff [regexp -all -inline {\S+} $::env(DECOMPRESSED_LIBS)] {
         lappend merge_cmd $ff
     }
     exec {*}$merge_cmd > ../../merged.lib

--- a/flow/scripts/sc/util/parse_target_config.py
+++ b/flow/scripts/sc/util/parse_target_config.py
@@ -136,8 +136,8 @@ def parse(chip, platform):
         dontuse_l = []
         for lf in libs:
             dontuse_l.append(os.path.join(mod_lib_base, f'{os.path.split(lf)[1]}-mod.lib'))
-        merged_config['DONT_USE_LIBS'] = ' '.join(dontuse_l)
-        merged_config['DONT_USE_SC_LIB'] = os.path.join('..', '..', 'merged.lib')
+        merged_config['DECOMPRESSED_LIBS'] = ' '.join(dontuse_l)
+        merged_config['DECOMPRESSED_SC_LIB'] = os.path.join('..', '..', 'merged.lib')
 
         # Set config environment values to be set during sc flow.
         for key, val in merged_config.items():

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -53,7 +53,7 @@ if {[info exist ::env(LATCH_MAP_FILE)]} {
 if {[info exist ::env(DFF_LIB_FILE)]} {
   dfflibmap -liberty $::env(DFF_LIB_FILE)
 } else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB)
+  dfflibmap -liberty $::env(DECOMPRESSED_SC_LIB)
 }
 opt
 

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -9,7 +9,7 @@ techmap
 if {[info exist ::env(DFF_LIB_FILE)]} {
   dfflibmap -liberty $::env(DFF_LIB_FILE)
 } else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB)
+  dfflibmap -liberty $::env(DECOMPRESSED_SC_LIB)
 }
 puts "abc [join $abc_args " "]"
 abc {*}$abc_args

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -28,7 +28,7 @@ foreach file $::env(VERILOG_FILES) {
 
 # Read standard cells and macros as blackbox inputs
 # These libs have their dont_use properties set accordingly
-read_liberty -lib {*}$::env(DONT_USE_LIBS)
+read_liberty -lib {*}$::env(DECOMPRESSED_LIBS)
 
 # Apply toplevel parameters (if exist)
 if {[info exist ::env(VERILOG_TOP_PARAMS)]} {
@@ -74,8 +74,15 @@ if {$::env(ABC_AREA)} {
 # Technology mapping for cells
 # ABC supports multiple liberty files, but the hook from Yosys to ABC doesn't
 set abc_args [list -script $abc_script \
-      -liberty $::env(DONT_USE_SC_LIB) \
+      -liberty $::env(DECOMPRESSED_SC_LIB) \
       -constr $::env(OBJECTS_DIR)/abc.constr]
+
+# Exclude dont_use cells
+if {[info exist ::env(DONT_USE_CELLS)] && $::env(DONT_USE_CELLS) != ""} {
+  foreach cell $::env(DONT_USE_CELLS) {
+    lappend abc_args -dont_use $cell
+  }
+}
 
 if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CLOCK_PERIOD)]} {
   puts "\[FLOW\] Extracting clock period from SDC file: $::env(SDC_FILE_CLOCK_PERIOD)"
@@ -90,7 +97,7 @@ if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CL
 
 # Create argument list for stat
 set stat_libs ""
-foreach lib $::env(DONT_USE_LIBS) {
+foreach lib $::env(DECOMPRESSED_LIBS) {
   append stat_libs "-liberty $lib "
 }
 


### PR DESCRIPTION
* Change the Makefile target for `DONT_USE_LIBS` to `DECOMPRESSED_LIBS`
  * Removes the call to markDontUse.py, replaces it with either gunzip or ln
* Switch yosys/abc to use the "dont use" flags available
* Switch all uses of `DONT_USE_SC_LIB` to `SC_LIB`
* Add missing `DFF_LIB_FILE` var to asap7


Closes #1502