### PR TITLE
restore equivalence_check for nangate45/aes

### DIFF
--- a/flow/designs/nangate45/aes/config.mk
+++ b/flow/designs/nangate45/aes/config.mk
@@ -9,7 +9,5 @@ export FLOORPLAN_DEF = ./designs/$(PLATFORM)/$(DESIGN_NICKNAME)/aes_ng45_fp.def
 
 export PLACE_DENSITY_LB_ADDON = 0.20
 export TNS_END_PERCENT        = 100
-# temporarily disabled equivalence check due to failures
-export EQUIVALENCE_CHECK     ?=   0
 export REMOVE_CELLS_FOR_EQY   = TAPCELL*
 


### PR DESCRIPTION
This was previously turned off, and the driverless nets issue was masked. Now that https://github.com/The-OpenROAD-Project/OpenROAD/pull/5644 has fixed the issue, we can restore it to ensure new problems will not arise.