### PR TITLE
makefile: improve logging, include name of stage as well as which script is running

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -571,7 +571,7 @@ $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 
 .PHONY: do-$(1)
 do-$(1): copyright.txt
-	@echo Running $(1) $(3).tcl
+	@echo Running $(3).tcl, stage $(1)
 	@(trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
 	 $(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
 	 $(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -571,7 +571,7 @@ $(if $(5),$(5),$(RESULTS_DIR))/$(1)$(if $(4),$(4),.odb): $(2)
 
 .PHONY: do-$(1)
 do-$(1): copyright.txt
-	@echo Running $(3).tcl
+	@echo Running $(1) $(3).tcl
 	@(trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
 	 $(OPENROAD_CMD) $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
 	 $(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \


### PR DESCRIPTION
This reminder is useful to find files, or e.g. rerun a stage `make do-2_6_floorplan_pdn`

After:

```
Running 2_6_floorplan_pdn pdn.tcl
```

Before

```
Running pdn.tcl
```