### PR TITLE
update mkdir call since we're writing into RESULTS_DIR

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -510,7 +510,7 @@ $(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_synth.rtlil
 	$(UNSET_AND_MAKE) do-yosys
 
 $(RESULTS_DIR)/1_synth.sdc: $(SDC_FILE)
-	mkdir -p $(REPORTS_DIR)
+	mkdir -p $(RESULTS_DIR)
 	cp $(SDC_FILE) $(RESULTS_DIR)/1_synth.sdc
 
 .PHONY: do-synth


### PR DESCRIPTION
The change is a no-op, since the RESULTS_DIR is created a couple of times before the 1_synth.sdc file is copied. But, we are writing into the RESULTS_DIR and not the REPORTS_DIR here.