### PR TITLE
Mock array flatten

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -23,15 +23,15 @@ export DIE_AREA  = $(shell \
   cd $(dir $(DESIGN_CONFIG)) && \
   python3 -c "import config; print(f'{0} {0} {config.die_width} {config.die_height}')")
 
-export BLOCKS                       = Element
+export BLOCKS                ?= Element
 
-export GDS_ALLOW_EMPTY       = Element
-
-export MACRO_PLACEMENT_TCL   = ./designs/asap7/mock-array/macro-placement.tcl
+ifneq ($(BLOCKS),)
+  export GDS_ALLOW_EMPTY       = Element
+  export MACRO_PLACEMENT_TCL   = ./designs/asap7/mock-array/macro-placement.tcl
+  export PDN_TCL               = $(FLOW_HOME)/platforms/asap7/openRoad/pdn/BLOCKS_grid_strategy.tcl
+endif
 
 export IO_CONSTRAINTS        = designs/asap7/mock-array/io.tcl
-
-export PDN_TCL               = $(FLOW_HOME)/platforms/asap7/openRoad/pdn/BLOCKS_grid_strategy.tcl
 
 # Target to force generation of Verilog per user settings MOCK_ARRAY_TABLE (rows, cols)
 verilog:


### PR DESCRIPTION
```
make BLOCKS= DESIGN_CONFIG=designs/asap7/mock-array/config.mk cts
```

```
make BLOCKS= DESIGN_CONFIG=designs/asap7/mock-array/config.mk gui_cts
```

![image](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/assets/2798822/cf305697-8a69-4e17-bba0-ed278f0b5e10)


```
$ make BLOCKS= DESIGN_CONFIG=designs/asap7/mock-array/config.mk elapsed
[INFO-FLOW] ASU ASAP7 - version 2
Default PVT selection: BC
./logs/asap7/mock-array/base
Log                       Elapsed seconds
1_1_yosys                          8
2_1_floorplan                      3
2_2_floorplan_io                   1
2_3_floorplan_tdms                 1
2_4_floorplan_macro                1
2_5_floorplan_tapcell              1
2_6_floorplan_pdn                  4
3_1_place_gp_skip_io              15
3_2_place_iop                      2
3_3_place_gp                      36
3_4_place_resized                 10
3_5_place_dp                      14
4_1_cts                           18
5_1_grt                           33
5_2_fillcell                       3
No elapsed time found in logs/asap7/mock-array/base/5_3_route.tmp.log
Total                            150
```
