### PR TITLE
makefile: add GUI_ARGS and GUI_SOURCE env vars

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -144,6 +144,8 @@ Note:
 | `IO_PLACER_H`         | The metal layer on which to place the I/O pins horizontally (top and bottom of the die).                                                                                         |
 | `IO_PLACER_V`         | The metal layer on which to place the I/O pins vertically (sides of the die).                                                                                                    |
 | `GUI_NO_TIMING`       | Skip loading timing for a faster GUI load.                                                                                                                                       |
+| `GUI_SOURCE` | Source the script. |
+| `GUI_ARGS` | OpenROAD command line options for gui_ and open_ targets, typically set tup `-exit` in combination with GUI_SOURCE to run a script and exit. |
 
 
 ### Placement

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -584,7 +584,7 @@ endef
 define OPEN_GUI
 .PHONY: $(1)_$(2)
 $(1)_$(2):
-	$(3)=$(RESULTS_DIR)/$(2) $(4) $(SCRIPTS_DIR)/gui.tcl
+	$(3)=$(RESULTS_DIR)/$(2) $(4) $(GUI_ARGS) $(SCRIPTS_DIR)/gui.tcl
 endef
 
 # Separate dependency checking and doing a step. This can
@@ -1056,10 +1056,10 @@ $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): kl
 
 .PHONY: gui_synth
 gui_synth:
-	$(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
+	$(OPENROAD_GUI_CMD) $(GUI_ARGS) $(SCRIPTS_DIR)/sta-synth.tcl
 .PHONY: open_synth
 open_synth:
-	$(OPENROAD_NO_EXIT_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
+	$(OPENROAD_NO_EXIT_CMD) $(GUI_ARGS) $(SCRIPTS_DIR)/sta-synth.tcl
 
 $(eval $(call OPEN_GUI_SHORTCUT,floorplan,2_floorplan.odb))
 $(eval $(call OPEN_GUI_SHORTCUT,place,3_place.odb))

--- a/flow/scripts/gui.tcl
+++ b/flow/scripts/gui.tcl
@@ -66,3 +66,7 @@ if {![info exist ::env(GUI_NO_TIMING)]} {
   # Cleanup temporary variables
   unset sdc_file s design_stage
 }
+
+if {[info exist env(GUI_SOURCE)]} {
+  source $::env(GUI_SOURCE)
+}

--- a/flow/scripts/sta-synth.tcl
+++ b/flow/scripts/sta-synth.tcl
@@ -1,2 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_synth.v 1_synth.sdc
+
+if {[info exist env(GUI_SOURCE)]} {
+  source $::env(GUI_SOURCE)
+}


### PR DESCRIPTION
These are used to execute a script upon startup and possibly exit immediately.

Previously `echo report_checks | make open_synth` was used, but the problem here is that if the command fails, then the error isn't and shouldn't be propagated to the user as open_synth is a REPL loop that should not propagate the exit code for a failed command, the app should continue to run.

Example uses:

```
make GUI_ARGS=-exit GUI_SOURCE=blah.tcl open_final
make GUI_ARGS=-exit GUI_SOURCE=blah.tcl open_synth
```

Failure to propagate error example:

```
$ echo abc | make open_synth
/home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init   /home/oyvind/OpenROAD-flow-scripts/flow/scripts/sta-synth.tcl
[deleted]
openroad> abc
invalid command name "abc"
while evaluating abc
openroad> 
$ echo $?
0
```
