### PR TITLE
util: makeIssue.sh: Use DESIGN_CONFIG env var for passing the path to the config

### DIFF
--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -95,7 +95,7 @@ echo "Using $COMPRESS to compress tar file"
 if [ -v FULL_ISSUE ]; then
     DESIGN_PLATFORM_FILES="$DESIGN_DIR $PLATFORM_DIR"
 else
-    DESIGN_PLATFORM_FILES="$DESIGN_DIR/config.mk $PLATFORM_DIR/config.mk"
+    DESIGN_PLATFORM_FILES="$DESIGN_CONFIG $PLATFORM_DIR/config.mk"
 fi
 
 set -x


### PR DESCRIPTION
`makeIssue.sh` specifies the path to the design config as `$DESIGN_DIR/config.mk`.
This will be incorrect for designs which use config that has name different than `config.mk`. We can use `DESIGN_CONFIG` env var to not have to make assumptions about the config file name.