### PR TITLE
Less iffy makefile for flattening policy

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -205,11 +205,10 @@ include $(PLATFORM_DIR)/config.mk
 
 # Enables hierarchical yosys
 export SYNTH_HIERARCHICAL ?= 0
-export SYNTH_STOP_MODULE_SCRIPT = $(OBJECTS_DIR)/mark_hier_stop_modules.tcl
-ifeq ($(SYNTH_HIERARCHICAL), 1)
+export SYNTH_STOP_MODULE_SCRIPT = $(RESULTS_DIR)/flatten_policy.tcl
 export HIER_REPORT_SCRIPT = $(SCRIPTS_DIR)/synth_hier_report.tcl
 export MAX_UNGROUP_SIZE ?= 0
-endif
+
 # Enables Re-synthesis for area reclaim
 export RESYNTH_AREA_RECOVER ?= 0
 export RESYNTH_TIMING_RECOVER ?= 0
@@ -508,14 +507,11 @@ memory:
 export SYNTH_SCRIPT ?= $(SCRIPTS_DIR)/synth.tcl
 export SYNTH_MEMORY_MAX_BITS ?= 4096
 
-$(SYNTH_STOP_MODULE_SCRIPT):
+.PHONY: do-yosys-flatten-policy
+do-yosys-flatten-policy:
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
 	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
 	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(HIER_REPORT_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_hier_report.log)
-
-ifeq ($(SYNTH_HIERARCHICAL), 1)
-do-yosys: $(SYNTH_STOP_MODULE_SCRIPT)
-endif
 
 export SDC_FILE_CLOCK_PERIOD = $(RESULTS_DIR)/clock_period.txt
 
@@ -541,7 +537,7 @@ $(RESULTS_DIR)/1_synth.rtlil:
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
 $(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_synth.rtlil
-	$(UNSET_AND_MAKE) do-yosys
+	$(UNSET_AND_MAKE) do-yosys-flatten-policy do-yosys
 
 $(RESULTS_DIR)/1_synth.sdc: $(SDC_FILE)
 	mkdir -p $(RESULTS_DIR)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -507,8 +507,8 @@ memory:
 export SYNTH_SCRIPT ?= $(SCRIPTS_DIR)/synth.tcl
 export SYNTH_MEMORY_MAX_BITS ?= 4096
 
-.PHONY: do-yosys-flatten-policy
-do-yosys-flatten-policy:
+.PHONY: do-yosys-keep-hierarchy
+do-yosys-keep-hierarchy:
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
 	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
 	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(HIER_REPORT_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_hier_report.log)
@@ -537,7 +537,7 @@ $(RESULTS_DIR)/1_synth.rtlil:
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
 $(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_synth.rtlil
-	$(UNSET_AND_MAKE) do-yosys-flatten-policy do-yosys
+	$(UNSET_AND_MAKE) do-yosys-keep-hierarchy do-yosys
 
 $(RESULTS_DIR)/1_synth.sdc: $(SDC_FILE)
 	mkdir -p $(RESULTS_DIR)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -205,7 +205,7 @@ include $(PLATFORM_DIR)/config.mk
 
 # Enables hierarchical yosys
 export SYNTH_HIERARCHICAL ?= 0
-export SYNTH_STOP_MODULE_SCRIPT = $(RESULTS_DIR)/flatten_policy.tcl
+export SYNTH_STOP_MODULE_SCRIPT = $(RESULTS_DIR)/keep_hierarchy.tcl
 export HIER_REPORT_SCRIPT = $(SCRIPTS_DIR)/synth_hier_report.tcl
 export MAX_UNGROUP_SIZE ?= 0
 

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -1,9 +1,6 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-if { [info exist ::env(SYNTH_HIERARCHICAL)] && $::env(SYNTH_HIERARCHICAL) == 1 && [file isfile $::env(SYNTH_STOP_MODULE_SCRIPT)] } {
-  puts "Sourcing $::env(SYNTH_STOP_MODULE_SCRIPT)"
-  source $::env(SYNTH_STOP_MODULE_SCRIPT)
-}
+source $::env(SYNTH_STOP_MODULE_SCRIPT)
 
 if { [info exist ::env(SYNTH_GUT)] && $::env(SYNTH_GUT) == 1 } {
   hierarchy -check -top $::env(DESIGN_NAME)

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,4 +1,4 @@
-proc write_flatten_policy {} {
+proc write_keep_hierarchy {} {
   if { ![info exist ::env(SYNTH_HIERARCHICAL)] || $::env(SYNTH_HIERARCHICAL) == 0 } {
     set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
     close $out_script_ptr
@@ -75,4 +75,4 @@ proc write_flatten_policy {} {
   close $out_script_ptr
 }
 
-write_flatten_policy
+write_keep_hierarchy

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,22 +1,28 @@
-source $::env(SCRIPTS_DIR)/synth_preamble.tcl
+proc write_flatten_policy {} {
+  if { ![info exist ::env(SYNTH_HIERARCHICAL)] || $::env(SYNTH_HIERARCHICAL) == 0 } {
+    set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
+    close $out_script_ptr
+    return
+  }
 
-synthesize_check {}
+  source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
-  techmap -map $::env(ADDER_MAP_FILE)
-}
-techmap
-if {[info exist ::env(DFF_LIB_FILE)]} {
-  dfflibmap -liberty $::env(DFF_LIB_FILE)
-} else {
-  dfflibmap -liberty $::env(DONT_USE_SC_LIB)
-}
-puts "abc [join $abc_args " "]"
-abc {*}$abc_args
+  synthesize_check {}
 
-tee -o $::env(REPORTS_DIR)/synth_hier_stat.txt stat {*}$stat_libs
+  if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
+    techmap -map $::env(ADDER_MAP_FILE)
+  }
+  techmap
+  if {[info exist ::env(DFF_LIB_FILE)]} {
+    dfflibmap -liberty $::env(DFF_LIB_FILE)
+  } else {
+    dfflibmap -liberty $::env(DONT_USE_SC_LIB)
+  }
+  puts "abc [join $abc_args " "]"
+  abc {*}$abc_args
 
-if { [info exist ::env(REPORTS_DIR)] && [file isfile $::env(REPORTS_DIR)/synth_hier_stat.txt] } {
+  tee -o $::env(REPORTS_DIR)/synth_hier_stat.txt stat {*}$stat_libs
+
   set ungroup_threshold 0
   if { [info exist ::env(MAX_UNGROUP_SIZE)] && $::env(MAX_UNGROUP_SIZE) > 0 } {
     set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
@@ -45,7 +51,7 @@ if { [info exist ::env(REPORTS_DIR)] && [file isfile $::env(REPORTS_DIR)/synth_h
       }
     }
   }
-  set out_script_ptr [open $::env(OBJECTS_DIR)/mark_hier_stop_modules.tcl w]
+  set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
   puts $out_script_ptr "hierarchy -check -top $::env(DESIGN_NAME)"
   foreach module $module_list {
     tee -o $::env(REPORTS_DIR)/synth_hier_stat_temp_module.txt stat -top "$module" {*}$stat_libs
@@ -57,10 +63,10 @@ if { [info exist ::env(REPORTS_DIR)] && [file isfile $::env(REPORTS_DIR)/synth_h
       if {[regexp { +Chip area for top module '(\S+)': (.*)} $line -> module_name area]} {
         puts "Area of module $module_name is $area"
         if {[expr $area > $ungroup_threshold]} {
-           puts "Preserving hierarchical module: $module_name"
-           puts $out_script_ptr "select -module {$module_name}"
-           puts $out_script_ptr "setattr -mod -set keep_hierarchy 1"
-           puts $out_script_ptr "select -clear"
+            puts "Preserving hierarchical module: $module_name"
+            puts $out_script_ptr "select -module {$module_name}"
+            puts $out_script_ptr "setattr -mod -set keep_hierarchy 1"
+            puts $out_script_ptr "select -clear"
         }
       }
     }
@@ -69,3 +75,4 @@ if { [info exist ::env(REPORTS_DIR)] && [file isfile $::env(REPORTS_DIR)/synth_h
   close $out_script_ptr
 }
 
+write_flatten_policy


### PR DESCRIPTION
No new or removed features, just moving conditional code into .tcl.

Introducing a do-synth-flatten-policy stage that figures out which modules to keep in flattening, with SYNTH_HIERARCHICAL=0, all Verilog modules are flattened.