### PR TITLE
syn: move dont_use processing to yosys

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -376,7 +376,7 @@ versions.txt:
 .SECONDEXPANSION:
 $(DONT_USE_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
 	@mkdir -p $(OBJECTS_DIR)/lib
-	$(UTILS_DIR)/markDontUse.py -p "$(DONT_USE_CELLS)" -i $^ -o $@
+	$(UTILS_DIR)/preprocessLib.py -i $^ -o $@
 
 $(OBJECTS_DIR)/lib/merged.lib:
 	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $(DONT_USE_LIBS) > $@

--- a/flow/scripts/sc/tools/openroad/sc_apr.tcl
+++ b/flow/scripts/sc/tools/openroad/sc_apr.tcl
@@ -29,7 +29,7 @@ set inputs [list]
 if {$sc_step == "or_synth"} {
     # Pre-synthesis: mark dont-use cells in liberty files, and merge them.
     foreach f [split $::env(LIB_FILES)] {
-        exec $::env(UTILS_DIR)/markDontUse.py -p $::env(DONT_USE_CELLS) -i $f -o "../../[file tail $f]-mod.lib"
+        exec $::env(UTILS_DIR)/preprocessLib.py -i $f -o "../../[file tail $f]-mod.lib"
     }
     set merge_cmd $::env(UTILS_DIR)/mergeLib.pl
     lappend merge_cmd $::env(PLATFORM)_merged

--- a/flow/scripts/sc/util/parse_target_config.py
+++ b/flow/scripts/sc/util/parse_target_config.py
@@ -128,7 +128,7 @@ def parse(chip, platform):
         index = '0'
         tool = chip.get('flowgraph', 'orflow', step, index, 'tool')
         # "Don't use" libraries get pre-processed. TODO: Currently placed in build dir root.
-        # Also, 'markDontUse.py' is called from TCL; might be easier to do that pp here.
+        # Also, 'preprocessLib.py' is called from TCL; might be easier to do that pp here.
         mod_lib_base = os.path.abspath(os.path.join(chip.get('option', 'builddir'),
                                                     config['DESIGN_NAME'],
                                                     chip.get('option', 'jobname')))

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -53,12 +53,17 @@ if {[info exist ::env(LATCH_MAP_FILE)]} {
 # At least this is predictable.
 renames -wire
 
+set dfflibmap_args ""
+foreach cell $::env(DONT_USE_CELLS) {
+  lappend dfflibmap_args -dont_use $cell
+}
+
 # Technology mapping of flip-flops
 # dfflibmap only supports one liberty file
 if {[info exist ::env(DFF_LIB_FILE)]} {
-  dfflibmap -liberty $::env(DFF_LIB_FILE)
+  dfflibmap -liberty $::env(DFF_LIB_FILE) {*}$dfflibmap_args
 } else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB)
+  dfflibmap -liberty $::env(DONT_USE_SC_LIB) {*}$dfflibmap_args
 }
 opt
 

--- a/flow/util/preprocessLib.py
+++ b/flow/util/preprocessLib.py
@@ -7,18 +7,13 @@ import argparse  # argument parsing
 # Parse and validate arguments
 # ==============================================================================
 parser = argparse.ArgumentParser(
-    description='Replaces occurrences of cells in def or verilog files')
-parser.add_argument('--patterns', '-p', required=True,
-                    help='List of search patterns')
+    description='Preprocesses Liberty files for compatibility with yosys/abc')
 parser.add_argument('--inputFile', '-i', required=True,
                     help='Input File')
 parser.add_argument('--outputFile', '-o', required=True,
                     help='Output File')
 args = parser.parse_args()
 
-
-# Convert * wildcards to regex wildcards
-patternList = args.patterns.replace('*','.*').split()
 
 # Read input file
 print("Opening file for replace:",args.inputFile)
@@ -28,15 +23,6 @@ else:
     f = open(args.inputFile, encoding="utf-8")
 content = f.read().encode("ascii", "ignore").decode("ascii")
 f.close()
-
-# Pattern to match a cell header
-pattern = r"(^\s*cell\s*\(\s*([\"]*"+"[\"]*|[\"]*".join(patternList)+"[\"]*)\)\s*\{)"
-
-# print(pattern)
-replace = r"\1\n    dont_use : true;"
-content, count = re.subn(pattern, replace, content, 0, re.M)
-print("Marked", count, "cells as dont_use")
-
 
 # Yosys-abc throws an error if original_pin is found within the liberty file.
 # removing


### PR DESCRIPTION
* Use new `dont_use` flag for `dfflibmap`
* Remove `dont_use` preprocessing from `markDontUse.py`
* Rename `markDontUse.py` to `preprocessLib.py`

This change requires a sync from upstream yosys. Support was added in https://github.com/YosysHQ/yosys/pull/4219; it should be upstream next month in yosys 0.39. Alternatively, we could update yosys immediately.