### PR TITLE
Fix a typo in documentation

### DIFF
--- a/docs/user/BuildWithDocker.md
+++ b/docs/user/BuildWithDocker.md
@@ -71,7 +71,7 @@ You can restrict the number of CPUs with the `-t|--threads N` argument:
 The binaries are only available from inside a Docker container. Here is an example of starting a container from the created Docker image.
 
 ``` shell
-docker run --rm -it -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd)/flow:/OpenROAD-flow-scripts/flow openroad/flow-ubuntu22-builder
+docker run --rm -it -u $(id -u ${USER}):$(id -g ${USER}) -v $(pwd)/flow:/OpenROAD-flow-scripts/flow openroad/flow-ubuntu22.04-builder
 ```
 
 Then, inside docker:


### PR DESCRIPTION
The image name should be "openroad/flow-ubuntu22.04-builder" and not "openroad/flow-ubuntu22-builder", to match the name in [build_openroad.sh](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/33a10d089d04f9b399ad2fe9da46fa997066a36b/build_openroad.sh#L35)