### PR TITLE
makefile: fix empty bash command when user doesn't have klayout

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -394,7 +394,7 @@ do-klayout_tech:
 	cp $(TECH_LEF) $(OBJECTS_DIR)/klayout_tech.lef
 
 KLAYOUT_ENV_VAR_IN_PATH_VERSION = 0.28.11
-KLAYOUT_VERSION = $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
+KLAYOUT_VERSION = $(if $(KLAYOUT_CMD),shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2,))
 
 KLAYOUT_ENV_VAR_IN_PATH = $(shell \
 	if [ -z "$(KLAYOUT_VERSION)" ]; then \


### PR DESCRIPTION
This PR fixes checking for `KLAYOUT_VERSION` when `KLAYOUT_CMD` is missing.

Currently Makefile always tries to check for `KLAYOUT_VERSION` but when `KLAYOUT_CMD` variable is empty it tries to execute invalid command and produces following error:
```
bash: - : invalid option
Usage:    bash [GNU long option] [option] ...
  bash [GNU long option] [option] script-file ...
GNU long options:
 --debug
 --debugger
 --dump-po-strings
 --dump-strings
 --help
 --init-file
 --login
 --noediting
 --noprofile
 --norc
 --posix
 --pretty-print
 --rcfile
 --restricted
 --verbose
 --version
Shell options:
 -ilrsD or -c command or -O shopt_option         (invocation only)
 -abefhkmnptuvxBCHP or -o option
```

