### PR TITLE
ORFS Dockerfile incremental optimization

### DIFF
--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -1,27 +1,42 @@
+# syntax=docker/dockerfile:1.7-labs
+
 # Target with dependencies to build all flow tools from their sources.
 # i.e., "./build_openroad.sh --local" from inside a docker container
 # NOTE: don't use this file directly unless you know what you are doing,
 # instead use etc/DockerHelper.sh
+
 ARG fromImage=openroad/flow-ubuntu22.04-dev:latest
 
-FROM $fromImage AS openroad-builder-base
+FROM $fromImage AS orfs-base
 
+WORKDIR /OpenROAD-flow-scripts
+COPY --link dev_env.sh dev_env.sh
+COPY --link build_openroad.sh build_openroad.sh
+
+FROM orfs-base AS orfs-builder-base
+
+COPY --link tools tools
 ARG numThreads=$(nproc)
 
-COPY . /OpenROAD-flow-scripts
-WORKDIR /OpenROAD-flow-scripts
+RUN echo "" > tools/yosys/abc/.gitcommit && \
+  ./build_openroad.sh --no_init --local --threads ${numThreads}
 
-RUN ./build_openroad.sh --no_init --local --threads ${numThreads}
+FROM orfs-base
 
-FROM $fromImage AS openroad-flow-scripts-base
+# The order for copying the directories is based on the frequency of changes (ascending order),
+# and the layer size (descending order)
+COPY --link docker docker
+COPY --link flow/tutorials flow/tutorials
+COPY --link docs docs
+COPY --link flow/test flow/test
+COPY --link flow/platforms flow/platforms
+COPY --link flow/util flow/util
+COPY --link flow/scripts flow/scripts
+COPY --link flow/designs flow/designs
 
-COPY . /OpenROAD-flow-scripts
-
-RUN rm -rf /OpenROAD-flow-scripts/tools /OpenROAD-flow-scripts/.git
-
-COPY --from=openroad-builder-base /OpenROAD-flow-scripts/tools/install /OpenROAD-flow-scripts/tools/install
-
-FROM $fromImage
-
-COPY --from=openroad-flow-scripts-base /OpenROAD-flow-scripts /OpenROAD-flow-scripts
-WORKDIR /OpenROAD-flow-scripts
+COPY --link --from=orfs-builder-base /OpenROAD-flow-scripts/tools/install tools/install
+COPY --link \
+     --exclude=.git* --exclude=tools/ --exclude=docs/ --exclude=docker/ \
+     --exclude=flow/designs --exclude=flow/platforms --exclude=flow/scripts \
+     --exclude=flow/test --exclude=flow/tutorials --exclude=flow/util \
+  . ./


### PR DESCRIPTION
# ORFS Dockerfile incremental optimization

This PR splits the final layers in the Docker image to reduce the download size for consecutive pulls, as well as enhances the Docker image build process by optimizing the Dockerfile and leveraging build-cache more effectively.

By separating the image into additional stages, we ensure faster pull speeds when minor changes are introduced, and significantly improve the build process by utilizing previously produced build cache.

You can find example built images under:

* [ghcr.io/antmicro/openroad-flow-scripts-test-cache/ubuntu22.04:latest](https://github.com/antmicro/OpenROAD-flow-scripts/pkgs/container/openroad-flow-scripts-test-cache%2Fubuntu22.04)
* [ghcr.io/antmicro/openroad-flow-scripts-test-cache/ubuntu20.04:latest](https://github.com/antmicro/OpenROAD-flow-scripts/pkgs/container/openroad-flow-scripts-test-cache%2Fubuntu20.04)

CI runs demonstrating the improvements:

1. **Image Built from Scratch**: [View Run](https://github.com/antmicro/OpenROAD-flow-scripts/actions/runs/9890334708)
2. **Minor Modification to README**: This change does not affect the ORFS tools and does not impact most of the ORFS Docker image layers, showcasing the efficiency of the build cache. [View Run](https://github.com/antmicro/OpenROAD-flow-scripts/actions/runs/9891162104) 

This PR introduces the following modifications:

* `docker/Dockerfile.builder`:
  * Multi-Stage Build: The image is divided into multiple stages of copying sources, to leverage caching effectively.
  * Tool Installation: The installation of tools is modified to prevent invalidation of the build cache by avoiding unnecessary copying of git-submodule files.
