### PR TITLE
synthesis: allow blackboxing macros

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -253,6 +253,7 @@ configuration file.
 | `CDL_FILES`              | Insert additional Circuit Description Language (`.cdl`) netlist files.                             | 
 | `DFF_LIB_FILES`          | Technology mapping liberty files for flip-flops.                                                   |
 | `DONT_USE_LIBS`          | Set liberty files as `dont_use`.                                                                   |
+| `MACROS`                 | Marked as black box during synthesis, defaults to `BLOCKS` |
 | `PRESERVE_CELLS`         | Mark modules to keep from getting removed in flattening.                                           |
 | `SYNTH_ARGS`             | Optional synthesis variables for yosys.                                                            |
 | `VERILOG_TOP_PARAMS`     | Apply toplevel params (if exist).                                                                  |

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -57,9 +57,9 @@ if {[info exist ::env(PRESERVE_CELLS)]} {
 
 
 
-if {[info exist ::env(BLOCKS)]} {
+if {[info exist ::env(MACROS)]} {
   hierarchy -check -top $::env(DESIGN_NAME)
-  foreach block $::env(BLOCKS) {
+  foreach block $::env(MACROS) {
     blackbox $block
     puts "blackboxing $block"
   }


### PR DESCRIPTION
If a macro is specified in ADDITIONAL_LEFS/LIBS and it is also present in the Verilog files, use MACROS to list those macros so as to have the module be marked as blackbox.

A Verilog file can contain more than one module, so it isn't always convenient to exclude a .v/sv file to have a module marked as black box.