### PR TITLE
mock-array: use Verilator instead of Chisel for simulation

### DIFF
--- a/flow/designs/asap7/mock-array/power.tcl
+++ b/flow/designs/asap7/mock-array/power.tcl
@@ -20,5 +20,5 @@ for {set x 0} {$x < 8} {incr x} {
 
 report_parasitic_annotation
 report_power
-read_power_activities -scope TOP/MockArrayTestbench/postSynthesis -vcd designs/src/mock-array/MockArrayTestbench.vcd
+read_power_activities -scope TOP/MockArray -vcd designs/src/mock-array/MockArrayTestbench.vcd
 report_power

--- a/flow/designs/asap7/mock-array/simulate.sh
+++ b/flow/designs/asap7/mock-array/simulate.sh
@@ -11,10 +11,22 @@ cd ../../src/mock-array
 cp ../../../results/asap7/mock-array/base/6_final.v post/MockArrayFinal.v
 cp ../../../results/asap7/mock-array_Element/base/6_final.v post/MockArrayElementFinal.v
 
-pwd
-rm -rf test_run_dir/
-sbt -Duser.home="$HOME" -Djline.terminal=jline.UnsupportedTerminal -batch \
-     "test:runMain SimulatePostSynthesis --width ${MOCK_ARRAY_COLS} --height ${MOCK_ARRAY_ROWS} --dataWidth ${MOCK_ARRAY_DATAWIDTH}"
+verilator -Wall --cc \
+  -Wno-DECLFILENAME \
+  -Wno-UNUSEDSIGNAL \
+  -Wno-PINMISSING \
+  --top-module MockArray \
+  --trace \
+  $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_AO_RVT_TT_201020.v \
+  $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_INVBUF_RVT_TT_201020.v \
+  $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v \
+  $PLATFORM_DIR/verilog/stdcell/dff.v \
+  $PLATFORM_DIR/verilog/stdcell/empty.v \
+  ../../../results/asap7/mock-array/base/6_final.v \
+  ../../../results/asap7/mock-array_Element/base/6_final.v \
+  --exe \
+  ../../../designs/src/mock-array/simulate.cpp
 
-cp test_run_dir/MockArray_should_Wiggle_some_wires/MockArrayTestbench.vcd .
+make -C obj_dir -f VMockArray.mk
 
+obj_dir/VMockArray

--- a/flow/designs/asap7/mock-array/verilog.sh
+++ b/flow/designs/asap7/mock-array/verilog.sh
@@ -14,8 +14,3 @@ sbt -Duser.home="$HOME" -Djline.terminal=jline.UnsupportedTerminal -batch \
 
 # reduce git noise as these comments will change if the line numbers in Chisel changes
 find . -name "*.v" -type f -exec sed -i 's/ \/\/.*$//' {} \;
-
-sbt -Duser.home="$HOME" -Djline.terminal=jline.UnsupportedTerminal -batch \
-     "test:runMain GenerateMockArray --width ${MOCK_ARRAY_COLS} --height ${MOCK_ARRAY_ROWS} --dataWidth ${MOCK_ARRAY_DATAWIDTH} -- --emit-modules verilog --emission-options disableMemRandomization,disableRegisterRandomization --target-dir ."
-
-cp test_run_dir/MockArray_should_Wiggle_some_wires/MockArray.vcd .

--- a/flow/designs/src/mock-array/.gitignore
+++ b/flow/designs/src/mock-array/.gitignore
@@ -8,3 +8,4 @@ target/
 .bsp/
 test_run_dir/
 MockArrayTestbench.vcd
+obj_dir/

--- a/flow/designs/src/mock-array/simulate.cpp
+++ b/flow/designs/src/mock-array/simulate.cpp
@@ -1,0 +1,78 @@
+#include "VMockArray.h"
+#include "verilated.h"
+#include <verilated_vcd_c.h>
+
+int main(int argc, char** argv) {
+    Verilated::commandArgs(argc, argv);
+    VMockArray * top = new VMockArray;
+    
+    Verilated::traceEverOn(true);
+    auto *vcd = new VerilatedVcdC;
+
+    top->reset = 1;
+    top->clock = 0;
+
+    QData *inputs[] = {
+    &top->io_ins_down_0,
+    &top->io_ins_down_1,
+    &top->io_ins_down_2,
+    &top->io_ins_down_3,
+    &top->io_ins_down_4,
+    &top->io_ins_down_5,
+    &top->io_ins_down_6,
+    &top->io_ins_down_7,
+    &top->io_ins_left_0,
+    &top->io_ins_left_1,
+    &top->io_ins_left_2,
+    &top->io_ins_left_3,
+    &top->io_ins_left_4,
+    &top->io_ins_left_5,
+    &top->io_ins_left_6,
+    &top->io_ins_left_7,
+    &top->io_ins_right_0,
+    &top->io_ins_right_1,
+    &top->io_ins_right_2,
+    &top->io_ins_right_3,
+    &top->io_ins_right_4,
+    &top->io_ins_right_5,
+    &top->io_ins_right_6,
+    &top->io_ins_right_7,
+    &top->io_ins_up_0,
+    &top->io_ins_up_1,
+    &top->io_ins_up_2,
+    &top->io_ins_up_3,
+    &top->io_ins_up_4,
+    &top->io_ins_up_5,
+    &top->io_ins_up_6,
+    &top->io_ins_up_7
+    };
+
+    top->trace(vcd, 99); // Trace all levels of hierarchy
+    vcd->open("MockArrayTestbench.vcd");
+
+    int tick = 0;
+    for (int j = 0; j < sizeof(inputs)/sizeof(*inputs); j++) {
+        for (int i = 0; i < 5; i++) {
+            // if (Verilated::gotFinish()) {
+            //     goto done;
+            // }
+            *inputs[j] = tick ^ ((tick/2)%2 ? 0 : 0xffffffffffffffffUL);
+            if (tick == 9) {
+                top->reset = 0;
+            }
+
+            for (int k = 0; k < 2; k++) {
+                top->eval();
+                vcd->dump(tick++);
+                top->clock = !top->clock;
+            }
+        }
+    }
+    done:
+    vcd->flush();
+    vcd->close();
+
+    top->final();
+    delete top;
+    return 0;
+}


### PR DESCRIPTION
Simplifies dependencies for CI testing and is also a more accessible example as not everybody uses Chisel...

```
make DESIGN_CONFIG=designs/asap7/mock-array/config.mk final simulate power
```

Roughly expected output from `make power`:

```
Found 1288 unannotated drivers.
Found 7560 partially unannotated drivers.
Group                  Internal  Switching    Leakage      Total
                          Power      Power      Power      Power (Watts)
----------------------------------------------------------------
Sequential             4.14e-01   1.16e-01   6.43e-06   5.30e-01  59.1%
Combinational          1.24e-01   1.00e-01   4.57e-06   2.25e-01  25.0%
Clock                  6.87e-02   7.36e-02   6.51e-07   1.42e-01  15.9%
Macro                  0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
Pad                    0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
----------------------------------------------------------------
Total                  6.07e-01   2.90e-01   1.16e-05   8.97e-01 100.0%
                          67.7%      32.3%       0.0%
Annotated 217546 pin activities.
Group                  Internal  Switching    Leakage      Total
                          Power      Power      Power      Power (Watts)
----------------------------------------------------------------
Sequential             1.70e+00   7.59e-01   6.46e-06   2.46e+00  60.0%
Combinational          8.28e-01   6.65e-01   4.75e-06   1.49e+00  36.5%
Clock                  6.87e-02   7.36e-02   6.51e-07   1.42e-01   3.5%
Macro                  0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
Pad                    0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
----------------------------------------------------------------
Total                  2.59e+00   1.50e+00   1.19e-05   4.09e+00 100.0%
                          63.4%      36.6%       0.0%
```
