### PR TITLE
flow: Makefile: Explicitly check USE_FILL against '1'

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -865,7 +865,7 @@ elapsed-all:
 
 # ==============================================================================
 
-ifneq ($(USE_FILL),)
+ifeq ($(USE_FILL),1)
 $(eval $(call do-step,6_1_fill,$(RESULTS_DIR)/5_route.odb $(RESULTS_DIR)/5_route.sdc $(FILL_CONFIG),density_fill))
 else
 $(eval $(call do-copy,6_1_fill,5_route.odb))


### PR DESCRIPTION
Only USE_FILL=1 should add metal fill. USE_FILL=0 and when USE_FILL is undefined should not add any metal fill.