### PR TITLE
asap7: report_checks -from [all_registers] -to [all_registers] is now fast

### DIFF
--- a/flow/platforms/asap7/constraints.sdc
+++ b/flow/platforms/asap7/constraints.sdc
@@ -86,6 +86,6 @@ set_max_delay $max_delay -from $non_clk_inputs -to [all_outputs]
 # in the histogram in the GUI and also includes these
 # groups in the report
 group_path -name in2reg -from $non_clk_inputs -to [all_registers]
-group_path -name reg2out -from [all_clocks] -to [all_outputs]
-group_path -name reg2reg -from [all_clocks] -to [all_registers]
+group_path -name reg2out -from [all_registers] -to [all_outputs]
+group_path -name reg2reg -from [all_registers] -to [all_registers]
 group_path -name in2out -from $non_clk_inputs -to [all_outputs]


### PR DESCRIPTION
`-from [all_clocks]` is not exactly the same as `-from [all_registers]`, but before OpenSTA was optimized for the `-from [all_registers]` case, `-from [all_clocks]` was the best we code do.


I don't think the DRC errors are relevant. mpl2 should have left [a bit of space between the rows](https://github.com/The-OpenROAD-Project/OpenROAD/issues/5522) of the elements.

![image](https://github.com/user-attachments/assets/6bcdafb6-95f4-449a-8bbf-2b7b53b043b4)
