### PR TITLE
makefile: improve memory report of used source files

### DIFF
--- a/flow/scripts/mem_dump.py
+++ b/flow/scripts/mem_dump.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
 
     src_files = set()
     for module_name, module_info in json_data["modules"].items():
-        for cell in module_info["cells"].values():
+        for cell in list(module_info["cells"].values()) + [module_info]:
             if "src" not in cell["attributes"]:
                 continue
             src_file = cell["attributes"]["src"].split(":")[0]


### PR DESCRIPTION
This method of finding source files actually in use is useful and timesaving to maintain a list of dependencies, but it is not 100% robust, some files could be left out. Plugged one more hole.