### PR TITLE
macro placement: less surprising logging

### DIFF
--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -48,10 +48,10 @@ if {[find_macros] != ""} {
 
   if {[info exists ::env(MACRO_PLACEMENT_TCL)]} {
     source $::env(MACRO_PLACEMENT_TCL)
-    puts "\[INFO\]\[FLOW-xxxx\] Using manual macro placement file $::env(MACRO_PLACEMENT_TCL)"
+    puts "Using manual macro placement file $::env(MACRO_PLACEMENT_TCL)"
   } elseif {[info exists ::env(MACRO_PLACEMENT)]} {
     source $::env(SCRIPTS_DIR)/read_macro_placement.tcl
-    puts "\[INFO\]\[FLOW-xxxx\] Using manual macro placement file $::env(MACRO_PLACEMENT)"
+    puts "Using manual macro placement file $::env(MACRO_PLACEMENT)"
     read_macro_placement $::env(MACRO_PLACEMENT)
   } elseif {[info exists ::env(RTLMP_FLOW)]} {
     puts "HierRTLMP Flow enabled..."


### PR DESCRIPTION
The `[INFO][FLOW-xxxx]` prefix is surprising, leaves questions... What is xxxx? Is something wrong? Should the code be updated?

Generally the .tcl code just puts logging information, so do the same here. There are no other occurrences in the .tcl scripts of `[INFO][FOO-]`.

The openroad binary has error/warning/info numbers that are allocated and guaranteed by build time checks to be unique.