### PR TITLE
mock-array:  use CTS_BUF_DISTANCE to make mock-array less brittle

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -57,4 +57,4 @@ export FASTROUTE_TCL = ./designs/$(PLATFORM)/mock-array/fastroute.tcl
 export MACRO_HALO_X            = 0.5
 export MACRO_HALO_Y            = 0.5
 
-export CTS_ARGS = -sink_clustering_enable -balance_levels -distance_between_buffers 60
+export CTS_BUF_DISTANCE = 60


### PR DESCRIPTION
@precisionmoon @maliberty CTS_ARGS had to be used while -insertion_delay was introduced, but now CTS_ARGS is no longer needed as CTS_BUF_DISTANCE alone adequately changes options.

With this change, mock-array is less brittle when CTS and CTS_ARGS is updated.