### PR TITLE
Add docker-buildx package installation

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -71,6 +71,7 @@ _installUbuntuPackages() {
     export DEBIAN_FRONTEND="noninteractive"
     apt-get -y update
     apt-get -y install --no-install-recommends \
+        curl \
         libqt5multimediawidgets5 \
         libqt5svg5-dev \
         libqt5xmlpatterns5-dev \
@@ -103,24 +104,6 @@ _installUbuntuPackages() {
         cd ${lastDir}
         rm -rf "${baseDir}"
     fi
-}
-
-_installDarwinPackages() {
-    brew install libffi tcl-tk ruby
-    brew install python libomp
-    brew link --force libomp
-    brew install --cask klayout
-}
-
-_installCI() {
-    apt-get -y update
-    apt-get -y install --no-install-recommends \
-        apt-transport-https \
-        ca-certificates \
-        coreutils \
-        curl \
-        python3 \
-        software-properties-common
 
     # Add Docker's official GPG key:
     install -m 0755 -d /etc/apt/keyrings
@@ -138,8 +121,26 @@ _installCI() {
         docker-ce \
         docker-ce-cli \
         containerd.io \
-        docker-buildx-plugin \
+        docker-buildx-plugin
+}
 
+_installDarwinPackages() {
+    brew install libffi tcl-tk ruby
+    brew install python libomp
+    brew link --force libomp
+    brew install --cask klayout
+    brew install docker docker-buildx
+}
+
+_installCI() {
+    apt-get -y update
+    apt-get -y install --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        coreutils \
+        curl \
+        python3 \
+        software-properties-common
 }
 
 _help() {


### PR DESCRIPTION
Since https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2155 Docker images are built with `buildx`, which is not a part of docker and has to be installed. It can fail with error like:

```
$ ./build_openroad.sh
[...]
Create docker image openroad/flow-ubuntu22.04-dev:761c66 using docker/Dockerfile.dev
unknown flag: --file
See 'docker --help'.

Usage:  docker [OPTIONS] COMMAND

A self-sufficient runtime for containers

Common Commands:
  run         Create and run a new container from an image
  exec        Execute a command in a running container
[...]
```

This PR adds installation of docker-buildx to `DependencyInstaller.sh`