### PR TITLE
make: less verbose output

### DIFF
--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -2,3 +2,4 @@ settings.mk
 vars.sh
 vars.gdb
 vars.tcl
+copyright.txt

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -537,8 +537,8 @@ SUB_MAKE = $(MAKE) $(foreach V,$(COMMAND_LINE_ARGS), $(if $($V),$V=$(shell echo 
 UNSET_AND_MAKE = @bash -c '$(UNSET_VARS); $(SUB_MAKE) $$@' --
 
 copyright.txt:
-	$(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl
-	touch copyright.txt
+	@$(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl
+	@touch copyright.txt
 
 # Separate dependency checking and doing a step. This can
 # be useful to retest a stage without having to delete the

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -537,7 +537,7 @@ SUB_MAKE = $(MAKE) $(foreach V,$(COMMAND_LINE_ARGS), $(if $($V),$V=$(shell echo 
 UNSET_AND_MAKE = @bash -c '$(UNSET_VARS); $(SUB_MAKE) $$@' --
 
 copyright.txt:
-	$(OPENROAD_CMD) -exit
+	$(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl
 	touch copyright.txt
 
 # Separate dependency checking and doing a step. This can
@@ -569,8 +569,8 @@ define do-step
 $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 	$$(UNSET_AND_MAKE) do-$(1)
 
-.PHONY: do-$(1) copyright.txt
-do-$(1):
+.PHONY: do-$(1)
+do-$(1): copyright.txt
 	@echo Running $(3).tcl
 	@(trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
 	 $(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -536,6 +536,10 @@ UNSET_VARS = for var in $(UNSET_VARIABLES_NAMES); do unset $$var; done
 SUB_MAKE = $(MAKE) $(foreach V,$(COMMAND_LINE_ARGS), $(if $($V),$V=$(shell echo "$($V)" | $(FLOW_HOME)/scripts/escape.sh),$V='')) --no-print-directory DESIGN_CONFIG=$(DESIGN_CONFIG)
 UNSET_AND_MAKE = @bash -c '$(UNSET_VARS); $(SUB_MAKE) $$@' --
 
+copyright.txt:
+	$(OPENROAD_CMD) -exit
+	touch copyright.txt
+
 # Separate dependency checking and doing a step. This can
 # be useful to retest a stage without having to delete the
 # target, or when building a wafer thin layer on top of
@@ -565,11 +569,13 @@ define do-step
 $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 	$$(UNSET_AND_MAKE) do-$(1)
 
-.PHONY: do-$(1)
+.PHONY: do-$(1) copyright.txt
 do-$(1):
-	(trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
-	 $(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json) 2>&1 | \
-	 tee $(LOG_DIR)/$(1).tmp.log
+	@echo Running $(3).tcl
+	@(trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
+	 $(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
+	 $(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \
+	 tee -a $(LOG_DIR)/$(1).tmp.log)
 endef
 
 # generate make rules to copy a file, if a dependency change and
@@ -1015,9 +1021,9 @@ clean_all: clean_synth clean_floorplan clean_place clean_cts clean_route clean_f
 .PHONY: nuke
 nuke: clean_test clean_issues
 	rm -rf ./results ./logs ./reports ./objects
-	rm -rf layer_*.mps macrocell.list *best.plt *_pdn.def dummy.guide
+	rm -rf layer_*.mps macrocell.list *best.plt *_pdn.def
 	rm -rf *.rpt *.rpt.old *.def.v pin_dumper.log
-	rm -rf versions.txt
+	rm -f versions.txt copyright.txt dummy.guide
 
 .PHONY: vars
 vars:


### PR DESCRIPTION
- output copyright & version once, a copyright.txt file is created to track if copyright has been output
- always output copyright notice & versions into log file, but not console


After:

```
$ make do-floorplan
mkdir -p ./logs/nangate45/gcd/base ./reports/nangate45/gcd/base
Running floorplan.tcl
[INFO ODB-0227] LEF file: NangateOpenCellLibrary.tech.lef, created 22 layers, 27 vias, 0 library cells
[INFO ODB-0227] LEF file: NangateOpenCellLibrary.macro.mod.lef, created 0 layers, 0 vias, 135 library cells

==========================================================================
Floorplan check_setup
--------------------------------------------------------------------------
number instances in verilog is 350
[WARNING IFP-0028] Core area lower left (1.000, 1.000) snapped to (1.140, 1.400).
[INFO IFP-0001] Added 21 rows of 162 site FreePDK45_38x28_10R_NP_162NW_34O.
[INFO RSZ-0026] Removed 18 buffers.
Default units for flow
 time 1ns
 capacitance 1fF
 resistance 1kohm
 voltage 1v
 current 1mA
 power 1nW
 distance 1um

==========================================================================
floorplan final report_design_area
--------------------------------------------------------------------------
Design area 506 u^2 56% utilization.
Elapsed time: 0:00.23[h:]min:sec. CPU time: user 0.21 sys 0.01 (99%). Peak memory: 98480KB.
Running io_placement_random.tcl
Found 0 macro blocks.
Using 2 tracks default min distance between IO pins.
[INFO PPL-0007] Random pin placement.
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.02 (98%). Peak memory: 95536KB.
Running tdms_place.tcl
No macros found: Skipping global_placement
Elapsed time: 0:00.18[h:]min:sec. CPU time: user 0.18 sys 0.00 (100%). Peak memory: 95660KB.
Running macro_place.tcl
[INFO ORD-0030] Using 16 thread(s).
No macros found: Skipping macro_placement
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.16 sys 0.02 (98%). Peak memory: 95920KB.
Running tapcell.tcl
[INFO TAP-0004] Inserted 42 endcaps.
[INFO TAP-0005] Inserted 0 tapcells.
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.01 (100%). Peak memory: 95232KB.
Running pdn.tcl
[INFO PDN-0001] Inserting grid: grid
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.18 sys 0.01 (100%). Peak memory: 97584KB.
cp ./results/nangate45/gcd/base/2_6_floorplan_pdn.odb ./results/nangate45/gcd/base/2_floorplan.odb
```


Before:

```
$ make do-floorplan
mkdir -p ./logs/nangate45/gcd/base ./reports/nangate45/gcd/base
(trap 'mv ./logs/nangate45/gcd/base/2_1_floorplan.tmp.log ./logs/nangate45/gcd/base/2_1_floorplan.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/floorplan.tcl -metrics ./logs/nangate45/gcd/base/2_1_floorplan.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_1_floorplan.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ODB-0227] LEF file: NangateOpenCellLibrary.tech.lef, created 22 layers, 27 vias, 0 library cells
[INFO ODB-0227] LEF file: NangateOpenCellLibrary.macro.mod.lef, created 0 layers, 0 vias, 135 library cells

==========================================================================
Floorplan check_setup
--------------------------------------------------------------------------
number instances in verilog is 350
[WARNING IFP-0028] Core area lower left (1.000, 1.000) snapped to (1.140, 1.400).
[INFO IFP-0001] Added 21 rows of 162 site FreePDK45_38x28_10R_NP_162NW_34O.
[INFO RSZ-0026] Removed 18 buffers.
Default units for flow
 time 1ns
 capacitance 1fF
 resistance 1kohm
 voltage 1v
 current 1mA
 power 1nW
 distance 1um

==========================================================================
floorplan final report_design_area
--------------------------------------------------------------------------
Design area 506 u^2 56% utilization.
Elapsed time: 0:00.23[h:]min:sec. CPU time: user 0.21 sys 0.01 (99%). Peak memory: 98476KB.
(trap 'mv ./logs/nangate45/gcd/base/2_2_floorplan_io.tmp.log ./logs/nangate45/gcd/base/2_2_floorplan_io.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/io_placement_random.tcl -metrics ./logs/nangate45/gcd/base/2_2_floorplan_io.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_2_floorplan_io.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
Found 0 macro blocks.
Using 2 tracks default min distance between IO pins.
[INFO PPL-0007] Random pin placement.
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.01 (99%). Peak memory: 95532KB.
(trap 'mv ./logs/nangate45/gcd/base/2_3_floorplan_tdms.tmp.log ./logs/nangate45/gcd/base/2_3_floorplan_tdms.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/tdms_place.tcl -metrics ./logs/nangate45/gcd/base/2_3_floorplan_tdms.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_3_floorplan_tdms.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
No macros found: Skipping global_placement
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.01 (98%). Peak memory: 95312KB.
(trap 'mv ./logs/nangate45/gcd/base/2_4_floorplan_macro.tmp.log ./logs/nangate45/gcd/base/2_4_floorplan_macro.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/macro_place.tcl -metrics ./logs/nangate45/gcd/base/2_4_floorplan_macro.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_4_floorplan_macro.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 16 thread(s).
No macros found: Skipping macro_placement
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.01 (98%). Peak memory: 95916KB.
(trap 'mv ./logs/nangate45/gcd/base/2_5_floorplan_tapcell.tmp.log ./logs/nangate45/gcd/base/2_5_floorplan_tapcell.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/tapcell.tcl -metrics ./logs/nangate45/gcd/base/2_5_floorplan_tapcell.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_5_floorplan_tapcell.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO TAP-0004] Inserted 42 endcaps.
[INFO TAP-0005] Inserted 0 tapcells.
Elapsed time: 0:00.19[h:]min:sec. CPU time: user 0.17 sys 0.02 (98%). Peak memory: 95280KB.
(trap 'mv ./logs/nangate45/gcd/base/2_6_floorplan_pdn.tmp.log ./logs/nangate45/gcd/base/2_6_floorplan_pdn.log' EXIT; /usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -exit -no_init  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/pdn.tcl -metrics ./logs/nangate45/gcd/base/2_6_floorplan_pdn.json) 2>&1 | tee ./logs/nangate45/gcd/base/2_6_floorplan_pdn.tmp.log
OpenROAD v2.0-12610-g3b9c4183e 
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO PDN-0001] Inserting grid: grid
Elapsed time: 0:00.20[h:]min:sec. CPU time: user 0.18 sys 0.01 (99%). Peak memory: 97840KB.
cp ./results/nangate45/gcd/base/2_6_floorplan_pdn.odb ./results/nangate45/gcd/base/2_floorplan.od
```