### PR TITLE
Set constant build path and timestamp for executables in Docker image

### DIFF
--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -19,6 +19,8 @@ COPY --link tools tools
 ARG numThreads=$(nproc)
 
 RUN echo "" > tools/yosys/abc/.gitcommit && \
+  env CFLAGS="-D__TIME__=0 -D__DATE__=0 -D__TIMESTAMP__=0 -Wno-builtin-macro-redefined" \
+  CXXFLAGS="-D__TIME__=0 -D__DATE__=0 -D__TIMESTAMP__=0 -Wno-builtin-macro-redefined" \
   ./build_openroad.sh --no_init --local --threads ${numThreads}
 
 FROM orfs-base

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -13,8 +13,11 @@ COPY InstallerOpenROAD.sh \
        /tmp/installer/tools/OpenROAD/etc/DependencyInstaller.sh
 
 ARG options=""
+ARG constantBuildDir="-constant-build-dir"
 
-RUN ./DependencyInstaller.sh $options \
+RUN env CFLAGS="-D__TIME__=0 -D__DATE__=0 -D__TIMESTAMP__=0 -Wno-builtin-macro-redefined" \
+      CXXFLAGS="-D__TIME__=0 -D__DATE__=0 -D__TIMESTAMP__=0 -Wno-builtin-macro-redefined" \
+      ./DependencyInstaller.sh $options $constantBuildDir \
       && rm -rf /tmp/installer /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
 ARG fromImage

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -36,7 +36,15 @@ _installCommon() {
         pip3 install --no-cache-dir --user -U $pkgs
     fi
 
-    baseDir=$(mktemp -d /tmp/DependencyInstaller-orfs-XXXXXX)
+    if [[ "$constantBuildDir" == "true" ]]; then
+        baseDir="/tmp/DependencyInstaller-ORFS"
+        if [[ -d "$baseDir" ]]; then
+            echo "[INFO] Removing old building directory $baseDir"
+        fi
+        mkdir -p "$baseDir"
+    else
+        baseDir=$(mktemp -d /tmp/DependencyInstaller-orfs-XXXXXX)
+    fi
 
     # Install Verilator
     verilatorPrefix=`realpath ${PREFIX:-"/usr/local"}`
@@ -239,6 +247,9 @@ Usage: $0
                                 #    sudo or with root access.
        $0 -ci
                                 # Installs CI tools
+       $0 -constant-build-dir
+                                #  Use constant build directory, instead of
+                                #    random one.
 EOF
     exit "${1:-1}"
 }
@@ -251,6 +262,7 @@ PREFIX=""
 option="all"
 # default isLocal
 isLocal="false"
+constantBuildDir="false"
 CI="no"
 
 # default values, can be overwritten by cmdline args
@@ -282,6 +294,10 @@ while [ "$#" -gt 0 ]; do
         -prefix=*)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"
             PREFIX=${1#*=}
+            ;;
+        -constant-build-dir)
+            OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"
+            constantBuildDir="true"
             ;;
         *)
             echo "unknown option: ${1}" >&2

--- a/etc/DockerHelper.sh
+++ b/etc/DockerHelper.sh
@@ -9,6 +9,7 @@ baseDir="$(pwd)"
 org=openroad
 
 DOCKER_CMD="docker"
+noConstantBuildDir=""
 
 _help() {
     cat <<EOF
@@ -32,6 +33,7 @@ usage: $0 [CMD] [OPTIONS]
   -password=PASSWORD            Password to loging at the docker registry.
   -ci                           Install CI tools in image
   -dry-run                      Do not push images to the repository
+  -no-constant-build-dir        Do not use constant build directory
   -h -help                      Show this message and exits
 
 EOF
@@ -67,7 +69,7 @@ _setup() {
             fromImage="${FROM_IMAGE_OVERRIDE:-$osBaseImage}"
             cp tools/OpenROAD/etc/DependencyInstaller.sh etc/InstallerOpenROAD.sh
             context="etc"
-            buildArgs="--build-arg options=${options}"
+            buildArgs="--build-arg options=${options} ${noConstantBuildDir}"
             ;;
         *)
             echo "Target ${target} not found" >&2
@@ -201,6 +203,9 @@ while [ "$#" -gt 0 ]; do
             ;;
         -tag=* )
             tag="${1#*=}"
+            ;;
+        -no-constant-build-dir )
+            noConstantBuildDir="--build-arg constantBuildDir= "
             ;;
         -os | -target | -threads | -username | -password | -tag )
             echo "${1} requires an argument" >&2


### PR DESCRIPTION
This PR modifies the build flow for Docker images to:

* Set build path for dependencies to a constant path (so that `__FILE__` is not different on every build of the image)
* Set TIME/DATE/TIMESTAMP to constant values so that the binaries are not affected by a different build time

Those changes prevent cache invalidation in Bazel due to different binary SHAs.

This PR depends on https://github.com/The-OpenROAD-Project/OpenROAD/pull/5726, since it introduces `-constant-build-dir`