### PR TITLE
designs/asap7/aes-block: support settings BLOCKS= for testing purposes

### DIFF
--- a/flow/designs/asap7/aes-block/config.mk
+++ b/flow/designs/asap7/aes-block/config.mk
@@ -13,7 +13,7 @@ export CORE_ASPECT_RATIO      = 1
 export CORE_MARGIN            = 2
 export PLACE_DENSITY          = 0.65
 
-export BLOCKS = aes_rcon aes_sbox
+export BLOCKS ?= aes_rcon aes_sbox
 export SYNTH_HIERARCHICAL = 1
 export RTLMP_FLOW = 1
 


### PR DESCRIPTION
locally it can be convenient to use aes-block module to create an a/b comparison with and without sub-blocks.