### PR TITLE
test: make issue now demonstrates ISSUE_TAG

### DIFF
--- a/flow/test/test_make_issue.sh
+++ b/flow/test/test_make_issue.sh
@@ -5,14 +5,15 @@ set -ue -o pipefail
 testname=Element
 
 make DESIGN_CONFIG=designs/asap7/mock-array/$testname/config.mk floorplan
-make DESIGN_CONFIG=designs/asap7/mock-array/$testname/config.mk io_placement_random_issue
-latest_file=$(ls -t io_placement_random_mock-array_${testname}_asap7_base*.tar.gz | head -n1)
-echo "Testing $latest_file"
+make ISSUE_TAG=tag DESIGN_CONFIG=designs/asap7/mock-array/$testname/config.mk io_placement_random_issue
+test_archive=io_placement_random_tag.tar.gz
+ls -l $test_archive
+echo "Testing $test_archive"
 . ../env.sh
 rm -rf results/make-issue/
 mkdir -p results/make-issue/
 cd results/make-issue/
-tar --strip-components=1 -xzf ../../$latest_file
+tar --strip-components=1 -xzf ../../$test_archive
 runme=run-me-mock-array_$testname-asap7-base.sh
 sed -i 's/openroad -no_init/openroad -exit -no_init/g' $runme
 ./$runme


### PR DESCRIPTION
By default a human/manual operation mode friendly tag is created so as not to accidentally overwrite a previous make issue test case, but when scripting it is useful to know the name of the file that is being generated, rather than trying to discover it after it has been generated by scanning folders.