### PR TITLE
env.sh: set up FLOW_HOME which flow/Makefile uses

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -21,3 +21,5 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk)/bin:$PATH"
   export CMAKE_PREFIX_PATH="$(brew --prefix or-tools)"
 fi
+
+export FLOW_HOME=$DIR/flow


### PR DESCRIPTION
This allows users of ORFS to find ORFS/flow folder after ". env.sh" is run