### PR TITLE
remove unecessary code from global_place.tcl

### DIFF
--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -22,9 +22,6 @@ set global_placement_args {}
 # Parameters for routability mode in global placement
 if {$::env(GPL_ROUTABILITY_DRIVEN)} {
   lappend global_placement_args {-routability_driven}
-    if { [info exists ::env(GPL_TARGET_RC)] } { 
-      lappend global_placement_args {-routability_target_rc_metric} $::env(GPL_TARGET_RC)
-  }
 }
 
 # Parameters for timing driven mode in global placement


### PR DESCRIPTION
this condition was previously added to modify the target RC valeu of a specific design to not enable routability mode in gpl. Should not be necessary anymore.
fixes issue https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1916 together with PR https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2301