### PR TITLE
make issue: add ADDITIONAL_FILES that can list extra files needed for make issue

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -239,6 +239,7 @@ configuration file.
 
 | Variable                 | Description                                                                                        |
 |--------------------------|----------------------------------------------------------------------------------------------------|
+| `ADDITIONAL_FILES`       | Additional files to be added to `make issue` archive |
 | `ADDITIONAL_LEFS`        | Hardened macro LEF view files listed here.                                                         |
 | `ADDITIONAL_LIBS`        | Hardened macro library files listed here.                                                          |
 | `ADDITIONAL_GDS`         | Hardened macro GDS files listed here.                                                              |

--- a/flow/designs/asap7/mock-array/Element/config.mk
+++ b/flow/designs/asap7/mock-array/Element/config.mk
@@ -43,3 +43,5 @@ export PLACE_PINS_ARGS = -annealing
 
 export GND_NETS_VOLTAGES      =
 export PWR_NETS_VOLTAGES      =
+
+export ADDITIONAL_FILES = designs/src/mock-array/util.tcl

--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -59,3 +59,5 @@ export MACRO_HALO_X            = 0.5
 export MACRO_HALO_Y            = 0.5
 
 export CTS_BUF_DISTANCE = 60
+
+export ADDITIONAL_FILES = designs/src/mock-array/util.tcl

--- a/flow/test/test_make_issue.sh
+++ b/flow/test/test_make_issue.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# make issue smoketest
+set -ue -o pipefail
+
+testname=Element
+
+make DESIGN_CONFIG=designs/asap7/mock-array/$testname/config.mk floorplan
+make DESIGN_CONFIG=designs/asap7/mock-array/$testname/config.mk io_placement_random_issue
+latest_file=$(ls -t io_placement_random_mock-array_${testname}_asap7_base*.tar.gz | head -n1)
+echo "Testing $latest_file"
+. ../env.sh
+rm -rf results/make-issue/
+mkdir -p results/make-issue/
+cd results/make-issue/
+tar --strip-components=1 -xzf ../../$latest_file
+runme=run-me-mock-array_$testname-asap7-base.sh
+sed -i 's/openroad -no_init/openroad -exit -no_init/g' $runme
+./$runme

--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -18,6 +18,7 @@ ISSUE_CP_DESIGN_FILE_VARS="SDC_FILE \
 ISSUE_CP_PLATFORM_FILE_VARS="LIB_FILES \
                              SC_LEF \
                              TECH_LEF \
+                             ADDITIONAL_FILES \
                              ADDITIONAL_LEFS \
                              CLKGATE_MAP_FILE \
                              ADDER_MAP_FILE \


### PR DESCRIPTION
@lpawelcz Fixes the error below.

```
make DESIGN_CONFIG=designs/asap7/mock-array/Element/config.mk io_placement_random_issue
```

Results in:

```
$ ./run-me-mock-array_Element-asap7-base.sh 
OpenROAD v2.0-13652-g6fc686431 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[ERROR STA-0340] cannot open 'designs/src/mock-array/util.tcl'.
Error: io.tcl, 1 STA-0340
openroad> 
```
