### PR TITLE
[AutoTuner] asap7/aes-block parameter

### DIFF
--- a/flow/designs/asap7/aes-block/autotuner.json
+++ b/flow/designs/asap7/aes-block/autotuner.json
@@ -3,8 +3,8 @@
     "_SDC_CLK_PERIOD": {
         "type": "float",
         "minmax": [
-            100,
-            600
+            300,
+            500
         ],
         "step": 0
     },
@@ -36,7 +36,7 @@
         "type": "int",
         "minmax": [
             0,
-            5
+            2
         ],
         "step": 1
     },
@@ -44,15 +44,15 @@
         "type": "int",
         "minmax": [
             0,
-            5
+            2
         ],
         "step": 1
     },
     "_FR_LAYER_ADJUST": {
         "type": "float",
         "minmax": [
-            0.1,
-            0.3
+            0.0,
+            0.1
         ],
         "step": 0
     },	
@@ -60,7 +60,7 @@
         "type": "float",
         "minmax": [
             0.0,
-            0.99
+            0.1
         ],
         "step": 0
     },


### PR DESCRIPTION
Working without _PINS_DISTANCE, but we aim to add that back in, maybe with a custom fastroute.tcl setup?