### PR TITLE
global route: remove deprecated -report_violating_nets option

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -99,7 +99,7 @@ puts "--------------------------------------------------------------------------
 if {![info exist env(SKIP_ANTENNA_REPAIR)]} {
   repair_antennas -iterations 5
   check_placement -verbose
-  check_antennas -report_file $env(REPORTS_DIR)/antenna.log -report_violating_nets
+  check_antennas -report_file $env(REPORTS_DIR)/antenna.log
 }
 
 estimate_parasitics -global_routing


### PR DESCRIPTION
Fixes:

```
[WARNING ANT-0011] -report_violating_nets is deprecated.
```