### PR TITLE
makefile: fix eqy failure, use ORFS built eqy

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -303,6 +303,8 @@ OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
 
 YOSYS_CMD               ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
 
+export EQY_EXE ?= $(abspath $(FLOW_HOME)/../dependencies/bin/eqy)
+
 # Use locally installed and built klayout if it exists, otherwise use klayout in path
 KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)
 KLAYOUT_BIN_FROM_DIR = $(KLAYOUT_DIR)/klayout

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -111,7 +111,7 @@ proc run_equivalence_test {} {
     write_eqy_verilog 4_after_rsz.v
     write_eqy_script
 
-    eval exec eqy -d $::env(LOG_DIR)/4_eqy_output \
+    eval exec $::env(EQY_EXE) -d $::env(LOG_DIR)/4_eqy_output \
         --force \
         --jobs $::env(NUM_CORES) \
         $::env(OBJECTS_DIR)/4_eqy_test.eqy \


### PR DESCRIPTION
@maliberty A quick stab at boarding up the broken window with room to refine in the future...

```
$ make DESIGN_CONFIG=designs/nangate45/aes/config.mk cts
[deleted]
[INFO RSZ-0032] Inserted 3 hold buffers.
Error: cts.tcl, 102 couldn't execute eqy: no such file or directory
```