### PR TITLE
asap7: speed up report_checks when using path groups for large designs

### DIFF
--- a/flow/platforms/asap7/constraints.sdc
+++ b/flow/platforms/asap7/constraints.sdc
@@ -86,6 +86,6 @@ set_max_delay $max_delay -from $non_clk_inputs -to [all_outputs]
 # in the histogram in the GUI and also includes these
 # groups in the report
 group_path -name in2reg -from $non_clk_inputs -to [all_registers]
-group_path -name reg2out -from [all_registers] -to [all_outputs]
-group_path -name reg2reg -from [all_registers] -to [all_registers]
+group_path -name reg2out -from [all_clocks] -to [all_outputs]
+group_path -name reg2reg -from [all_clocks] -to [all_registers]
 group_path -name in2out -from $non_clk_inputs -to [all_outputs]


### PR DESCRIPTION
Takes running time of first report_checks on a large test design from 25 minutes to 2 minutes or so, which is the same roughly as on master.

Note that there are no large projects in ORFS that exhibits this behavior as the goal in ORFS is to maximize testing coverage while reining in running times for tests.