### PR TITLE
docker_shell: Change default docker image to ubuntu 22.04

### DIFF
--- a/flow/util/docker_shell
+++ b/flow/util/docker_shell
@@ -29,7 +29,7 @@ docker run -u $(id -u ${USER}):$(id -g ${USER}) \
  -e MAKEFILES=/OpenROAD-flow-scripts/flow/Makefile \
  -v $WORKSPACE:`pwd` \
  $DOCKER_INTERACTIVE \
- ${OR_IMAGE:-openroad/flow-centos7-builder:latest} \
+ ${OR_IMAGE:-openroad/flow-ubuntu22.04-builder:latest} \
  bash -c "set -ex
  mkdir /tmp/xdg-run
  . ./env.sh


### PR DESCRIPTION
With https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/08c0a549d2d84bfefa84d3b16454856ed515eca7 the default docker image was changed to ubuntu 22.04. It also makes sense to change the default docker image in `docker_shell` script.
