### PR TITLE
[Autotuner] WIP: Regression test 1

### DIFF
--- a/flow/designs/asap7/aes/autotuner.json
+++ b/flow/designs/asap7/aes/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
    "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/asap7/gcd/autotuner.json
+++ b/flow/designs/asap7/gcd/autotuner.json
@@ -3,8 +3,8 @@
     "_SDC_CLK_PERIOD": {
         "type": "float",
         "minmax": [
-            300,
-            1000
+            50,
+            500
         ],
         "step": 0
     },

--- a/flow/designs/asap7/ibex/autotuner.json
+++ b/flow/designs/asap7/ibex/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/gcd/autotuner.json
+++ b/flow/designs/ihp-sg13g2/gcd/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/ibex/autotuner.json
+++ b/flow/designs/ihp-sg13g2/ibex/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            4
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/sky130hd/aes/autotuner.json
+++ b/flow/designs/sky130hd/aes/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/sky130hd/gcd/autotuner.json
+++ b/flow/designs/sky130hd/gcd/autotuner.json
@@ -65,14 +65,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/designs/sky130hd/ibex/autotuner.json
+++ b/flow/designs/sky130hd/ibex/autotuner.json
@@ -64,14 +64,6 @@
         ],
         "step": 0
     },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
-    },
     "CTS_CLUSTER_SIZE": {
         "type": "int",
         "minmax": [

--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -80,7 +80,7 @@ fi
 # Run Autotuner CI specifically for gcd on selected platforms.
 RUN_AUTOTUNER=0
 case $DESIGN_NAME in
-  "gcd")
+  "gcd" "aes" "ibex")
     RUN_AUTOTUNER=1
     ;;
 esac
@@ -103,12 +103,10 @@ if [ $RUN_AUTOTUNER -eq 1 ]; then
   PLATFORM=${PLATFORM//-/}
   # convert to uppercase
   PLATFORM=${PLATFORM^^}
+  DESIGN_NAME=${DESIGN_NAME^^}
 
-  echo "Running Autotuner smoke tune test"
-  python3 -m unittest tools.AutoTuner.test.smoke_test_tune.${PLATFORM}TuneSmokeTest.test_tune
-
-  echo "Running Autotuner smoke sweep test"
-  python3 -m unittest tools.AutoTuner.test.smoke_test_sweep.${PLATFORM}SweepSmokeTest.test_sweep
+  echo "Running Autotuner Regression Test"
+  python3 -m unittest tools.AutoTuner.test.regression_tune_base.${PLATFORM}TuneRegression${DESIGN_NAME}Test.test_tune
 fi
 
 exit $ret

--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -84,14 +84,13 @@ case $DESIGN_NAME in
     RUN_AUTOTUNER=1
     ;;
 esac
-case $PLATFORM in
-     "asap7" | "sky130hd" | "ihp-sg13g2" )
-      # Keep RUN_AUTOTUNER enabled only for these platforms
-      ;;
-     *)
-      RUN_AUTOTUNER=0
-      ;;
-esac
+if [ $RUN_AUTOTUNER -eq 1 ]; then
+  case $PLATFORM in
+       "gf180" | "nangate45" | "sky130hd_fakestack" | "sky130hs")
+        RUN_AUTOTUNER=0
+        ;;
+  esac
+fi
 
 if [ $RUN_AUTOTUNER -eq 1 ]; then
   # change directory to the root of the repo

--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -80,7 +80,7 @@ fi
 # Run Autotuner CI specifically for gcd on selected platforms.
 RUN_AUTOTUNER=0
 case $DESIGN_NAME in
-  "gcd" "aes" "ibex")
+  "gcd" | "aes" | "ibex")
     RUN_AUTOTUNER=1
     ;;
 esac

--- a/tools/AutoTuner/.gitignore
+++ b/tools/AutoTuner/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # Autotuner env
 autotuner_env
+*.log
+.env
+*.zip

--- a/tools/AutoTuner/test/regression_tune_base.py
+++ b/tools/AutoTuner/test/regression_tune_base.py
@@ -1,0 +1,170 @@
+import unittest
+import subprocess
+import os
+import json
+import pandas as pd
+import glob
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.join(cur_dir, "../src/autotuner")
+os.chdir(src_dir)
+
+
+def get_latest_date(path):
+    return max(glob.glob(f"{path}/*"), key=os.path.getmtime)
+
+
+def combine_csv(path):
+    df = pd.concat(
+        [pd.read_csv(fname) for fname in glob.glob(f"{path}/*/progress.csv")]
+    )
+    df.to_csv(f"{path}/progress_overall.csv", index=False)
+
+
+def load_df(filename):
+    df = pd.read_csv(filename)
+    cols_to_remove = [
+        "done",
+        "training_iteration",
+        "trial_id",
+        "date",
+        "timestamp",
+        "pid",
+        "hostname",
+        "node_ip",
+        "time_since_restore",
+        "time_total_s",
+        "iterations_since_restore",
+    ]
+    df = df[df["minimum"] != 9e99]
+    df = df.drop(columns=cols_to_remove)
+    return df
+
+
+def get_latest_data(path):
+    latest_path = get_latest_date(path)
+    print("Using folder:", latest_path)
+    combine_csv(latest_path)
+    return load_df(f"{latest_path}/progress_overall.csv")
+
+
+class BaseTuneRegressionBaseTest(unittest.TestCase):
+    platform = ""
+    design = ""
+    qor = 0
+    THRESHOLD = 0.25  # qor median is within +- 25% of the expected value
+
+    def setUp(self):
+        self.config = os.path.join(
+            cur_dir,
+            f"../../../flow/designs/{self.platform}/{self.design}/autotuner.json",
+        )
+        self.experiment = f"test-regression"
+        self.command = (
+            "python3 distributed.py"
+            f" --design {self.design}"
+            f" --platform {self.platform}"
+            f" --experiment {self.experiment}"
+            f" --config {self.config}"
+            f" tune --samples 10"
+        )
+
+
+class ASAP7TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
+    platform = "asap7"
+    design = "gcd"
+    qor = 37668.290
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        median_qor = df["minimum"].median()
+        self.assertLess(abs(median_qor - self.qor) / self.qor, self.THRESHOLD)
+
+
+class SKY130HDTuneRegressionGCDTest(BaseTuneRegressionBaseTest):
+    platform = "sky130hd"
+    design = "gcd"
+    qor = 327.023
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        median_qor = df["minimum"].median()
+        self.assertLess(abs(median_qor - self.qor) / self.qor, self.THRESHOLD)
+
+
+class IHPSG13G2TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
+    platform = "ihp-sg13g2"
+    design = "gcd"
+    qor = 251.102
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        median_qor = df["minimum"].median()
+        self.assertLess(abs(median_qor - self.qor) / self.qor, self.THRESHOLD)
+
+
+class ASAP7TuneRegressionAESTest(BaseTuneRegressionBaseTest):
+    platform = "asap7"
+    design = "aes"
+    qor = 70934.140
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+class SKY130HDTuneRegressionAESTest(BaseTuneRegressionBaseTest):
+    platform = "sky130hd"
+    design = "aes"
+    qor = 546.433
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+class IHPSG13G2TuneRegressionAESTest(BaseTuneRegressionBaseTest):
+    platform = "ihp-sg13g2"
+    design = "aes"
+    qor = 544.835
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/AutoTuner/test/regression_tune_base.py
+++ b/tools/AutoTuner/test/regression_tune_base.py
@@ -76,7 +76,7 @@ class BaseTuneRegressionBaseTest(unittest.TestCase):
 class ASAP7TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
     platform = "asap7"
     design = "gcd"
-    qor = 37668.290
+    qor = 35847.475
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -92,7 +92,7 @@ class ASAP7TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
 class SKY130HDTuneRegressionGCDTest(BaseTuneRegressionBaseTest):
     platform = "sky130hd"
     design = "gcd"
-    qor = 327.023
+    qor = 332.139
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -108,7 +108,7 @@ class SKY130HDTuneRegressionGCDTest(BaseTuneRegressionBaseTest):
 class IHPSG13G2TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
     platform = "ihp-sg13g2"
     design = "gcd"
-    qor = 251.102
+    qor = 398.452
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -124,7 +124,7 @@ class IHPSG13G2TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
 class ASAP7TuneRegressionAESTest(BaseTuneRegressionBaseTest):
     platform = "asap7"
     design = "aes"
-    qor = 70934.140
+    qor = 61455.680
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -140,7 +140,7 @@ class ASAP7TuneRegressionAESTest(BaseTuneRegressionBaseTest):
 class SKY130HDTuneRegressionAESTest(BaseTuneRegressionBaseTest):
     platform = "sky130hd"
     design = "aes"
-    qor = 546.433
+    qor = 540.688
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -156,7 +156,7 @@ class SKY130HDTuneRegressionAESTest(BaseTuneRegressionBaseTest):
 class IHPSG13G2TuneRegressionAESTest(BaseTuneRegressionBaseTest):
     platform = "ihp-sg13g2"
     design = "aes"
-    qor = 544.835
+    qor = 544.728
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -172,7 +172,7 @@ class IHPSG13G2TuneRegressionAESTest(BaseTuneRegressionBaseTest):
 class ASAP7TuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
     platform = "asap7"
     design = "ibex"
-    qor = 205678.545
+    qor = 192118.310
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -188,7 +188,7 @@ class ASAP7TuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
 class SKY130HDTuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
     platform = "sky130hd"
     design = "ibex"
-    qor = 1425.996
+    qor = 1421.194
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)
@@ -204,7 +204,7 @@ class SKY130HDTuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
 class IHPSG13G2TuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
     platform = "ihp-sg13g2"
     design = "ibex"
-    qor = 1422.309
+    qor = 1278.664
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)

--- a/tools/AutoTuner/test/regression_tune_base.py
+++ b/tools/AutoTuner/test/regression_tune_base.py
@@ -69,6 +69,9 @@ class BaseTuneRegressionBaseTest(unittest.TestCase):
             f" tune --samples 10"
         )
 
+    def test_tune(self):
+        raise NotImplementedError("Subclasses must implement this method.")
+
 
 class ASAP7TuneRegressionGCDTest(BaseTuneRegressionBaseTest):
     platform = "asap7"
@@ -154,6 +157,54 @@ class IHPSG13G2TuneRegressionAESTest(BaseTuneRegressionBaseTest):
     platform = "ihp-sg13g2"
     design = "aes"
     qor = 544.835
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+class ASAP7TuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
+    platform = "asap7"
+    design = "ibex"
+    qor = 205678.545
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+class SKY130HDTuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
+    platform = "sky130hd"
+    design = "ibex"
+    qor = 1425.996
+
+    def test_tune(self):
+        out = subprocess.run(self.command, shell=True, check=True)
+        successful = out.returncode == 0
+        self.assertTrue(successful)
+
+        # check if final mean QoR is within confidence interval of expected value
+        df = get_latest_data(f"../../../../flow/logs/{self.platform}/{self.design}")
+        mean_qor = df["minimum"].mean()
+        self.assertLess(abs(mean_qor - self.qor) / self.qor, (1 - self.THRESHOLD))
+
+
+class IHPSG13G2TuneRegressionIBEXTest(BaseTuneRegressionBaseTest):
+    platform = "ihp-sg13g2"
+    design = "ibex"
+    qor = 1422.309
 
     def test_tune(self):
         out = subprocess.run(self.command, shell=True, check=True)


### PR DESCRIPTION
This PR currently aims to implement regression for the default usage (`python distributed.py --design <> --platform <> --config <> tune --samples <>`). 
Future works can benchmark other algorithms

Explanation
- The QoR benchmark are obtained by running 100 trials of each **Ray version-platform-design** combination. The value in the tests are the highest 1st quartile QoR for each combination. 
- Ray version: `2.7`, `2.8`, `2.9`
- Platform: `asap7`, `sky130hd`, `ihpsg13g2`
- Design: `gcd`, `aes`, `ibex`
- Criteria for passing each regression is that the QoR must be within ±25% of the baseline

Note
- This regression should be activated only when AT/related files are touched.
- When `tools/Autotuner/requirements.txt` is changed
- When `autotuner.json` is changed -> test on that design 
- When `distributed.py` is changed. 
- Also track Makefile. Things that can potentially alter flow results

Tasks
- [x] Need to recalibrate with new changes
- [ ] Fix seeds as a easy way to control the results. But that might not be enough because ORFS always changing as well. 