### PR TITLE
metrics: add SKIP_METRICS=1 variable to speed up builds

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -6,6 +6,11 @@ platform, design and tool specific variables to allow finer control and
 user overrides at various flow stages. These are defined in the
 `config.mk` file located in the platform and design specific directories.
 
+### General variables for all stages
+
+| Variable         | Description                                                                        |
+|------------------|------------------------------------------------------------------------------------|
+| `SKIP_METRICS`   | If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds. |
 
 ## Platform
 

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -10,7 +10,7 @@ user overrides at various flow stages. These are defined in the
 
 | Variable         | Description                                                                        |
 |------------------|------------------------------------------------------------------------------------|
-| `SKIP_METRICS`   | If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds. |
+| `SKIP_REPORT_METRICS`   | If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds. |
 
 ## Platform
 

--- a/flow/scripts/report_metrics.tcl
+++ b/flow/scripts/report_metrics.tcl
@@ -7,7 +7,7 @@ proc report_puts { out } {
 }
 
 proc report_metrics { stage when {include_erc true} {include_clock_skew true} } {
-  if {[info exists ::env(SKIP_METRICS)] && $::env(SKIP_METRICS) == 1} {
+  if {[info exists ::env(SKIP_REPORT_METRICS)] && $::env(SKIP_REPORT_METRICS) == 1} {
     return
   }
   set filename $::env(REPORTS_DIR)/${stage}_[string map {" " "_"} $when].rpt

--- a/flow/scripts/report_metrics.tcl
+++ b/flow/scripts/report_metrics.tcl
@@ -7,6 +7,9 @@ proc report_puts { out } {
 }
 
 proc report_metrics { stage when {include_erc true} {include_clock_skew true} } {
+  if {[info exists ::env(SKIP_METRICS)] && $::env(SKIP_METRICS) == 1} {
+    return
+  }
   set filename $::env(REPORTS_DIR)/${stage}_[string map {" " "_"} $when].rpt
   set fileId [open $filename w]
   close $fileId


### PR DESCRIPTION
CTS, for instance, invokes metrics three times, which is a waste of time if those metrics are not used.

Calculating metrics for CTS can take hours.

@maliberty Thoughts?