### PR TITLE
makefile: reduce surprises, NUM_CORES can now be specified on command line

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -243,7 +243,7 @@ export RTLMP_BLOCKAGE_FILE ?= $(OBJECTS_DIR)/rtlmp/partition.txt.blockage
 #-------------------------------------------------------------------------------
 ifeq (,$(strip $(NUM_CORES)))
   # Linux (utility program)
-  NUM_CORES := $(shell NUM_CORES 2>/dev/null)
+  NUM_CORES := $(shell nproc 2>/dev/null)
 
   ifeq (,$(strip $(NUM_CORES)))
     # Linux (generic)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -241,26 +241,24 @@ export RTLMP_RPT_FILE ?= partition.txt
 export RTLMP_BLOCKAGE_FILE ?= $(OBJECTS_DIR)/rtlmp/partition.txt.blockage
 
 #-------------------------------------------------------------------------------
-ifeq (, $(strip $(NPROC)))
+ifeq (,$(strip $(NUM_CORES)))
   # Linux (utility program)
-  NPROC := $(shell nproc 2>/dev/null)
+  NUM_CORES := $(shell NUM_CORES 2>/dev/null)
 
-  ifeq (, $(strip $(NPROC)))
+  ifeq (,$(strip $(NUM_CORES)))
     # Linux (generic)
-    NPROC := $(shell grep -c ^processor /proc/cpuinfo 2>/dev/null)
+    NUM_CORES := $(shell grep -c ^processor /proc/cpuinfo 2>/dev/null)
   endif
-  ifeq (, $(strip $(NPROC)))
+  ifeq (,$(strip $(NUM_CORES)))
     # BSD (at least FreeBSD and Mac OSX)
-    NPROC := $(shell sysctl -n hw.ncpu 2>/dev/null)
+    NUM_CORES := $(shell sysctl -n hw.ncpu 2>/dev/null)
   endif
-  ifeq (, $(strip $(NPROC)))
+  ifeq (,$(strip $(NUM_CORES)))
     # Fallback
-    NPROC := 1
+    NUM_CORES := 1
   endif
 endif
-ifeq ($(NUM_CORES),)
-  export NUM_CORES := $(NPROC)
-endif
+export NUM_CORES
 
 export LSORACLE_CMD ?= $(shell command -v lsoracle)
 ifeq ($(LSORACLE_CMD),)
@@ -280,7 +278,7 @@ YOSYS_FLAGS += -v 3
 export TIME_BIN   ?= /usr/bin/time
 TIME_CMD = $(TIME_BIN) -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.'
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
-ifeq (, $(strip $(TIME_TEST)))
+ifeq (,$(strip $(TIME_TEST)))
   TIME_CMD = $(TIME_BIN)
 endif
 

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -258,7 +258,9 @@ ifeq (, $(strip $(NPROC)))
     NPROC := 1
   endif
 endif
-export NUM_CORES := $(NPROC)
+ifeq ($(NUM_CORES),)
+  export NUM_CORES := $(NPROC)
+endif
 
 export LSORACLE_CMD ?= $(shell command -v lsoracle)
 ifeq ($(LSORACLE_CMD),)

--- a/flow/util/distributed.py
+++ b/flow/util/distributed.py
@@ -488,7 +488,7 @@ def openroad(base_dir, parameters, flow_variant, path=''):
     make_command += f'make -C {base_dir}/flow DESIGN_CONFIG=designs/'
     make_command += f'{args.platform}/{args.design}/config.mk'
     make_command += f' FLOW_VARIANT={flow_variant} {parameters}'
-    make_command += f' NPROC={args.openroad_threads} SHELL=bash'
+    make_command += f' NUM_PROCS={args.openroad_threads} SHELL=bash'
     run_command(make_command,
                 timeout=args.timeout,
                 stderr_file=f'{log_path}error-make-finish.log',


### PR DESCRIPTION
`NUM_CORES=1234  make print-NUM_CORES` now prints 1234