### PR TITLE
Optimize Docker Images for ORFS

### DIFF
--- a/.github/workflows/github-actions-cron-test-installer.yml
+++ b/.github/workflows/github-actions-cron-test-installer.yml
@@ -45,10 +45,10 @@ jobs:
           sudo service docker restart
       - name: Run installer
         run: |
-          ./etc/DockerHelper.sh create -target=dev -os=${{ matrix.os }}
+          ./etc/DockerHelper.sh create -target=dev -os=${{ matrix.os }} -tag=latest
       - name: Build project
         run: |
-          ./etc/DockerHelper.sh create -target=builder -os=${{ matrix.os }}
+          ./etc/DockerHelper.sh create -target=builder -os=${{ matrix.os }} -tag=latest
       - name: Test build
         run: |
           cmd="source ./env.sh ; yosys -help ; openroad -help ; make -C flow ;"

--- a/.github/workflows/github-actions-publish-docker-images.yml
+++ b/.github/workflows/github-actions-publish-docker-images.yml
@@ -1,0 +1,131 @@
+name: Build and publish ORFS images
+on:
+  push:
+    paths:
+      - etc/DependencyInstaller.sh
+      - etc/DockerHelper.sh
+      - .github/workflows/github-actions-publish-docker-images.yml
+      - build_openroad.sh
+      - env.sh
+      - flow/Makefile
+      - docker/Dockerfile.dev
+      - docker/Dockerfile.builder
+  pull_request:
+    paths:
+      - etc/DependencyInstaller.sh
+      - etc/DockerHelper.sh
+      - .github/workflows/github-actions-publish-docker-images.yml
+      - build_openroad.sh
+      - env.sh
+      - flow/Makefile
+      - docker/Dockerfile.dev
+      - docker/Dockerfile.builder
+
+jobs:
+  buildDependenciesImage:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [["ubuntu20.04", "ubuntu:20.04"], ["ubuntu22.04", "ubuntu:22.04"]]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Set environment variables
+        run: |
+          echo "IMAGE_DEPS=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-dev/${{ matrix.os[0] }}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry (GHCR)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: gha
+          password: ${{ github.token }}
+
+      - name: Copy OpenROAD installer
+        run: cp tools/OpenROAD/etc/DependencyInstaller.sh etc/InstallerOpenROAD.sh
+
+      - name: Build and export dependencies image
+        uses: docker/build-push-action@v6
+        with:
+          context: etc
+          push: true
+          tags: ${{ env.IMAGE_DEPS }}:latest
+          file: docker/Dockerfile.dev
+          build-args: |
+            fromImage=${{ matrix.os[1] }}
+            numThreads=$(nproc)
+          cache-from: type=registry,ref=${{ env.IMAGE_DEPS }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_DEPS }}:buildcache,mode=max
+
+  buildORFSImage:
+    needs: buildDependenciesImage
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu20.04", "ubuntu22.04"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
+      - name: Check out repository code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - name: Set environment variables
+        run: |
+          echo "IMAGE=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')/${{ matrix.os }}" >> $GITHUB_ENV
+          echo "IMAGE_DEPS=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-dev/${{ matrix.os }}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # We don't use the build-push-action here because it hangs
+      - name: Build ORFS image
+        run: |
+          docker buildx build \
+            --load \
+            --build-arg fromImage=${{ env.IMAGE_DEPS }}:latest \
+            --build-arg numThreads=$(nproc) \
+            --cache-from type=registry,ref=${{ env.IMAGE }}:buildcache \
+            --tag ${{ env.IMAGE }}:latest \
+            --file docker/Dockerfile.builder \
+            .
+
+      - name: Test build
+        run: |
+          cmd="source ./env.sh && yosys -help && openroad -help && make -C flow ;"
+          docker run ${{ env.IMAGE }}:latest /bin/bash -c "${cmd}"
+
+      - name: Login to GitHub Container Registry (GHCR)
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: gha
+          password: ${{ github.token }}
+
+      - name: Export ORFS image
+        run: |
+          docker buildx build \
+            --build-arg fromImage=${{ env.IMAGE_DEPS }}:latest \
+            --build-arg numThreads=$(nproc) \
+            --cache-from type=registry,ref=${{ env.IMAGE }}:buildcache \
+            --cache-to type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max \
+            --tag ${{ env.IMAGE }}:latest \
+            --file docker/Dockerfile.builder \
+            --push \
+            .

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -4,7 +4,7 @@
 # instead use etc/DockerHelper.sh
 ARG fromImage=openroad/flow-ubuntu22.04-dev:latest
 
-FROM $fromImage
+FROM $fromImage AS openroad-builder-base
 
 ARG numThreads=$(nproc)
 
@@ -12,3 +12,16 @@ COPY . /OpenROAD-flow-scripts
 WORKDIR /OpenROAD-flow-scripts
 
 RUN ./build_openroad.sh --no_init --local --threads ${numThreads}
+
+FROM $fromImage AS openroad-flow-scripts-base
+
+COPY . /OpenROAD-flow-scripts
+
+RUN rm -rf /OpenROAD-flow-scripts/tools /OpenROAD-flow-scripts/.git
+
+COPY --from=openroad-builder-base /OpenROAD-flow-scripts/tools/install /OpenROAD-flow-scripts/tools/install
+
+FROM $fromImage
+
+COPY --from=openroad-flow-scripts-base /OpenROAD-flow-scripts /OpenROAD-flow-scripts
+WORKDIR /OpenROAD-flow-scripts

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -15,7 +15,7 @@ COPY InstallerOpenROAD.sh \
 ARG options=""
 
 RUN ./DependencyInstaller.sh $options \
-      && rm -rf /tmp/installer
+      && rm -rf /tmp/installer /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 ARG fromImage
 

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -30,9 +30,9 @@ _installCommon() {
     fi
     local pkgs="pandas numpy firebase_admin click pyyaml"
     if [[ $(id -u) == 0 ]]; then
-        pip3 install -U $pkgs
+        pip3 install --no-cache-dir -U $pkgs
     else
-        pip3 install --user -U $pkgs
+        pip3 install --no-cache-dir --user -U $pkgs
     fi
 }
 
@@ -70,7 +70,7 @@ _installUbuntuCleanUp() {
 _installUbuntuPackages() {
     export DEBIAN_FRONTEND="noninteractive"
     apt-get -y update
-    apt-get -y install \
+    apt-get -y install --no-install-recommends \
         libqt5multimediawidgets5 \
         libqt5svg5-dev \
         libqt5xmlpatterns5-dev \

--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -20,13 +20,14 @@ usage: $0 [CMD] [OPTIONS]
   push                          Push the docker image to Docker Hub
 
   OPTIONS:
-  -os=OS_NAME                   Choose beween ubuntu20.04 and ubuntu22.04 (default).
-  -target=TARGET                Choose target fo the Docker image:
+  -os=OS_NAME                   Choose between ubuntu20.04 and ubuntu22.04 (default).
+  -target=TARGET                Choose target for the Docker image:
                                   'dev': os + packages to compile app
                                   'builder': os + packages to compile app +
                                              copy source code and build app
   -threads                      Max number of threads to use if compiling.
                                   Default = \$(nproc)
+  -tag                          Use as the image tag. Default is git commit sha
   -ci                           Install CI tools in image
   -h -help                      Show this message and exits
   -username                     Docker Username


### PR DESCRIPTION
# Optimize Docker Images for ORFS

This PR modifies the Dockerfile and scripts for ORFS docker image size optimization and adds CI configuration for deploying to GitHub Registry with build cache for building time optimization.

You can find example built images under:

* [ghcr.io/antmicro/openroad-flow-scripts-test-cache/ubuntu22.04:latest](https://github.com/antmicro/OpenROAD-flow-scripts/pkgs/container/openroad-flow-scripts-test-cache%2Fubuntu22.04)
* [ghcr.io/antmicro/openroad-flow-scripts-test-cache/ubuntu20.04:latest](https://github.com/antmicro/OpenROAD-flow-scripts/pkgs/container/openroad-flow-scripts-test-cache%2Fubuntu20.04)

# Structure

This PR introduces the following modifications:

1. `github-actions-cron-test-installer.yml` - Fixes CI workflow file to pass.
2. `Dockerfile.dev` and `DependencyInstaller.sh` - Removes install cache and skips recommended dependencies, leading to approximately `200MB` image size optimization.
3. `Dockerfile.builder` - Refactors image to perform a multi-stage build, removing build cache and dependencies on intermediate stages. This resulted in a size reduction to `4.3GB` for the output image.
4. `github-actions-publish-docker-images.yml` - CI workflow to build, [test](https://github.com/antmicro/OpenROAD-flow-scripts/blob/61287-optimize-docker-image/.github/workflows/github-actions-publish-docker-images.yml#L108-L111), and push ORFS docker images. Utilizes build cache from previous builds to accelerate the building process.