### PR TITLE
makefile: make STDBUF_CMD optional

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -332,7 +332,7 @@ endif
 KLAYOUT_FOUND            = $(if $(KLAYOUT_CMD),,$(error KLayout not found in PATH))
 
 ifneq ($(shell command -v stdbuf),)
-  STDBUF_CMD = stdbuf -o L
+  STDBUF_CMD ?= stdbuf -o L
 endif
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
originally added for Mac in 4fa7b95bb, solves problems that don't exist on x86 Linux distributions normally.

Removing stdbuf dependency is helpful when running in some containerized environments, like Bazel.