### PR TITLE
mock-array: make Element more interesting in simulation

### DIFF
--- a/flow/designs/src/mock-array/Element.v
+++ b/flow/designs/src/mock-array/Element.v
@@ -58,10 +58,10 @@ module Element(
     REG_5 <= io_ins_right;
     REG_6 <= io_ins_left;
     REG_7 <= io_ins_up;
-    io_outs_left_REG <= REG | REG_1;
-    io_outs_up_REG <= REG_2 | REG_3;
-    io_outs_right_REG <= REG_4 | REG_5;
-    io_outs_down_REG <= REG_6 | REG_7;
+    io_outs_left_REG <= REG ^ REG_1;
+    io_outs_up_REG <= REG_2 ^ REG_3;
+    io_outs_right_REG <= REG_4 ^ REG_5;
+    io_outs_down_REG <= REG_6 ^ REG_7;
     REG_8 <= io_lsbIns_4;
   end
 endmodule

--- a/flow/designs/src/mock-array/src/main/scala/MockArray.scala
+++ b/flow/designs/src/mock-array/src/main/scala/MockArray.scala
@@ -74,7 +74,7 @@ class MockArray(width: Int, height: Int, singleElementWidth: Int)
     //  up <-> right
     (io.outs.asSeq zip (io.ins.asSeq ++ Seq(io.ins.asSeq.head))
       .sliding(2).toSeq.reverse.map(_.map(RegNext(_)))).foreach {
-      case (a, b) => a := RegNext(b(0) | b(1))
+      case (a, b) => a := RegNext(b(0) ^ b(1))
     }
 
     // Combinational logic, but a maximum flight path of 4 elements


### PR DESCRIPTION
Previously everything would converge to 1 because everything was OR'ed together, so XOR together to wiggle things more.