### PR TITLE
[DO NOT REVIEW] asap7/mul: equivalence check

### DIFF
--- a/flow/designs/asap7/mul/config.mk
+++ b/flow/designs/asap7/mul/config.mk
@@ -1,0 +1,17 @@
+export PLATFORM               = asap7
+
+export DESIGN_NAME            = Mul
+export DESIGN_NICKNAME        = mul
+
+export VERILOG_FILES = $(sort $(wildcard ./designs/src/$(DESIGN_NICKNAME)/*.sv))
+export SDC_FILE      = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/constraints.sdc
+
+export ABC_AREA                 = 1
+
+export CORE_UTILIZATION         = 40
+export CORE_ASPECT_RATIO        = 1
+export CORE_MARGIN              = 2
+export PLACE_DENSITY            = 0.65
+export TNS_END_PERCENT          = 100
+export EQUIVALENCE_CHECK       ?=   1
+export REMOVE_CELLS_FOR_EQY     = TAPCELL*

--- a/flow/designs/asap7/mul/constraints.sdc
+++ b/flow/designs/asap7/mul/constraints.sdc
@@ -1,0 +1,5 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 250
+
+source $env(PLATFORM_DIR)/constraints.sdc

--- a/flow/designs/src/mul/Mul.sv
+++ b/flow/designs/src/mul/Mul.sv
@@ -1,0 +1,9 @@
+module Mul(
+    input clock,
+    input  [7:0] io_src_0, io_src_1,
+    output reg [7:0] io_dst
+);
+  always @(posedge clock) begin
+    io_dst <= io_src_0 * io_src_1;
+  end
+endmodule


### PR DESCRIPTION
@maliberty Several things needs doing here:

- [ ] `. env.sh` and `make DESIGN_CONFIG=designs/asap7/mul/config.mk` fails locally because eqy is not in the path, even though it is in dependencies/bin/eqy
- [ ] Hook up this test to Jenkins: looks like how this is done has changed or at least I didn't find where in ORFS to do this
- [ ] Investigate the eqy failure that we're trying to study here, seems like this is a known problem in Yosys. https://github.com/YosysHQ/yosys/issues/3879 https://github.com/YosysHQ/yosys/pull/3882
- [ ] This is an attempt to rearticulate this test-case in ORFS speak: https://github.com/The-OpenROAD-Project/bazel-orfs/pull/119