### PR TITLE
gpl: include default overflow threshold values in gpl script

### DIFF
--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -41,10 +41,6 @@ if {$::env(GPL_ROUTABILITY_DRIVEN)} {
 # Parameters for timing driven mode in global placement
 if {$::env(GPL_TIMING_DRIVEN)} {
   lappend global_placement_args {-timing_driven}
-  
-  # Timing-driven iterations will trigger with these overflow values
-  set reweight_overflow {79 64 49 29 21 15}
-  lappend global_placement_args {-timing_driven_net_reweight_overflow} $reweight_overflow
 }
 
 proc do_placement {place_density global_placement_args} {

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -29,6 +29,8 @@ if {[info exist ::env(PLACE_DENSITY_LB_ADDON)]} {
 }
 
 set global_placement_args {}
+
+# Parameters for routability mode in global placement
 if {$::env(GPL_ROUTABILITY_DRIVEN)} {
   lappend global_placement_args {-routability_driven}
     if { [info exists ::env(GPL_TARGET_RC)] } { 
@@ -36,8 +38,13 @@ if {$::env(GPL_ROUTABILITY_DRIVEN)} {
   }
 }
 
+# Parameters for timing driven mode in global placement
 if {$::env(GPL_TIMING_DRIVEN)} {
   lappend global_placement_args {-timing_driven}
+  
+  # Timing-driven iterations will trigger with these overflow values
+  set reweight_overflow {79 64 49 29 21 15}
+  lappend global_placement_args {-timing_driven_net_reweight_overflow} $reweight_overflow
 }
 
 proc do_placement {place_density global_placement_args} {


### PR DESCRIPTION
This should provide easier access for the user to modify values. For example, removing some values can reduce runtime. As mentioned in the text added to gpl README in OR PR: https://github.com/The-OpenROAD-Project/OpenROAD/pull/5318