### PR TITLE
ppl interactive tweaking

### DIFF
--- a/flow/scripts/io_placement.tcl
+++ b/flow/scripts/io_placement.tcl
@@ -1,15 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 3_1_place_gp_skip_io.odb 2_floorplan.sdc
 
-if {[info exists ::env(FLOORPLAN_DEF)]} {
-    puts "Skipping IO placement as DEF file was used to initialize floorplan."
-} else {
-  if {[info exists ::env(IO_CONSTRAINTS)]} {
-    source $::env(IO_CONSTRAINTS)
-  }
-  place_pins -hor_layer $::env(IO_PLACER_H) \
-           -ver_layer $::env(IO_PLACER_V) \
-           {*}$::env(PLACE_PINS_ARGS)
-}
+source $::env(SCRIPTS_DIR)/io_placement_util.tcl
 
 write_db $::env(RESULTS_DIR)/3_2_place_iop.odb

--- a/flow/scripts/io_placement_random.tcl
+++ b/flow/scripts/io_placement_random.tcl
@@ -1,16 +1,8 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 2_1_floorplan.odb 1_synth.sdc
 
-if {[info exists ::env(FLOORPLAN_DEF)]} {
-    puts "Skipping IO placement as DEF file was used to initialize floorplan."
-} else {
-  if {[info exists ::env(IO_CONSTRAINTS)]} {
-    source $::env(IO_CONSTRAINTS)
-  }
-  place_pins -hor_layer $::env(IO_PLACER_H) \
-           -ver_layer $::env(IO_PLACER_V) \
-           -random \
-           {*}$::env(PLACE_PINS_ARGS)
-}
+lappend ::env(PLACE_PINS_ARGS) -random
+
+source $::env(SCRIPTS_DIR)/io_placement_util.tcl
 
 write_db $::env(RESULTS_DIR)/2_2_floorplan_io.odb

--- a/flow/scripts/io_placement_util.tcl
+++ b/flow/scripts/io_placement_util.tcl
@@ -1,0 +1,12 @@
+if {[info exists ::env(FLOORPLAN_DEF)]} {
+    puts "Skipping IO placement as DEF file was used to initialize floorplan."
+} else {
+  if {[info exists ::env(IO_CONSTRAINTS)]} {
+    source $::env(IO_CONSTRAINTS)
+  }
+  set args [list -hor_layer $::env(IO_PLACER_H) \
+           -ver_layer $::env(IO_PLACER_V) \
+           {*}$::env(PLACE_PINS_ARGS)]
+  puts "place_pins [join $args " "]"
+  place_pins {*}$args
+}


### PR DESCRIPTION
These changes support updating and seeing the results interactively in the GUI of changes to io pin placement.

Example:

1. `make floorplan`
2. `make gui_2_1_floorplan.odb`
3. Now run `source scripts/io_placement_util.tcl`
4. Resize GUI so that pins are rendered(this is probably a tiny bug in the GUI...)
5. Tweak pin configuration .tcl files or e.g. `set ::env(PLACE_PINS_ARGS) {-annealing -min_distance 7 -min_distance_in_tracks}`
6. Run `clear_io_pin_constraints; source scripts/io_placement_util.tcl`

See results immediately.