### PR TITLE
Re-worked mock-array simulate and power steps to work with CI

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -46,15 +46,15 @@ verilog:
 	export MOCK_ARRAY_COLS=$(word 2, $(MOCK_ARRAY_TABLE)) ; \
 	./designs/asap7/mock-array/verilog.sh
 
-#.PHONY: simulate
-#simulate:
-#	export MOCK_ARRAY_ROWS=$(word 1, $(MOCK_ARRAY_TABLE)) ; \
-#	export MOCK_ARRAY_COLS=$(word 2, $(MOCK_ARRAY_TABLE)) ; \
-#	./designs/asap7/mock-array/simulate.sh
+.PHONY: simulate
+simulate:
+	export MOCK_ARRAY_ROWS=$(word 1, $(MOCK_ARRAY_TABLE)) ; \
+	export MOCK_ARRAY_COLS=$(word 2, $(MOCK_ARRAY_TABLE)) ; \
+	./designs/asap7/mock-array/simulate.sh
 
-#.PHONY: power
-#power:
-#	$(OPENSTA_EXE) -no_init -exit designs/asap7/mock-array/power.tcl
+.PHONY: power
+power:
+	$(OPENSTA_EXE) -no_init -exit designs/asap7/mock-array/power.tcl
 
 # If this design isn't quickly done in detailed routing, something is wrong.
 # At time of adding this option, only 12 iterations were needed for 0

--- a/flow/designs/asap7/mock-array/power.tcl
+++ b/flow/designs/asap7/mock-array/power.tcl
@@ -20,7 +20,7 @@ for {set x 0} {$x < 8} {incr x} {
 
 report_parasitic_annotation
 report_power
-read_power_activities -scope TOP/MockArray -vcd designs/src/mock-array/MockArrayTestbench.vcd
+read_power_activities -scope TOP/MockArray -vcd $::env(RESULTS_DIR)/MockArrayTestbench.vcd
 report_power
 
 # FIXME add an automated test to check that the top-level power is

--- a/flow/designs/asap7/mock-array/simulate.sh
+++ b/flow/designs/asap7/mock-array/simulate.sh
@@ -1,20 +1,34 @@
 #!/usr/bin/env bash
+#
+# Executes Verilator to generate a VCD file based on simulation
+# simulate.cpp is set up to write the VCD file into the results directory
+#
 set -ex
 
-# allow this script to be invoked from any folder
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-BASE=$DIR/../..
 
-cd $DIR
+RESULTS_DIR="$FLOW_HOME/results/asap7/mock-array/base"
+OBJ_DIR="$RESULTS_DIR/verilator/obj"
+POST_DIR="$RESULTS_DIR/verilator/post"
 
-cd ../../src/mock-array
-cp ../../../results/asap7/mock-array/base/6_final.v post/MockArrayFinal.v
-cp ../../../results/asap7/mock-array_Element/base/6_final.v post/MockArrayElementFinal.v
+# If you run outside of the Makefile system, then PLATFORM_DIR won't be set
+if [[ -z "$PLATFORM_DIR" ]]; then
+    PLATFORM_DIR="$FLOW_HOME/platforms/asap7"
+fi
 
+# Make sure the output directories are created
+mkdir -p $OBJ_DIR
+mkdir -p $POST_DIR
+
+# Copy Verilog files used for simulation to post dir in the objects area
+cp $FLOW_HOME/results/asap7/mock-array/base/6_final.v $POST_DIR/MockArrayFinal.v
+cp $FLOW_HOME/results/asap7/mock-array_Element/base/6_final.v $POST_DIR/MockArrayElement.v
+
+# Run simulation and have Verilator write the output files to the objects area
 verilator -Wall --cc \
   -Wno-DECLFILENAME \
   -Wno-UNUSEDSIGNAL \
   -Wno-PINMISSING \
+  --Mdir $OBJ_DIR \
   --top-module MockArray \
   --trace \
   $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_AO_RVT_TT_201020.v \
@@ -22,11 +36,13 @@ verilator -Wall --cc \
   $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v \
   $PLATFORM_DIR/verilog/stdcell/dff.v \
   $PLATFORM_DIR/verilog/stdcell/empty.v \
-  ../../../results/asap7/mock-array/base/6_final.v \
-  ../../../results/asap7/mock-array_Element/base/6_final.v \
+  $FLOW_HOME/results/asap7/mock-array/base/6_final.v \
+  $FLOW_HOME/results/asap7/mock-array_Element/base/6_final.v \
   --exe \
-  ../../../designs/src/mock-array/simulate.cpp
+  $FLOW_HOME/designs/src/mock-array/simulate.cpp
 
-make -j -C obj_dir -f VMockArray.mk
+# Link the generated object files into the VMockArray executable
+make -j -C $OBJ_DIR -f VMockArray.mk
 
-obj_dir/VMockArray
+# Run the simulation
+$OBJ_DIR/VMockArray

--- a/flow/designs/src/mock-array/.gitignore
+++ b/flow/designs/src/mock-array/.gitignore
@@ -7,5 +7,3 @@ target/
 .bloop/
 .bsp/
 test_run_dir/
-MockArrayTestbench.vcd
-obj_dir/

--- a/flow/designs/src/mock-array/post/.gitignore
+++ b/flow/designs/src/mock-array/post/.gitignore
@@ -1,1 +1,0 @@
-MockArray*.v

--- a/flow/designs/src/mock-array/simulate.cpp
+++ b/flow/designs/src/mock-array/simulate.cpp
@@ -2,6 +2,20 @@
 #include "verilated.h"
 #include <verilated_vcd_c.h>
 
+/**
+ * Returns the VCD output path under the results directory
+ **/
+static std::string getVCDFilePath() {
+
+    std::string vcd_file_name = "results/asap7/mock-array/base/MockArrayTestbench.vcd";
+    std::string flow_home_dir = getenv("FLOW_HOME");
+    if (flow_home_dir.empty()) {
+        flow_home_dir = ".";
+    }
+    std::string vcd_path = flow_home_dir + "/" + vcd_file_name;
+    return vcd_path;
+}
+
 int main(int argc, char** argv) {
     Verilated::commandArgs(argc, argv);
     VMockArray * top = new VMockArray;
@@ -48,7 +62,7 @@ int main(int argc, char** argv) {
     };
 
     top->trace(vcd, 99); // Trace all levels of hierarchy
-    vcd->open("MockArrayTestbench.vcd");
+    vcd->open(getVCDFilePath().c_str());
 
     int tick = 0;
     for (int j = 0; j < sizeof(inputs)/sizeof(*inputs); j++) {


### PR DESCRIPTION
Addresses https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2264

Updated the mock-array simulate and power steps so that they read/write VCD and associated files from the flow/results directory vs. the flow/designs directory. The new directory paths are:

- "post" directory - results/asap7/mock-array/base/verilator/post
- "obj_dir" directory - results/asap7/mock-array/base/verilator/obj

The simulate.sh still allows you to call it from an arbitrary directory, but it will use FLOW_HOME to figure out the location of the files that it needs to access. The simulate.cpp file has been updated to write the VCD file to the results/asap7/mock-array/base directory, which is also where the power.tcl file now looks for the VCD file.

Cleaned up some .gitignores as a result of the changes.
