### PR TITLE
Pass multiple lib files to ABC

### DIFF
--- a/docs/user/BuildWithPrebuilt.md
+++ b/docs/user/BuildWithPrebuilt.md
@@ -5,7 +5,7 @@ Please ensure the Klayout version (denoted with `klayoutVersion` variable) is co
 
 Instructions for installing:
 - [Klayout>=0.28.8](https://www.klayout.de/build.html)
-- [Yosys>=0.39](https://github.com/YosysHQ/oss-cad-suite-build/blob/master/README.md#installation)
+- [Yosys>=0.41](https://github.com/YosysHQ/oss-cad-suite-build/blob/master/README.md#installation)
 
 ```{tip} Unfortunately KLayout maintainers do not provide Debian 10/11 compatible packages. You can follow the build-from-sources instruction (Version >=0.25) and Ubuntu 22 instructions [here](https://www.klayout.de/build.html#:~:text=Building%20KLayout%20on%20Linux%20(Version%20%3E%3D%200.25)). 
 ```
@@ -39,7 +39,7 @@ Please ensure the Klayout version (denoted with `klayoutVersion` variable) is co
 
 Instructions for installing:
 - [Klayout>=0.28.8](https://www.klayout.de/build.html)
-- [Yosys>=0.39](https://github.com/YosysHQ/oss-cad-suite-build/blob/master/README.md#installation)
+- [Yosys>=0.41](https://github.com/YosysHQ/oss-cad-suite-build/blob/master/README.md#installation)
 
 ```{tip} Unfortunately KLayout maintainers do not provide Debian 10/11 compatible packages. You can follow the build-from-sources instruction (Version >=0.25) and Ubuntu 22 instructions [here](https://www.klayout.de/build.html#:~:text=Building%20KLayout%20on%20Linux%20(Version%20%3E%3D%200.25)). 
 ```

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -324,8 +324,8 @@ WRAPPED_LIBS = $(foreach lib,$(notdir $(WRAP_LIBS)),$(OBJECTS_DIR)/$(lib:.lib=_m
 export ADDITIONAL_LEFS += $(WRAPPED_LEFS) $(WRAP_LEFS)
 export LIB_FILES += $(WRAP_LIBS) $(WRAPPED_LIBS)
 
-export DONT_USE_LIBS   = $(patsubst %.lib.gz, %.lib, $(addprefix $(OBJECTS_DIR)/lib/, $(notdir $(LIB_FILES))))
-export DONT_USE_SC_LIB ?= $(firstword $(DONT_USE_LIBS))
+export PROCESSED_LIBS   = $(patsubst %.lib.gz, %.lib, $(addprefix $(OBJECTS_DIR)/lib/, $(notdir $(LIB_FILES))))
+export PROCESSED_SC_LIB ?= $(firstword $(PROCESSED_LIBS))
 
 # Stream system used for final result (GDS is default): GDS, GSDII, GDS2, OASIS, or OAS
 STREAM_SYSTEM ?= GDS
@@ -384,12 +384,9 @@ versions.txt:
 # Create temporary Liberty files which have the proper dont_use properties set
 # For use with Yosys and ABC
 .SECONDEXPANSION:
-$(DONT_USE_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
+$(PROCESSED_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
 	@mkdir -p $(OBJECTS_DIR)/lib
 	$(UTILS_DIR)/preprocessLib.py -i $^ -o $@
-
-$(OBJECTS_DIR)/lib/merged.lib:
-	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $(DONT_USE_LIBS) > $@
 
 # Pre-process KLayout tech
 # ==============================================================================
@@ -496,7 +493,7 @@ $(SDC_FILE_CLOCK_PERIOD): $(SDC_FILE)
 	echo $(ABC_CLOCK_PERIOD_IN_PS) > $@
 
 .PHONY: yosys-dependencies
-yosys-dependencies: $(DONT_USE_LIBS) $(WRAPPED_LIBS) $(DONT_USE_SC_LIB) $(DFF_LIB_FILE) $(VERILOG_FILES) $(CACHED_NETLIST) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE)
+yosys-dependencies: $(PROCESSED_LIBS) $(WRAPPED_LIBS) $(PROCESSED_SC_LIB) $(DFF_LIB_FILE) $(VERILOG_FILES) $(CACHED_NETLIST) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE)
 
 .PHONY: do-yosys
 do-yosys: yosys-dependencies

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -271,9 +271,9 @@ endif
 export LIB_FILES             += $($(CORNER)_$(LIB_MODEL)_LIB_FILES)
 export LIB_FILES             += $(ADDITIONAL_LIBS)
 export DB_FILES              += $(realpath $($(CORNER)_DB_FILES))
+export DFF_LIB_FILE           = $($(CORNER)_$(LIB_MODEL)_DFF_LIB_FILE)
 export TEMPERATURE            = $($(CORNER)_TEMPERATURE)
 export VOLTAGE                = $($(CORNER)_VOLTAGE)
-export DONT_USE_SC_LIB        = $(OBJECTS_DIR)/lib/merged.lib
 
 # ---------------------------------------------------------
 #  IR Drop

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -118,7 +118,7 @@ if { [info exist ::env(RESYNTH_TIMING_RECOVER)] && $::env(RESYNTH_TIMING_RECOVER
 
   write_verilog $::env(RESULTS_DIR)/2_pre_abc_timing.v
 
-  restructure -target timing -liberty_file $::env(DONT_USE_SC_LIB) \
+  restructure -target timing -liberty_file $::env(PROCESSED_SC_LIB) \
               -work_dir $::env(RESULTS_DIR)
 
   write_verilog $::env(RESULTS_DIR)/2_post_abc_timing.v
@@ -163,7 +163,7 @@ if { [info exist ::env(RESYNTH_AREA_RECOVER)] && $::env(RESYNTH_AREA_RECOVER) ==
   set tiehi_lib_name [get_name [get_property [lindex [get_lib_cell $tiehi_cell_name] 0] library]]
   set tiehi_port $tiehi_lib_name/$tiehi_cell_name/[lindex $env(TIEHI_CELL_AND_PORT) 1]
 
-  restructure -liberty_file $::env(DONT_USE_SC_LIB) -target "area" \
+  restructure -liberty_file $::env(PROCESSED_SC_LIB) -target "area" \
         -tiehi_port $tiehi_port \
         -tielo_port $tielo_port \
         -work_dir $::env(RESULTS_DIR)

--- a/flow/scripts/sc/tools/openroad/sc_apr.tcl
+++ b/flow/scripts/sc/tools/openroad/sc_apr.tcl
@@ -33,7 +33,7 @@ if {$sc_step == "or_synth"} {
     }
     set merge_cmd $::env(UTILS_DIR)/mergeLib.pl
     lappend merge_cmd $::env(PLATFORM)_merged
-    foreach ff [regexp -all -inline {\S+} $::env(DONT_USE_LIBS)] {
+    foreach ff [regexp -all -inline {\S+} $::env(PROCESSED_LIBS)] {
         lappend merge_cmd $ff
     }
     exec {*}$merge_cmd > ../../merged.lib

--- a/flow/scripts/sc/util/parse_target_config.py
+++ b/flow/scripts/sc/util/parse_target_config.py
@@ -136,8 +136,8 @@ def parse(chip, platform):
         dontuse_l = []
         for lf in libs:
             dontuse_l.append(os.path.join(mod_lib_base, f'{os.path.split(lf)[1]}-mod.lib'))
-        merged_config['DONT_USE_LIBS'] = ' '.join(dontuse_l)
-        merged_config['DONT_USE_SC_LIB'] = os.path.join('..', '..', 'merged.lib')
+        merged_config['PROCESSED_LIBS'] = ' '.join(dontuse_l)
+        merged_config['PROCESSED_SC_LIB'] = os.path.join('..', '..', 'merged.lib')
 
         # Set config environment values to be set during sc flow.
         for key, val in merged_config.items():

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -62,7 +62,7 @@ foreach cell $::env(DONT_USE_CELLS) {
 if {[info exist ::env(DFF_LIB_FILE)]} {
   dfflibmap -liberty $::env(DFF_LIB_FILE) {*}$dfflibmap_args
 } else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB) {*}$dfflibmap_args
+  dfflibmap -liberty $::env(PROCESSED_SC_LIB) {*}$dfflibmap_args
 }
 opt
 

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -9,7 +9,7 @@ techmap
 if {[info exist ::env(DFF_LIB_FILE)]} {
   dfflibmap -liberty $::env(DFF_LIB_FILE)
 } else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB)
+  dfflibmap -liberty $::env(PROCESSED_SC_LIB)
 }
 puts "abc [join $abc_args " "]"
 abc {*}$abc_args

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -30,7 +30,7 @@ foreach file $::env(VERILOG_FILES) {
 
 # Read standard cells and macros as blackbox inputs
 # These libs have their dont_use properties set accordingly
-read_liberty -lib {*}$::env(DONT_USE_LIBS)
+read_liberty -lib {*}$::env(PROCESSED_LIBS)
 
 # Apply toplevel parameters (if exist)
 if {[info exist ::env(VERILOG_TOP_PARAMS)]} {
@@ -64,10 +64,11 @@ if {$::env(ABC_AREA)} {
 }
 
 # Technology mapping for cells
-# ABC supports multiple liberty files, but the hook from Yosys to ABC doesn't
-set abc_args [list -script $abc_script \
-      -liberty $::env(DONT_USE_SC_LIB) \
-      -constr $::env(OBJECTS_DIR)/abc.constr]
+set abc_args [list -script $abc_script -constr $::env(OBJECTS_DIR)/abc.constr]
+
+foreach lib $::env(PROCESSED_LIBS) {
+  lappend abc_args -liberty $lib
+}
 
 # Exclude dont_use cells. This includes macros that are specified via
 # LIB_FILES and ADDITIONAL_LIBS that are included in LIB_FILES.
@@ -90,7 +91,7 @@ if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CL
 
 # Create argument list for stat
 set stat_libs ""
-foreach lib $::env(DONT_USE_LIBS) {
+foreach lib $::env(PROCESSED_LIBS) {
   append stat_libs "-liberty $lib "
 }
 


### PR DESCRIPTION
Yosys allows for passing though multiple .lib files to ABC since version 0.41. Therefore, external liberty merging is no longer required in any part of the flow. This PR removes liberty merging and updates variable names

* Change `DONT_USE_*` variables to `PROCESSED_*` variables to better reflect their meaning (we stopped modifying `dont_use` properties in lib files since #1813)
* Remove the mergeLib rule in Makefile since there are no more users of it
* Pass multiple libs into the abc options
* Add a default `DFF_LIB_FILE` for `asap7` because it appears that it was always supposed to have one, but it instead relied on the FF files being merged into the standard cell files

If/when `dfflibmap` supports reading multiple lib files, we can completely remove `DFF_LIB_FILE` and `PROCESSED_SC_LIB` variables. Restructure may lose some support but the underlying abc version would just have to be updated.