### PR TITLE
makefile: reduce number of shell invocations

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -312,7 +312,9 @@ KLAYOUT_BIN_FROM_DIR = $(KLAYOUT_DIR)/klayout
 ifeq ($(wildcard $(KLAYOUT_BIN_FROM_DIR)), $(KLAYOUT_BIN_FROM_DIR))
 KLAYOUT_CMD ?= sh -c 'LD_LIBRARY_PATH=$(dir $(KLAYOUT_BIN_FROM_DIR)) $$0 "$$@"' $(KLAYOUT_BIN_FROM_DIR)
 else
-KLAYOUT_CMD ?= $(shell command -v klayout)
+ifeq ($(KLAYOUT_CMD),)
+KLAYOUT_CMD := $(shell command -v klayout)
+endif
 endif
 KLAYOUT_FOUND            = $(if $(KLAYOUT_CMD),,$(error KLayout not found in PATH))
 
@@ -404,7 +406,7 @@ do-klayout_tech:
 	cp $(TECH_LEF) $(OBJECTS_DIR)/klayout_tech.lef
 
 KLAYOUT_ENV_VAR_IN_PATH_VERSION = 0.28.11
-KLAYOUT_VERSION = $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
+KLAYOUT_VERSION := $(shell $(KLAYOUT_CMD) -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2)
 
 KLAYOUT_ENV_VAR_IN_PATH = $(shell \
 	if [ -z "$(KLAYOUT_VERSION)" ]; then \


### PR DESCRIPTION
While debugging a problem, I discovered that I can list all the shell commands run in make using the command below.

Modified Makefile so that klayout version is resolved once instead of many times.

```
$ make ".SHELLFLAGS=--verbose -o pipefail -c" print-HELLO
pwd
nproc 2>/dev/null
command -v lsoracle
/usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' echo foo 2>/dev/null
command -v klayout
command -v stdbuf
echo GDS | tr '[:lower:]' '[:upper:]'
/usr/bin/klayout -v 2>/dev/null | grep 'KLayout' | cut -d ' ' -f2
if [ -z "0.28.5" ]; then echo "not_found"; elif [ "$(echo -e "0.28.5\n0.28.11" | sort -V | head -n1)" = "0.28.5" ] && [ "0.28.5" != "0.28.11" ]; then echo "invalid"; else echo "valid"; fi
/usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' echo foo 2>/dev/null
/usr/bin/time -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.' echo foo 2>/dev/null
sed -nE "s/^set\s+clk_period\s+(\S+).*|.*-period\s+(\S+).*/\1\2/p" ./designs/nangate45/gcd/constraint.sdc | head -1 | awk '{print $1}'
echo "HELLO = "
HELLO = 
```