### PR TITLE
asap7/mock-array: add some space between element rows

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -74,6 +74,8 @@ export FASTROUTE_TCL = ./designs/$(PLATFORM)/mock-array/fastroute.tcl
 export MACRO_HALO_X            = 0.5
 export MACRO_HALO_Y            = 0.5
 
+export MACRO_PLACE_HALO = 0 2.16
+
 export CTS_BUF_DISTANCE = 60
 
 export ADDITIONAL_FILES = designs/src/mock-array/util.tcl


### PR DESCRIPTION
Bring back the MACRO_PLACE_HALO=0 2.16.

I don't think it was removed for a reason. There needs to be some place between the element rows so that the clock can be routed.

There's some sort of problem, because even with this change, there's no space between the element rows:

```
$ make DESIGN_CONFIG=designs/asap7/mock-array/config.mk do-2_4_floorplan_macro gui_2_4_floorplan_macro 
[INFO][FLOW] Invoked hierarchical flow.
Block Element needs to be hardened.
OpenROAD v2.0-15041-g158e25fe0 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 20 thread(s).
mkdir -p ./objects/asap7/mock-array/base
Running macro_place.tcl, stage 2_4_floorplan_macro
[INFO ORD-0030] Using 20 thread(s).
HierRTLMP Flow enabled...
rtl_macro_placer -halo_width 0 -halo_height 2.16 -boundary_weight 0 -report_directory ./objects/asap7/mock-array/base/rtlmp -target_util 0.30
Floorplan Outline: (0.0, 0.0) (358.56, 388.8),  Core Outline: (2.16, 2.16) (356.4, 386.64)
	Number of std cell instances: 129
	Area of std cell instances: 23.37
	Number of macros: 64
	Area of macros: 119439.39
	Halo width: 0.00
	Halo height: 2.16
	Area of macros with halos: 131383.38
	Area of std cell instances + Area of macros: 119462.77
	Core area: 136198.20
	Design Utilization: 0.88
	Core Utilization: 0.00
	Manufacturing Grid: 1

Elapsed time: 0:04.24[h:]min:sec. CPU time: user 36.83 sys 0.05 (868%). Peak memory: 266888KB.
ODB_FILE=./results/asap7/mock-array/base/2_4_floorplan_macro.odb /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -gui   /home/oyvind/OpenROAD-flow-scripts/flow/scripts/gui.tcl
QSocketNotifier: Can only be used with threads started with QThread
OpenROAD v2.0-15041-g158e25fe0 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[WARNING GUI-0066] Heat map "IR Drop" has not been populated with data.
```


![image](https://github.com/user-attachments/assets/04304624-8057-46be-adb8-73b8e1934950)
