### PR TITLE
flow: tweak report_metrics and global route repair antenna progress messages

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -92,17 +92,16 @@ if { [info exists ::env(RECOVER_POWER)] } {
   report_power
 }
 
-puts "\n=========================================================================="
-puts "check_antennas"
-puts "--------------------------------------------------------------------------"
-
 if {![info exist env(SKIP_ANTENNA_REPAIR)]} {
+  puts "Repair antennas..."
   repair_antennas -iterations 5
   check_placement -verbose
   check_antennas -report_file $env(REPORTS_DIR)/antenna.log
 }
 
+puts "Estimate parasitics..."
 estimate_parasitics -global_routing
+
 report_metrics 5 "global route"
 
 # Write SDC to results with updated clock periods that are just failing.

--- a/flow/scripts/report_metrics.tcl
+++ b/flow/scripts/report_metrics.tcl
@@ -10,6 +10,7 @@ proc report_metrics { stage when {include_erc true} {include_clock_skew true} } 
   if {[info exists ::env(SKIP_REPORT_METRICS)] && $::env(SKIP_REPORT_METRICS) == 1} {
     return
   }
+  puts "Report metrics stage $stage, $when..."
   set filename $::env(REPORTS_DIR)/${stage}_[string map {" " "_"} $when].rpt
   set fileId [open $filename w]
   close $fileId


### PR DESCRIPTION
This makes it easier to understand what long running operations are in progress.

Use case: understand where time disappears in global route when it takes 3 hours.