### PR TITLE
[Autotuner] Upgrade protobuf and SQAlchemy version

### DIFF
--- a/tools/AutoTuner/requirements.txt
+++ b/tools/AutoTuner/requirements.txt
@@ -7,4 +7,5 @@ pandas==2.2.1
 colorama==0.4.4
 bayesian-optimization==1.4.0
 tensorboard==2.16.2
-protobuf==3.20.1
+protobuf==3.20.3
+SQLAlchemy==1.4.17


### PR DESCRIPTION
Protobuf --> 3.20.3
Dependabot issue (see email @vvbandeira )

SQAlchemy --> 1.4,17
Error with running `distributed.py`'s Ax search without this additional module. 

Fixes https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1741