### PR TITLE
gitignore: update in anticipation of bazel test-case

### DIFF
--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -2,3 +2,5 @@ settings.mk
 vars.sh
 vars.gdb
 vars.tcl
+.user-bazelrc
+bazel-*


### PR DESCRIPTION
while we are pondering whether to add some bazel-orfs test-cases it is nice to amend the .gitignore so that switching between pull requests is easier