### PR TITLE
makefile: make it easier to find log

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -630,7 +630,7 @@ do-$(1): $(OBJECTS_DIR)/copyright.txt
 	trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
 	$(OPENROAD_EXE) -exit -no_init $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
 	$(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \
-	tee -a $(LOG_DIR)/$(1).tmp.log)
+	tee -a $(abspath $(LOG_DIR)/$(1).tmp.log))
 endef
 
 # generate make rules to copy a file, if a dependency change and


### PR DESCRIPTION
Use case is to follow logs of a running process on some computer without knowing the folder name of that process:

- run `ps -Af | grep openroad`
- run `tail -f <full path>/5_3_route.tmp.log`