### PR TITLE
makefile: versions.txt used by make issue is now in OBJECTS_DIR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,6 @@ flow/run-me*.sh
 flow/vars*.sh
 flow/vars*.tcl
 flow/vars*.gdb
-flow/versions.txt
 
 # Common temp files
 flow/*.log

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ flow/run-me*.sh
 flow/vars*.sh
 flow/vars*.tcl
 flow/vars*.gdb
-flow/versions.txt
 
 # Common temp files
 flow/pt_shell_command.log

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -364,9 +364,10 @@ $(foreach block,$(BLOCKS),$(eval ./results/$(PLATFORM)/$(DESIGN_NICKNAME)_$(bloc
 #-------------------------------------------------------------------------------
 .PHONY: versions.txt
 versions.txt:
-	@$(YOSYS_CMD) -V > $@
-	@echo openroad `$(OPENROAD_EXE) -version` >> $@
-	@$(KLAYOUT_CMD) -zz -v >> $@
+	mkdir -p $(OBJECTS_DIR)
+	@$(YOSYS_CMD) -V > $(OBJECTS_DIR)/$@
+	@echo openroad `$(OPENROAD_EXE) -version` >> $(OBJECTS_DIR)/$@
+	@$(KLAYOUT_CMD) -zz -v >> $(OBJECTS_DIR)/$@
 
 # Pre-process libraries
 # ==============================================================================
@@ -992,7 +993,7 @@ nuke: clean_test clean_issues
 	rm -rf ./results ./logs ./reports ./objects
 	rm -rf layer_*.mps macrocell.list *best.plt *_pdn.def
 	rm -rf *.rpt *.rpt.old *.def.v pin_dumper.log
-	rm -f versions.txt $(OBJECTS_DIR)/copyright.txt dummy.guide
+	rm -f $(OBJECTS_DIR)/versions.txt $(OBJECTS_DIR)/copyright.txt dummy.guide
 
 .PHONY: vars
 vars:


### PR DESCRIPTION
this avoids having to add versions.txt to .gitignore for all projects that are using ORFS.

Tested locally, worked fine.

```
$ make floorplan
[deleted]
$ make floorplan_issue
mkdir -p ./objects/nangate45/gcd/base
/home/oyvind/OpenROAD-flow-scripts/flow/util/makeIssue.sh floorplan
Creating run-me-gcd-nangate45-base.sh script
Creating vars-gcd-nangate45-base.sh/tcl script
Archiving issue to floorplan_gcd_nangate45_base_2024-04-23_16-44.tar.gz
Using pigz to compress tar file
++ sort
++ for f in $ISSUE_CP_FILES
++ echo ./designs/nangate45/gcd/constraint.sdc
++ for f in $ISSUE_CP_FILES
++ echo ./designs/src/gcd/gcd.v
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lef/NangateOpenCellLibrary.macro.mod.lef
++ for f in $ISSUE_CP_FILES
++ uniq
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lef/NangateOpenCellLibrary.tech.lef
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cells_clkgate.v
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cells_latch.v
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cdl/NangateOpenCellLibrary.cdl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/tapcell.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/grid_strategy-M1-M4-M7.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/fastroute.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/rcx_patterns.rules
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/fakeram.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/fastroute.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/grid_strategy-M1-M4-M7.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/make_tracks.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/setRC.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/tapcell.tcl
++ for f in $ISSUE_CP_FILES
++ echo /home/oyvind/OpenROAD-flow-scripts/flow/util/def2stream.py
++ for f in $ISSUE_CP_FILES
++ echo run-me-gcd-nangate45-base.sh
++ for f in $ISSUE_CP_FILES
++ echo vars-gcd-nangate45-base.sh
++ for f in $ISSUE_CP_FILES
++ echo vars-gcd-nangate45-base.tcl
++ for f in $ISSUE_CP_FILES
++ echo vars-gcd-nangate45-base.gdb
+ tar --use-compress-program=pigz --ignore-failed-read -chf floorplan_gcd_nangate45_base_2024-04-23_16-44.tar.gz '--transform=s|^|floorplan_gcd_nangate45_base_2024-04-23_16-44/|S' '--transform=s|^floorplan_gcd_nangate45_base_2024-04-23_16-44/home/oyvind/OpenROAD-flow-scripts/flow/|floorplan_gcd_nangate45_base_2024-04-23_16-44/|S' ./designs/nangate45/gcd//config.mk /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/config.mk ./logs/nangate45/gcd/base ./objects/nangate45/gcd/base ./reports/nangate45/gcd/base ./results/nangate45/gcd/base /home/oyvind/OpenROAD-flow-scripts/flow/scripts ./designs/nangate45/gcd/constraint.sdc ./designs/src/gcd/gcd.v /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cdl/NangateOpenCellLibrary.cdl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cells_clkgate.v /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/cells_latch.v /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/fakeram.tcl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/fastroute.tcl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/grid_strategy-M1-M4-M7.tcl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lef/NangateOpenCellLibrary.macro.mod.lef /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lef/NangateOpenCellLibrary.tech.lef /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/lib/NangateOpenCellLibrary_typical.lib /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/make_tracks.tcl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/rcx_patterns.rules /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/setRC.tcl /home/oyvind/OpenROAD-flow-scripts/flow/platforms/nangate45/tapcell.tcl /home/oyvind/OpenROAD-flow-scripts/flow/util/def2stream.py run-me-gcd-nangate45-base.sh vars-gcd-nangate45-base.gdb vars-gcd-nangate45-base.sh vars-gcd-nangate45-base.tcl
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
+ '[' -v EXCLUDE_PLATFORM ']'
+ '[' '!' -z ']'
$ tar -tzvf floorplan_gcd_nangate45_base_2024-04-23_16-44.tar.gz | grep versions.txt
-rw-rw-r-- oyvind/oyvind   109 2024-04-23 16:44 floorplan_gcd_nangate45_base_2024-04-23_16-44/./objects/nangate45/gcd/base/versions.txt
$ ls versions.txt
ls: cannot access 'versions.txt': No such file or directory
```