### PR TITLE
flow/util/generate-vars: Fix absolute paths conversion

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -53,11 +53,11 @@ while read -r VAR; do
         echo "set env ${name} ${value}" >> $1.gdb
         continue
     fi
-    if [[ ${value} == /* ]]; then
-        # convert absolute paths if possible to use FLOW_HOME variable
-        value=$(sed -e "s,${FLOW_ROOT},\${FLOW_HOME},g" <<< "${value}")
-        value=$(sed -e "s,${ORFS_ROOT},\${FLOW_HOME}/\.\.,g" <<< "${value}")
-    fi
+
+    # convert absolute paths if possible to use FLOW_HOME variable
+    value=$(sed -e "s,${FLOW_ROOT},\${FLOW_HOME},g" <<< "${value}")
+    value=$(sed -e "s,${ORFS_ROOT},\${FLOW_HOME}/\.\.,g" <<< "${value}")
+
     echo "export ${name}=\"${value}\"" >> $1.sh
     if [[ "${value}" == *'$'* ]]; then
         echo "set env ${name} $(sed -e 's,${FLOW_HOME},getenv("FLOW_HOME"),' <<< ${value})" >> $1.gdb


### PR DESCRIPTION
I noticed that `<stage>_issue` targets generate files with env vars that contain some absolute paths for example in `SYNTH_ARGS` env var.

This PR fixes the conversion of absolute paths for the .sh file. The fix applies to cases when the environment variable has the absolute path but it does not start at the very beginning of the env var value.

Example:
* before the fix: `export SYNTH_ARGS="-flatten -extra-map /home/tester/OpenROAD-flow-scripts/flow/designs/src/lcu/lcu_kogge_stone.v"`
* after the fix: `export SYNTH_ARGS="-flatten -extra-map ${FLOW_HOME}/designs/src/lcu/lcu_kogge_stone.v"`