### PR TITLE
removed CTS_BUF_CELL from design config makefiles

### DIFF
--- a/flow/designs/asap7/swerv_wrapper/config.mk
+++ b/flow/designs/asap7/swerv_wrapper/config.mk
@@ -23,7 +23,6 @@ export CORE_AREA   = 5 5 545 595
 
 export PLACE_PINS_ARGS = -exclude left:* -exclude right:* 
 export PLACE_DENSITY_LB_ADDON = 0.20
-export CTS_BUF_CELL  = BUFx8_ASAP7_75t_R
 
 export FASTROUTE_TCL = ./designs/$(PLATFORM)/swerv_wrapper/fastroute.tcl
 

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -29,7 +29,6 @@ export MACRO_PLACE_HALO = 100 100
 export MACRO_PLACE_CHANNEL = 200 200
 
 # CTS tuning
-export CTS_BUF_CELL = sky130_fd_sc_hd__clkbuf_8
 export CTS_BUF_DISTANCE = 600
 #export CTS_CLUSTER_DIAMETER = 100
 #export CTS_CLUSTER_SIZE = 30


### PR DESCRIPTION
Removed CTS_BUF_CELL from asap7/swerv_wrapper and sky130hd/microwatt config.mk's. Forgot to remove them as part of prior commit that removed CTS_BUF_CELL from the README