### PR TITLE
sky130hd-microwatt: increase halos/channels for mpl2 flow & turn off boundary penalty

### DIFF
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -22,8 +22,11 @@ export ADDITIONAL_LEFS  = $(wildcard $(microwatt_DIR)/lef/*.lef)
 export ADDITIONAL_LIBS = $(wildcard $(microwatt_DIR)/lib/*.lib)
 
 export SYNTH_HIERARCHICAL = 1
-
 export RTLMP_FLOW = True
+
+export RTLMP_BOUNDARY_WT = 0
+export MACRO_PLACE_HALO = 100 100
+export MACRO_PLACE_CHANNEL = 200 200
 
 # CTS tuning
 export CTS_BUF_CELL = sky130_fd_sc_hd__clkbuf_8


### PR DESCRIPTION
This should unblock either the boundary penalty fix for mpl2 and the gpl routability changes.

