### PR TITLE
makefile: make issue now uses SCRIPTS_DIR bundled into .tar.gz

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -55,6 +55,9 @@ while read -r VAR; do
     fi
 
     # convert absolute paths if possible to use FLOW_HOME variable
+    if [[ "${name}" == *"SCRIPTS_DIR"* ]]; then
+        value=$(sed -e "s,${FLOW_ROOT},.,g" <<< "${value}")
+    fi
     value=$(sed -e "s,${FLOW_ROOT},\${FLOW_HOME},g" <<< "${value}")
     value=$(sed -e "s,${ORFS_ROOT},\${FLOW_HOME}/\.\.,g" <<< "${value}")
 


### PR DESCRIPTION
The reason scripts are bundled into .tar.gz is to capture the exact state of the scripts and make the bug-report standalone.

This should solve occasional failures to reproduce when ORFS does not match the version that was used when make issue was invoked

Fixed:

```
$ grep SCRIPTS_DIR vars-mock-array_Element-asap7-base.sh 
export SCRIPTS_DIR="./scripts"
```

Was wrong, using ORFS scripts, rather than the scripts in the archive:

```
$ grep SCRIPTS_DIR vars-mock-array_Element-asap7-base.sh 
export SCRIPTS_DIR="${FLOW_HOME}/scripts"
```