### PR TITLE
fillcell: remove unused set_metrics_storage

### DIFF
--- a/flow/scripts/fillcell.tcl
+++ b/flow/scripts/fillcell.tcl
@@ -1,4 +1,3 @@
-utl::set_metrics_stage "globalroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 5_1_grt.odb 4_cts.sdc
 


### PR DESCRIPTION
Probably accidentally copy and pasted set_metrics_stage from global route.

report_metrics is not called in fillcell.tcl