### PR TITLE
flow: removed vestiges of prefixing convention in puts/logging

### DIFF
--- a/flow/platforms/asap7/openRoad/tapcell.tcl
+++ b/flow/platforms/asap7/openRoad/tapcell.tcl
@@ -1,8 +1,8 @@
-puts "\[INFO-FLOW\] Tap and End Cap cell insertion"
-puts "\[INFO-FLOW\]   TAP Cell          : $::env(TAP_CELL_NAME)"
-puts "\[INFO-FLOW\]   ENDCAP Cell       : $::env(TAP_CELL_NAME)"
-puts "\[INFO-FLOW\]   Halo Around Macro : $::env(MACRO_HALO_X) $::env(MACRO_HALO_Y)"
-puts "\[INFO-FLOW\]   TAP Cell Distance : 25"
+puts "Tap and End Cap cell insertion"
+puts "  TAP Cell          : $::env(TAP_CELL_NAME)"
+puts "  ENDCAP Cell       : $::env(TAP_CELL_NAME)"
+puts "  Halo Around Macro : $::env(MACRO_HALO_X) $::env(MACRO_HALO_Y)"
+puts "  TAP Cell Distance : 25"
 
 # allow user to set the halo around macro with MACRO_HALO_?
 tapcell \

--- a/flow/scripts/add_routing_blk.tcl
+++ b/flow/scripts/add_routing_blk.tcl
@@ -45,5 +45,5 @@ foreach inst $allInsts {
 }
 
 if {$cnt != 0} {
-  puts "\[INFO\] created $cnt routing blockages over macros"
+  puts "Created $cnt routing blockages over macros"
 }

--- a/flow/scripts/deletePowerNets.tcl
+++ b/flow/scripts/deletePowerNets.tcl
@@ -18,7 +18,7 @@ proc deleteNetByName {name} {
   set block [$chip getBlock]
   set net [$block findNet $name]
   $net destroySWires
-  puts "\[INFO\] Deleted net '[$net getName]'"
+  puts "Deleted net '[$net getName]'"
 }
 
 deleteNetByName VDD

--- a/flow/scripts/deleteRoutingObstructions.tcl
+++ b/flow/scripts/deleteRoutingObstructions.tcl
@@ -7,5 +7,5 @@ proc deleteRoutingObstructions {} {
   foreach obstruction $obstructions {
     odb::dbObstruction_destroy $obstruction
   }
-  puts "\[INFO\] Deleted [llength $obstructions] routing obstructions"
+  puts "Deleted [llength $obstructions] routing obstructions"
 }

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -78,11 +78,11 @@ if {[info exist ::env(DONT_USE_CELLS)] && $::env(DONT_USE_CELLS) != ""} {
 }
 
 if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CLOCK_PERIOD)]} {
-  puts "\[FLOW\] Extracting clock period from SDC file: $::env(SDC_FILE_CLOCK_PERIOD)"
+  puts "Extracting clock period from SDC file: $::env(SDC_FILE_CLOCK_PERIOD)"
   set fp [open $::env(SDC_FILE_CLOCK_PERIOD) r]
   set clock_period [string trim [read $fp]]
   if {$clock_period != ""} {
-    puts "\[FLOW\] Setting clock period to $clock_period"
+    puts "Setting clock period to $clock_period"
     lappend abc_args -D $clock_period
   }
   close $fp


### PR DESCRIPTION
this convention was never followed through in .tcl, so remove it.