### PR TITLE
[DO NOT REVIEW YET] mock-alu: add a check in .sdc that output register can be found

### DIFF
--- a/flow/designs/asap7/mock-alu/constraints.sdc
+++ b/flow/designs/asap7/mock-alu/constraints.sdc
@@ -11,3 +11,9 @@ set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
 
 set_input_delay  [expr $clk_period * 0.7] -clock $clk_name $non_clock_inputs 
 set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set output_regs [get_cells *io_out_REG*]
+if {[llength $output_regs] == 0} {
+    puts "ERROR: Could not find *io_out_REG*"
+    exit 1
+}


### PR DESCRIPTION
Will work after https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2101 is merged.