### PR TITLE
makefile: delete preview macro stuff

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -657,8 +657,6 @@ endif
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,2_4_floorplan_macro,$(RESULTS_DIR)/2_3_floorplan_tdms.odb $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),macro_place))
 
-$(eval $(call do-step,2_floorplan_debug_macros,$(RESULTS_DIR)/2_1_floorplan.odb $(RESULTS_DIR)/1_synth.v $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),floorplan_debug_macros))
-
 # STEP 5: Tapcell and Welltie insertion
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,2_5_floorplan_tapcell,$(RESULTS_DIR)/2_4_floorplan_macro.odb $(TAPCELL_TCL),tapcell))
@@ -1036,18 +1034,6 @@ RESULTS_OAS = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.oas)))
 .PHONY: $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file))
 $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): klayout_%: $(OBJECTS_DIR)/klayout.lyt
 	$(KLAYOUT_CMD) -nn $(OBJECTS_DIR)/klayout.lyt $(RESULTS_DIR)/$*
-
-.PHONY: preview_macro_placement
-
-ifneq ($(or $(MACRO_PLACEMENT),$(MACRO_PLACEMENT_TCL)),)
-MACRO_PREVIEW_ODB = 2_floorplan_debug_macros.odb
-else
-MACRO_PREVIEW_ODB = 2_4_floorplan_macro.odb
-endif
-
-preview_macro_placement:
-	@$(UNSET_AND_MAKE) $(RESULTS_DIR)/$(MACRO_PREVIEW_ODB)
-	@$(UNSET_AND_MAKE) gui_$(MACRO_PREVIEW_ODB)
 
 .PHONY: gui_synth
 gui_synth:

--- a/flow/scripts/floorplan_debug_macros.tcl
+++ b/flow/scripts/floorplan_debug_macros.tcl
@@ -1,6 +1,0 @@
-source $::env(SCRIPTS_DIR)/load.tcl
-load_design 2_1_floorplan.odb 1_synth.sdc
-
-source $::env(SCRIPTS_DIR)/macro_place_util.tcl
-
-write_db $::env(RESULTS_DIR)/2_floorplan_debug_macros.odb


### PR DESCRIPTION
I was excited about this feature, then I ended up never using it and forgot all about it.

Perhaps someone is using it, but the only way to know is to delete it and see if anyone protests in pull request or after it is merged, in which case it is easily restored or reimplemented.