### PR TITLE
platforms: use path relative to the FLOW_HOME

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -190,7 +190,7 @@ export RESYNTH_TIMING_RECOVER ?= 0
 export ABC_AREA ?= 0
 
 # Global setting for Synthesis
-export SYNTH_ARGS ?= -flatten -extra-map $(PLATFORM_HOME)/common/lcu_kogge_stone.v
+export SYNTH_ARGS ?= -flatten -extra-map $(FLOW_HOME)/platforms/common/lcu_kogge_stone.v
 
 # Global setting for Floorplan
 export PLACE_PINS_ARGS


### PR DESCRIPTION
For private PDKs we use a different PLATFORM_HOME which does not contain the "common" folder.