### PR TITLE
asap7: add path groups to constraints.sdc

### DIFF
--- a/flow/platforms/asap7/constraints.sdc
+++ b/flow/platforms/asap7/constraints.sdc
@@ -81,3 +81,11 @@ set max_delay 80
 set_max_delay $max_delay -from $non_clk_inputs -to [all_registers]
 set_max_delay $max_delay -from $all_register_outputs -to [all_outputs]
 set_max_delay $max_delay -from $non_clk_inputs -to [all_outputs]
+
+# This allows us to view the different groups
+# in the histogram in the GUI and also includes these
+# groups in the report
+group_path -name in2reg -from $non_clk_inputs -to [all_registers]
+group_path -name reg2out -from [all_registers] -to [all_outputs]
+group_path -name reg2reg -from [all_registers] -to [all_registers]
+group_path -name in2out -from $non_clk_inputs -to [all_outputs]


### PR DESCRIPTION
platforms/asap7/constraints.sdc, read the comments in that file for the full story, is a shared constraints file for designs, such as mock-array, that is building a hierarchy of macros.

Add path groups to this design so that the slack histogram can filter on path group.

Constraints must be met for each macro in the reg2reg path group, but violations at the macro level for paths outside of the reg2reg path group may or may not be a problem higher up when the macro is used.