### PR TITLE
sg13g2: Use decoupling cells as fill cells

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -27,7 +27,7 @@ sg13g2_dfrbp_2
 
 
 # Define fill cells
-export FILL_CELLS = sg13g2_fill_1 sg13g2_fill_2 sg13g2_fill_4 sg13g2_fill_8
+export FILL_CELLS = sg13g2_fill_1 sg13g2_fill_2 sg13g2_decap_4 sg13g2_decap_8
 # -----------------------------------------------------
 #  Yosys
 #  ----------------------------------------------------


### PR DESCRIPTION
Currently, only the fill cells `sg13g2_fill_[1|2|4|8]` are used. Instead of `sg13g2_fill_[4|8]` the supply decouling cells `sg13g2_decap_]4|8]` shall be used.