### PR TITLE
docker: back out --progress plain buildkit feature for now

### DIFF
--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -82,8 +82,7 @@ _create() {
         --file "${file}" \
         --tag "${imagePath}" \
         ${buildArgs} \
-        "${context}" \
-        --progress plain
+        "${context}"
     rm -f etc/InstallerOpenROAD.sh
 }
 


### PR DESCRIPTION
the --progress plain option is tied to the buildkit feature somehow, doesn't work on Ubuntu out of the box

This progress message was introduced recently in 7c442a1a2