### PR TITLE
Fix `ABC contains local modifications` error when building Docker image

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -273,6 +273,12 @@ __local_build()
             set -u
         fi
 
+        YOSYS_ABC_PATH=tools/yosys/abc
+        if [[ -d "${YOSYS_ABC_PATH}/.git" ]]; then
+            # update indexes to make sure git diff-index uses correct data
+            git --work-tree=${YOSYS_ABC_PATH} --git-dir=${YOSYS_ABC_PATH}/.git update-index --refresh
+        fi
+
         echo "[INFO FLW-0017] Compiling Yosys."
         ${NICE} make install -C tools/yosys -j "${PROC}" ${YOSYS_ARGS}
 


### PR DESCRIPTION
This PR fixes an errors appearing when OpenROAD is built, first locally and then in Docker image.

It can be reproduced on Ubuntu 23.04 with commands:
```
sudo ./setup.sh
./build_openroad.sh --local --latest --clean-force && ./build_openroad.sh --latest --clean-force
```

Yosys uses `git diff-index` to detect changes in ABC, which did not update indexes before check ([code](https://github.com/The-OpenROAD-Project/yosys/blob/a1bb0255d654ffd0d8503577274f24b349a42995/Makefile#L798)). Received error:
```
> [4/4] RUN ./build_openroad.sh --no_init --local --threads 16:
78.96 [ 88%] Building techlibs/quicklogic/ql_dsp_macc_pm.h
79.02 [ 89%] Building techlibs/sf2/synth_sf2.o
79.02 [ 89%] Building techlibs/xilinx/synth_xilinx.o
79.27 [ 89%] Building techlibs/xilinx/xilinx_dffopt.o
79.35 [ 99%] Building yosys-config
79.35 [ 99%] Building abc/abc-0cd90d0
79.38 ERROR: ABC contains local modifications! Set ABCREV=default in Yosys Makefile!
79.38 make: *** [Makefile:795: abc/abc-0cd90d0] Error 1
79.38 make: *** Waiting for unfinished jobs....
82.53 make: Leaving directory '/OpenROAD-flow-scripts/tools/yosys'
------
Dockerfile.builder:16
--------------------
  14 |     # RUN cat tools/yosys/Makefile | grep ABCREV
  15 |     # RUN cd tools/yosys/abc; git status; cd -
  16 | >>> RUN ./build_openroad.sh --no_init --local --threads ${numThreads}
  17 |
--------------------
ERROR: failed to solve: process "/bin/sh -c ./build_openroad.sh --no_init --local --threads ${numThreads}" did not complete successfully: exit code: 2
```
Fixed by adding `git update-index --refresh` before building Yosys.