### PR TITLE
Memory lists source files actually used

### DIFF
--- a/flow/scripts/mem_dump.py
+++ b/flow/scripts/mem_dump.py
@@ -1,16 +1,12 @@
 import argparse
 import json
-import os
 import sys
 
 
 def format_ram_table_from_json(data, max_bits=None):
     formatting = "{:<15} | {:<15} | {:<15} | {:<50}\n"
-    table = formatting.format("Rows",
-                              "Width",
-                              "Total bits",
-                              "Name")
-    table += "-"*len(table) + "\n"
+    table = formatting.format("Rows", "Width", "Total bits", "Name")
+    table += "-" * len(table) + "\n"
     max_ok = True
     for module_name, module_info in data["modules"].items():
         cells = module_info["cells"]
@@ -21,9 +17,7 @@ def format_ram_table_from_json(data, max_bits=None):
             size = int(parameters["SIZE"], 2)
             width = int(parameters["WIDTH"], 2)
             bits = size * width
-            table += formatting.format(size,
-                                       width,
-                                       bits,
+            table += formatting.format(size, width, bits,
                                        module_name + "." + memory)
             if max_bits is not None and bits > max_bits:
                 max_ok = False
@@ -38,8 +32,11 @@ if __name__ == "__main__":
 
     with open(args.file, 'r') as file:
         json_data = json.load(file)
-    formatted_table, max_ok = format_ram_table_from_json(json_data, args.max_bits)
+    formatted_table, max_ok = format_ram_table_from_json(
+        json_data, args.max_bits)
     print()
     print(formatted_table)
     if not max_ok:
-        sys.exit("ERROR: Synthesized memory size exceeds maximum allowed bits " + str(args.max_bits))
+        sys.exit(
+            "ERROR: Synthesized memory size exceeds maximum allowed bits " +
+            str(args.max_bits))

--- a/flow/scripts/mem_dump.py
+++ b/flow/scripts/mem_dump.py
@@ -32,9 +32,21 @@ if __name__ == "__main__":
 
     with open(args.file, 'r') as file:
         json_data = json.load(file)
+
+    src_files = set()
+    for module_name, module_info in json_data["modules"].items():
+        for cell in module_info["cells"].values():
+            if "src" not in cell["attributes"]:
+                continue
+            src_file = cell["attributes"]["src"].split(":")[0]
+            src_files.add(src_file)
+
+    print("Source files actually used in the design:")
+    print(" " + "\n ".join(src_files))
+
+    print("Memories found in the design:")
     formatted_table, max_ok = format_ram_table_from_json(
         json_data, args.max_bits)
-    print()
     print(formatted_table)
     if not max_ok:
         sys.exit(

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -102,6 +102,8 @@ close $constr
 proc synthesize_check {synth_args} {
   # Generic synthesis
   log_cmd synth -top $::env(DESIGN_NAME) -run :fine {*}$synth_args
+  # Get rid of unused modules
+  clean
   json -o $::env(RESULTS_DIR)/mem.json
   # Run report and check here so as to fail early if this synthesis run is doomed
   exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json


### PR DESCRIPTION
@maliberty This is part documentation that this is possible, part CI regression testing that build times are not affected, part a useful report.

I can immediately use this report to trim down dependencies in bazel-orfs scripts today for manually maintined dependencies. Also, this approach demonstrates some shortcomings compared to cmake's ability to automatically determine dependencies from .cpp and .h files, which is useful to know.

Knowing this information is especially useful when using e.g. Chisel/Amaranth or other RTL metaprogramming where Verilog files are generated.

Example of use. We can see that there are more .v files in dependencies for synthesis for aes, so if I change some .v file that is only used in synthesis, I still have to re-run synthesis.

Carefully maintaining dependencies can save many, many hours of build times for large projects... This is especially useful when iterating on RTL for backend modifications w.r.t. fMax where small changes to RTL that do not change dependencies can lead to large fMax effects and where only parts of the design(not all macros) need to be rebuilt. Think megaboom... 24 hour build times...


These are all the .v files that designs/asap7/aes/config.mk depends on for synthesis today:

```
$ ls *.v | cat
aes_cipher_top.v
aes_inv_cipher_top.v
aes_inv_sbox.v
aes_key_expand_128.v
aes_rcon.v
aes_sbox.v
timescale.v
```

Whereas it could be shortend to:

```
$ git diff
diff --git a/flow/designs/asap7/aes/config.mk b/flow/designs/asap7/aes/config.mk
index 05cd01ae..c1d4096f 100644
--- a/flow/designs/asap7/aes/config.mk
+++ b/flow/designs/asap7/aes/config.mk
@@ -3,7 +3,11 @@ export PLATFORM               = asap7
 export DESIGN_NAME            = aes_cipher_top
 export DESIGN_NICKNAME        = aes
 
-export VERILOG_FILES = $(sort $(wildcard ./designs/src/$(DESIGN_NICKNAME)/*.v))
+export VERILOG_FILES =  ./designs/src/aes/aes_key_expand_128.v \
+ ./designs/src/aes/aes_cipher_top.v \
+ ./designs/src/aes/aes_rcon.v \
+ ./designs/src/aes/aes_sbox.v
+
 export SDC_FILE      = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 
 export ABC_AREA                 = 1
```



```
$ make DESIGN_CONFIG=designs/asap7/aes/config.mk synth memory
[INFO-FLOW] ASU ASAP7 - version 2
Default PVT selection: BC model: NLDM
make: Nothing to be done for 'synth'.
python3 /home/oyvind/OpenROAD-flow-scripts/flow/scripts/mem_dump.py ./results/asap7/aes/base/mem.json
Source files actually used in the design:
 ./designs/src/aes/aes_cipher_top.v
 ./designs/src/aes/aes_rcon.v
 ./designs/src/aes/aes_key_expand_128.v
 ./designs/src/aes/aes_sbox.v
Memories found in the design:
Rows            | Width           | Total bits      | Name                                              
---------------------------------------------------------------------------------------------------------
16              | 8               | 128             | aes_cipher_top.$flatten\u0.\r0.$auto$proc_rom.cc:155:do_switch$406
256             | 8               | 2048            | aes_cipher_top.$flatten\u0.\u0.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\u0.\u1.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\u0.\u2.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\u0.\u3.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us00.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us01.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us02.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us03.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us10.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us11.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us12.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us13.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us20.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us21.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us22.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us23.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us30.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us31.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us32.$auto$proc_rom.cc:155:do_switch$402
256             | 8               | 2048            | aes_cipher_top.$flatten\us33.$auto$proc_rom.cc:155:do_switch$402
```

```
$ ls *.v | cat
aes_cipher_top.v
aes_inv_cipher_top.v
aes_inv_sbox.v
aes_key_expand_128.v
aes_rcon.v
aes_sbox.v
timescale.v
```
