### PR TITLE
mock-array: upgrade to Chisel 3.6.1 and chiseltest 0.6.2

### DIFF
--- a/flow/designs/src/mock-array/build.sbt
+++ b/flow/designs/src/mock-array/build.sbt
@@ -8,8 +8,8 @@ scalaVersion := "2.13.6"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-language:reflectiveCalls")
 
 val defaultVersions = Map(
-  "chisel3" -> "3.6.0-RC2",
-  "chiseltest" -> "0.6.0-RC2"
+  "chisel3" -> "3.6.1",
+  "chiseltest" -> "0.6.2"
 )
 
 libraryDependencies ++= (Seq("chisel3", "chiseltest").map { dep: String =>
@@ -17,7 +17,7 @@ libraryDependencies ++= (Seq("chisel3", "chiseltest").map { dep: String =>
     .getOrElse(dep + "Version", defaultVersions(dep)) withSources () withJavadoc ()
 })
 
-addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.6.0-RC2" cross CrossVersion.full)
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % "3.6.1" cross CrossVersion.full)
 
 libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.0"
 


### PR DESCRIPTION
Verified that there is no change in generated Verilog.

Upgrading is just to take a question off the table w.r.t. a problem with post-synthesis simulation in current communication about future PR.