### PR TITLE
Makefile: fix make issue snag

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -392,9 +392,17 @@ $(foreach block,$(BLOCKS),$(eval ./results/$(PLATFORM)/$(DESIGN_NICKNAME)_$(bloc
 .PHONY: versions.txt
 versions.txt:
 	mkdir -p $(OBJECTS_DIR)
-	@$(YOSYS_CMD) -V > $(OBJECTS_DIR)/$@
+	@if [ -z "$(YOSYS_CMD)" ]; then \
+		echo >> $(OBJECTS_DIR)/$@ "yosys not installed"; \
+	else \
+		$(YOSYS_CMD) -V > $(OBJECTS_DIR)/$@; \
+	fi
 	@echo openroad `$(OPENROAD_EXE) -version` >> $(OBJECTS_DIR)/$@
-	@$(KLAYOUT_CMD) -zz -v >> $(OBJECTS_DIR)/$@
+	@if [ -z "$(KLAYOUT_CMD)" ]; then \
+		echo >> $(OBJECTS_DIR)/$@ "klayout not installed"; \
+	else \
+		$(KLAYOUT_CMD) -zz -v >> $(OBJECTS_DIR)/$@; \
+	fi
 
 # Pre-process libraries
 # ==============================================================================


### PR DESCRIPTION
versions.txt for make issue now works with blank KLAYOUT_CMD and/or YOSYS_CMD

KLAYOUT_CMD is optional if one doesn't need to run through final and YOSYS_CMD is optional as the netlist can be cached.

```
$ make KLAYOUT_CMD= YOSYS_CMD= versions.txt
mkdir -p ./objects/nangate45/gcd/base
$ cat objects/nangate45/gcd/base/versions.txt
klayout not installed
yosys not installed
openroad v2.0-15055-gdb7d56e4d
klayout not installed
$ make versions.txt
mkdir -p ./objects/nangate45/gcd/base
$ cat objects/nangate45/gcd/base/versions.txt
Yosys 0.44 (git sha1 80ba43d26, clang++ 16.0.6 -fPIC -O3) openroad v2.0-15055-gdb7d56e4d
KLayout 0.28.5
```