### PR TITLE
Updated env var usage in Verilator simulation flow per PR feedback

### DIFF
--- a/flow/designs/asap7/mock-array/simulate.sh
+++ b/flow/designs/asap7/mock-array/simulate.sh
@@ -5,15 +5,8 @@
 #
 set -ex
 
-
-RESULTS_DIR="$FLOW_HOME/results/asap7/mock-array/base"
 OBJ_DIR="$RESULTS_DIR/verilator/obj"
 POST_DIR="$RESULTS_DIR/verilator/post"
-
-# If you run outside of the Makefile system, then PLATFORM_DIR won't be set
-if [[ -z "$PLATFORM_DIR" ]]; then
-    PLATFORM_DIR="$FLOW_HOME/platforms/asap7"
-fi
 
 # Make sure the output directories are created
 mkdir -p $OBJ_DIR

--- a/flow/designs/src/mock-array/simulate.cpp
+++ b/flow/designs/src/mock-array/simulate.cpp
@@ -3,16 +3,19 @@
 #include <verilated_vcd_c.h>
 
 /**
- * Returns the VCD output path under the results directory
+ * Returns the VCD output path.
+ *
+ * If RESULTS_DIR is set, the VCD file will be written there. If not, it will be written to the 
+ * current directory.
  **/
 static std::string getVCDFilePath() {
 
-    std::string vcd_file_name = "results/asap7/mock-array/base/MockArrayTestbench.vcd";
-    std::string flow_home_dir = getenv("FLOW_HOME");
-    if (flow_home_dir.empty()) {
-        flow_home_dir = ".";
+    std::string results_dir = getenv("RESULTS_DIR");
+    std::string vcd_file_name = "MockArrayTestbench.vcd";
+    if (results_dir.empty()) {
+        results_dir = ".";
     }
-    std::string vcd_path = flow_home_dir + "/" + vcd_file_name;
+    std::string vcd_path = results_dir + "/" + vcd_file_name;
     return vcd_path;
 }
 


### PR DESCRIPTION
Incorporated feedback from https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/2264.

Assumption is that simulate.sh will always be called from within Makefile system, so we can assume that the relevant env vars have been set and don't need to check them.