### PR TITLE
Add power simulation support and Verilator to the CI pipeline

### DIFF
--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -2,7 +2,7 @@
 
 set -eoux pipefail
 
-cd "$(dirname $(readlink -f $0))/../"
+cd "$(dirname "$(readlink -f "$0")")/../"
 
 # Setting args (and setting default values for testing)
 DESIGN_NAME=${1:-gcd}
@@ -13,20 +13,20 @@ if [ $# -eq 4 ]; then
 fi
 DESIGN_CONFIG=./designs/$PLATFORM/$DESIGN_NAME/$CONFIG_MK
 LOG_FILE=./logs/$PLATFORM/$DESIGN_NAME.log
-mkdir -p ./logs/$PLATFORM
+mkdir -p "./logs/$PLATFORM"
 
 __make="make DESIGN_CONFIG=$DESIGN_CONFIG"
-if [ ! -z "${FLOW_VARIANT+x}" ]; then
+if [ -n "${FLOW_VARIANT+x}" ]; then
   __make+=" FLOW_VARIANT=$FLOW_VARIANT"
 fi
 
-mkdir -p $(dirname $LOG_FILE)
-$__make clean_all clean_metadata 2>&1 | tee $LOG_FILE
+mkdir -p "$(dirname "$LOG_FILE")"
+$__make clean_all clean_metadata 2>&1 | tee "$LOG_FILE"
 
 # turn off abort on error so we can always capture the result
 set +e
 
-$__make finish metadata 2>&1 | tee -a $LOG_FILE
+$__make finish metadata 2>&1 | tee -a "$LOG_FILE"
 
 # Save the return code to return as the overall status after we package
 # the results
@@ -36,21 +36,21 @@ if [ -z "${PRIVATE_DIR+x}" ]; then
   PRIVATE_DIR="../../private_tool_scripts"
 fi
 
-if [ -f "$PRIVATE_DIR/openRoad/private.mk" ] && [ ! -z ${SAVE_TO_DB+x} ]; then
+if [ -f "$PRIVATE_DIR/openRoad/private.mk" ] && [ -n "${SAVE_TO_DB+x}" ]; then
   $__make save_to_metrics_db
   ret=$(( ret + $? ))
 fi
 
-if [ -f "$PRIVATE_DIR/util/utils.mk" ] && [ ! -z ${RUN_CALIBRE+x} ]; then
+if [ -f "$PRIVATE_DIR/util/utils.mk" ] && [ -n "${RUN_CALIBRE+x}" ]; then
   $__make calibre_drc
   ret=$(( ret + $? ))
   $__make convert_calibre
   ret=$(( ret + $? ))
-  if [ ! -z ${SAVE_TO_DB+x} ]; then
+  if [ -n "${SAVE_TO_DB+x}" ]; then
     $__make save_to_drc_db
     ret=$(( ret + $? ))
   fi
-  if [ ! -z ${CHECK_DRC_DB+x} ]; then
+  if [ -n "${CHECK_DRC_DB+x}" ]; then
     $__make check_drc_db
     ret=$(( ret + $? ))
   fi
@@ -59,8 +59,8 @@ fi
 # Only enabled abort on error at the end to allow script to reach make issue
 set -e
 
-if [ ! -z ${MAKE_ISSUE+x} ]; then
-  $__make final_report_issue 2>&1 | tee -a $LOG_FILE
+if [ -n "${MAKE_ISSUE+x}" ]; then
+  $__make final_report_issue 2>&1 | tee -a "$LOG_FILE"
 fi
 
 exit $ret

--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -63,4 +63,15 @@ if [ -n "${MAKE_ISSUE+x}" ]; then
   $__make final_report_issue 2>&1 | tee -a "$LOG_FILE"
 fi
 
+# Find make targets
+TARGETS=$($__make -np | grep -e '^[^ ]*:')
+if [ $ret -eq 0 ] && grep -q 'simulate:' <(echo $TARGETS); then
+  $__make simulate 2>&1 | tee -a "$LOG_FILE"
+  ret=$(( ret + $? ))
+fi
+if [ $ret -eq 0 ] && grep -q 'power:' <(echo $TARGETS); then
+  $__make power 2>&1 | tee -a "$LOG_FILE"
+  ret=$(( ret + $? ))
+fi
+
 exit $ret


### PR DESCRIPTION
# Add power simulation support and Verilator to the CI pipeline

This PR enhances the test suite by introducing `simulate` and `power` build targets for designs that include a `power.tcl` file. The `power.tcl` file sets the pass/fail criteria for power simulations, ensuring that tests are run only for designs with these predefined criteria.

This PR modifies the following:

* `flow/test/test_helper.sh` - Updated to execute power simulation for designs that have a `power.tcl` file present
* `docker/Dockerfile.builder` - Adds build and installation instructions for the Verilator
* `etc/DependencyInstaller.sh` - Updates dependencies to cover those of Verilator
* `.gitmodules` - Adds Verilator as a sub-module located under the `tools/verilator` path