### PR TITLE
Add synthesis canonical input file

### DIFF
--- a/docs/tutorials/FlowTutorial.md
+++ b/docs/tutorials/FlowTutorial.md
@@ -160,7 +160,7 @@ constraints. We will use default configuration variables for this tutorial.
 |--------------------|------------------------------------------------------------------------------------------------------------------------------------------|
 | `PLATFORM`         | Specifies Process design kit.                                                                                                            |
 | `DESIGN_NAME`      | The name of the top-level module of the design                                                                                           |
-| `VERILOG_FILES`    | The path to the design Verilog files                                                                                                     |
+| `VERILOG_FILES`    | The path to the design Verilog files or JSON files providing a description of modules (check `yosys -h write_json` for more details).    |
 | `SDC_FILE`         | The path to design `.sdc` file                                                                                                           |
 | `CORE_UTILIZATION` | The core utilization percentage.                                                                                                         |
 | `PLACE_DENSITY`    | The desired placement density of cells. It reflects how spread the cells would be on the core area. 1 = closely dense. 0 = widely spread |

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -222,7 +222,7 @@ file for each design located in the OpenROAD-flow-scripts directory of
 |-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `PLATFORM`      | Specifies process design kit or technology node to be used.                                                                                                          |
 | `DESIGN_NAME`   | The name of the top-level module of the design.                                                                                                                      |
-| `VERILOG_FILES` | The path to the design Verilog files.                                                                                                                                |
+| `VERILOG_FILES` | The path to the design Verilog files or JSON files providing a description of modules (check `yosys -h write_json` for more details).                                |
 | `SDC_FILE`      | The path to design constraint (SDC) file.                                                                                                                            |
 
 

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -470,7 +470,7 @@ do-synth-report:
 
 .PHONY: memory
 memory:
-	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
+	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/1_0_synth_canonical.json
 
 # ==============================================================================
 
@@ -520,7 +520,7 @@ $(RESULTS_DIR)/1_synth.v: $(RESULTS_DIR)/1_1_yosys.v
 
 .PHONY: clean_synth
 clean_synth:
-	rm -f $(RESULTS_DIR)/1_*.v $(RESULTS_DIR)/1_synth.sdc $(RESULTS_DIR)/mem.json
+	rm -f $(RESULTS_DIR)/1_*.v $(RESULTS_DIR)/1_synth.sdc $(RESULTS_DIR)/1_0_synth_canonical.json
 	rm -f $(REPORTS_DIR)/synth_*
 	rm -f $(LOG_DIR)/1_*
 	rm -f $(SYNTH_STOP_MODULE_SCRIPT)

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -22,7 +22,11 @@ if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
 
 # Read verilog files
 foreach file $::env(VERILOG_FILES) {
-  read_verilog -defer -sv {*}$vIdirsArgs $file
+  if {[file extension $file] == ".json"} {
+    read_json $file
+  } else {
+    read_verilog -defer -sv {*}$vIdirsArgs $file
+  }
 }
 
 
@@ -102,9 +106,10 @@ close $constr
 proc synthesize_check {synth_args} {
   # Generic synthesis
   log_cmd synth -top $::env(DESIGN_NAME) -run :fine {*}$synth_args
-  json -o $::env(RESULTS_DIR)/mem.json
+  clean
+  json -o $::env(RESULTS_DIR)/1_0_synth_canonical.json
   # Run report and check here so as to fail early if this synthesis run is doomed
-  exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
+  exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/1_0_synth_canonical.json
   synth -top $::env(DESIGN_NAME) -run fine: {*}$synth_args
   # Get rid of indigestibles
   chformal -remove


### PR DESCRIPTION
This PR renames `mem.json` file, generated during `synth` stage, to `1_0_synth_canonical.json`, which can be used as synthesis input.

Also, `VERILOG_FILES` behavior was modified to enable passing JSON files (created with `write_json`) - `read_verilog` or `read_json` is used based on the file extension.