### PR TITLE
gitignore: there are some .scala files in the source folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ docs/build
 GitGuide.md
 mainREADME.md
 build
+.scala-build/
+.bsp/


### PR DESCRIPTION
Ignore .scala-build folders that can be created by Visual Studio Code when editing ORFS