### PR TITLE
floorplan: report unused ADDITIONAL_... macros

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -2,6 +2,34 @@ utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_synth.v 1_synth.sdc
 
+proc report_unused_masters {} {
+  set db [ord::get_db]
+  set libs [$db getLibs]
+  set masters ""
+  foreach lib $libs {
+    foreach master [$lib getMasters] {
+      # filter out non-block masters, or you can remove this conditional to detect any unused master
+      if {[$master getType] == "BLOCK"} {
+        lappend masters $master
+      }
+    }
+  }
+
+  set block [ord::get_db_block]
+  set insts [$block getInsts]
+
+  foreach inst $insts {
+    set inst_master [$inst getMaster]
+    set masters [lsearch -all -not -inline $masters $inst_master]
+  }
+
+  foreach master $masters {
+    puts "Master [$master getName] is loaded but not used in the design"
+  }
+}
+
+report_unused_masters
+
 #Run check_setup
 puts "\n=========================================================================="
 puts "Floorplan check_setup"


### PR DESCRIPTION
Ref. https://github.com/The-OpenROAD-Project/OpenROAD/discussions/5009


To see report, run:
 
```  
$ make DESIGN_CONFIG=designs/asap7/gcd/config.mk ADDITIONAL_LEFS=platforms/asap7/lef/fakeram7_256x32.lef ADDITIONAL_LIBS=platforms/asap7/lib/fakeram7_256x32.lib do-floorplan
[deleted]
Running floorplan.tcl, stage 2_1_floorplan
[INFO ODB-0227] LEF file: /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7_tech_1x_201209.lef, created 24 layers, 9 vias
[INFO ODB-0227] LEF file: /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7sc7p5t_28_R_1x_220121a.lef, created 212 library cells
[INFO ODB-0227] LEF file: platforms/asap7/lef/fakeram7_256x32.lef, created 1 library cells
Master fakeram7_256x32 is loaded but not used in the design
...
```