### PR TITLE
sky130hd-microwatt: design specific configs to allow mpl2 and gpl changes

### DIFF
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -22,8 +22,11 @@ export ADDITIONAL_LEFS  = $(wildcard $(microwatt_DIR)/lef/*.lef)
 export ADDITIONAL_LIBS = $(wildcard $(microwatt_DIR)/lib/*.lib)
 
 export SYNTH_HIERARCHICAL = 1
-
 export RTLMP_FLOW = True
+
+export RTLMP_BOUNDARY_WT = 0
+export MACRO_PLACE_HALO = 100 100
+export MACRO_PLACE_CHANNEL = 200 200
 
 # CTS tuning
 export CTS_BUF_CELL = sky130_fd_sc_hd__clkbuf_8

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -28,6 +28,9 @@ export RTLMP_BOUNDARY_WT = 0
 export MACRO_PLACE_HALO = 100 100
 export MACRO_PLACE_CHANNEL = 200 200
 
+# Temporary
+export SKIP_ANTENNA_REPAIR = 1
+
 # CTS tuning
 export CTS_BUF_CELL = sky130_fd_sc_hd__clkbuf_8
 export CTS_BUF_DISTANCE = 600


### PR DESCRIPTION
New attempt to to do what was done in #1890 and reverted  in #1891  due to antenna repair crash.
1. Increase the halos
2. Set mpl2 SA boundary penalty to zero

Now we're manually (and temporarily) skipping antenna repair to avoid the crash.

Also using the latest OR to avoid some other failing after merging.