### PR TITLE
Make sure OpenROAD is built with installed dependencies

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -62,13 +62,13 @@ Options:
     --yosys-args-overwrite  Do not use default flags set by this scrip during
                             Yosys compilation.
 
-    --yosys-args STRING      Aditional compilation flags for Yosys compilation.
+    --yosys-args STRING     Additional compilation flags for Yosys compilation.
 
     --openroad-args-overwrite
                             Do not use default flags set by this scrip during
                             OpenROAD app compilation.
 
-    --openroad-args STRING  Aditional compilation flags for OpenROAD app
+    --openroad-args STRING  Additional compilation flags for OpenROAD app
                             compilation.
 
     --install-path PATH     Path to install tools. Default is ${INSTALL_PATH}.
@@ -84,7 +84,7 @@ Options:
 Options valid only for Docker builds:
     -c, --copy-platforms    Copy platforms to inside docker image.
 
-    --os=DOCKER_OS_NAME     Choose beween ubuntu22.04 (default), ubuntu20.04.
+    --os=DOCKER_OS_NAME     Choose between ubuntu22.04 (default), ubuntu20.04.
 
     This script builds the OpenROAD tools: openroad, yosys and yosys plugins.
     By default, the tools will be built from the linked submodule hashes.
@@ -128,14 +128,14 @@ while (( "$#" )); do
                         DOCKER_COPY_PLATFORMS=1
                         ;;
                 --yosys-args-overwrite)
-                        YOSYS_OVERWIRTE_ARGS=1
+                        YOSYS_OVERWRITE_ARGS=1
                         ;;
                 --yosys-args)
                         YOSYS_USER_ARGS="$2"
                         shift
                         ;;
                 --openroad-args-overwrite)
-                        OPENROAD_APP_OVERWIRTE_ARGS=1
+                        OPENROAD_APP_OVERWRITE_ARGS=1
                         ;;
                 --openroad-args)
                         OPENROAD_APP_USER_ARGS="$2"
@@ -189,14 +189,14 @@ if [ -n "$CMAKE_INSTALL_RPATH" ]; then
 fi
 
 __args_setup() {
-        if [ ! -z "${YOSYS_OVERWIRTE_ARGS+x}" ]; then
+        if [ ! -z "${YOSYS_OVERWRITE_ARGS+x}" ]; then
                 echo "[INFO FLW-0014] Overwriting Yosys compilation flags."
                 YOSYS_ARGS="${YOSYS_USER_ARGS}"
         else
                 YOSYS_ARGS+=" ${YOSYS_USER_ARGS}"
         fi
 
-        if [ ! -z "${OPENROAD_APP_OVERWIRTE_ARGS+x}" ]; then
+        if [ ! -z "${OPENROAD_APP_OVERWRITE_ARGS+x}" ]; then
                 echo "[INFO FLW-0015] Overwriting OpenROAD app compilation flags."
                 OPENROAD_APP_ARGS="${OPENROAD_APP_USER_ARGS}"
         else

--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -5,7 +5,8 @@
 set -eu
 
 # Make sure we are on the correct folder before beginning
-cd "$(dirname $(readlink -f $0))"
+DIR="$(dirname $(readlink -f $0))"
+cd "$DIR"
 
 # Set up paths to dependencies, such as cmake and boost. Safe no-op
 # if tools were set up elsewhere in the path.
@@ -246,7 +247,7 @@ __local_build()
         ${NICE} make install -C tools/yosys -j "${PROC}" ${YOSYS_ARGS}
 
         echo "[INFO FLW-0018] Compiling OpenROAD."
-        eval ${NICE} cmake tools/OpenROAD -B tools/OpenROAD/build ${OPENROAD_APP_ARGS}
+        eval ${NICE} ./tools/OpenROAD/etc/Build.sh -dir="$DIR/tools/OpenROAD/build" -threads=${PROC} -cmake=\'${OPENROAD_APP_ARGS}\'
         ${NICE} cmake --build tools/OpenROAD/build --target install -j "${PROC}"
 }
 

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -278,6 +278,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         -ci)
             CI="yes"
+            OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} -save-deps-prefixes=/etc/openroad_deps_prefixes.txt"
             ;;
         -prefix=*)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"


### PR DESCRIPTION
Requires https://github.com/The-OpenROAD-Project/OpenROAD/pull/5660

This PR adds option in `build_openroad.sh` script to enable using build arguments from file. This way, additional CMake parameters (from https://github.com/The-OpenROAD-Project/OpenROAD/pull/5660) can be used to make sure the right dependencies' versions are used and prevent errors (e.g. used incompatible version of OR-Tools from system) like:
```
mbff.cpp:(.text+0x1a38d): undefined reference to `operations_research::sat::CpModelProto::CpModelProto(google::protobuf::Arena*)'
/usr/bin/ld: mbff.cpp:(.text+0x1a394): undefined reference to `absl::lts_20240116::container_internal::kEmptyGroup'
/usr/bin/ld: mbff.cpp:(.text+0x1e47e): undefined reference to `absl::lts_20240116::container_internal::kEmptyGroup'
/usr/bin/ld: mbff.cpp:(.text+0x1e4cf): undefined reference to `operations_research::sat::SatParameters::SatParameters(google::protobuf::Arena*)'
collect2: error: ld returned 1 exit status
```