### PR TITLE
makefile: fix memory target dependency

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -465,7 +465,7 @@ do-synth-report:
 	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_metrics.tcl) 2>&1 | tee -a $(LOG_DIR)/1_1_yosys.log
 
 .PHONY: memory
-memory: $(RESULTS_DIR)/mem.json
+memory:
 	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
 
 # ==============================================================================


### PR DESCRIPTION
synth builds mem.json as a side-effect, there is no rule with mem.json as a target, so remove the dependency.