### PR TITLE
Add missing `-y`

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -84,7 +84,7 @@ _installUbuntuPackages() {
 
     # install KLayout
     if _versionCompare $1 -ge 23.04; then
-        apt-get install klayout python3-pandas
+        apt-get install -y klayout python3-pandas
     else
         if [[ $1 == 20.04 ]]; then
             klayoutChecksum=15a26f74cf396d8a10b7985ed70ab135


### PR DESCRIPTION
This PR adds missing `-y` to `apt install klayout`, to make sure `setup.sh` script is not stopped and will not wait for user's confirmation.