### PR TITLE
Fix building Docker image with local dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,3 +31,6 @@ core*
 # git
 .git
 .gitignore
+
+# local dependencies
+dependencies/


### PR DESCRIPTION
When local dependencies are prepared with [setup.sh](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/setup.sh) script, `dependencies/` folder is created, which is automatically copied into Docker image and sourced by [dev_env.sh](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/dev_env.sh). This results in missing SWIG error:
```
$ sudo setup.sh
[...]
$ ./build_openroad --latest
[...]
> [4/4] RUN ./build_openroad.sh --no_init --local --threads 16:
139.8   "4.0")
139.8 Call Stack (most recent call first):
139.8   /OpenROAD-flow-scripts/dependencies/share/cmake-3.24/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
139.8   /OpenROAD-flow-scripts/dependencies/share/cmake-3.24/Modules/FindSWIG.cmake:153 (find_package_handle_standard_args)
139.8   src/CMakeLists.txt:169 (find_package)
139.8
139.8
139.8 -- Configuring incomplete, errors occurred!
139.8 See also "/OpenROAD-flow-scripts/tools/OpenROAD/build/CMakeFiles/CMakeOutput.log".
139.8 See also "/OpenROAD-flow-scripts/tools/OpenROAD/build/CMakeFiles/CMakeError.log".
------
Dockerfile.builder:16
--------------------
  14 |     RUN cat tools/yosys/Makefile | grep ABCREV
  15 |     RUN cd tools/yosys/abc; git status; cd -
  16 | >>> RUN ./build_openroad.sh --no_init --local --threads ${numThreads}
  17 |
--------------------
ERROR: failed to solve: process "/bin/sh -c ./build_openroad.sh --no_init --local --threads ${numThreads}" did not complete successfully: exit code: 1
```

This PR fixes it by ignoring `dependencies/` directory during Docker build.