### PR TITLE
docker_shell: connect container to host network

### DIFF
--- a/flow/util/docker_shell
+++ b/flow/util/docker_shell
@@ -28,6 +28,7 @@ docker run -u $(id -u ${USER}):$(id -g ${USER}) \
  -e FLOW_HOME=/OpenROAD-flow-scripts/flow/ \
  -e MAKEFILES=/OpenROAD-flow-scripts/flow/Makefile \
  -v $WORKSPACE:`pwd` \
+ --network host \
  $DOCKER_INTERACTIVE \
  ${OR_IMAGE:-openroad/flow-centos7-builder:latest} \
  bash -c "set -ex


### PR DESCRIPTION
This is a similar problem to the one described in https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1123#issuecomment-1582025520.
This PR fixes issue with running GUI targets through [docker_shell](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/flow/util/docker_shell).  My attempts to run e.g.:
```
[flow]% ./util/docker_shell make gui_cts
```
failed with the following error message:
```
qt.qpa.screen: QXcbConnection: Could not connect to display :0                                                                                
Could not connect to any X display.                                                                                                           
make: *** [gui_4_cts.odb] Error 1 
```

Adding `--network host` to `docker run` call in `docker_shell` fixed this for me.