### PR TITLE
asap7: delete some inconsistent logging

### DIFF
--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -1,7 +1,3 @@
-ifeq ($(MAKELEVEL),0)
-$(info [INFO-FLOW] ASU ASAP7 - version 2)
-endif
-
 export PLATFORM                = asap7
 export PROCESS                 = 7
 


### PR DESCRIPTION
This logging is not done by other PDKs, so more consistent now.

I'm highly suspicious of that version number that is being logged.

Vestige? Where is the definition of that version and how do I check if it is the most recent?