### PR TITLE
makefile: POLA - Principle Of Least Astonishment for variables

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -136,6 +136,9 @@ export TNS_END_PERCENT ?=100
 
 # Default routing layer adjustment
 export ROUTING_LAYER_ADJUSTMENT ?= 0.5
+export RECOVER_POWER ?= 0
+export SKIP_INCREMENTAL_REPAIR ?= 0
+export DETAILED_METRICS ?= 0
 
 # If we are running headless use offscreen rendering for save_image
 ifndef DISPLAY

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -46,7 +46,7 @@ set_dont_use $::env(DONT_USE_CELLS)
 utl::push_metrics_stage "cts__{}__pre_repair"
 
 estimate_parasitics -placement
-if {[info exist ::env(DETAILED_METRICS)]} {
+if { $::env(DETAILED_METRICS) } {
   report_metrics 4 "cts pre-repair"
 }
 utl::pop_metrics_stage
@@ -55,7 +55,7 @@ repair_clock_nets
 
 utl::push_metrics_stage "cts__{}__post_repair"
 estimate_parasitics -placement
-if {[info exist ::env(DETAILED_METRICS)]} {
+if { $::env(DETAILED_METRICS) } {
   report_metrics 4 "cts post-repair"
 }
 utl::pop_metrics_stage

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -49,15 +49,15 @@ proc global_route_helper {} {
     set_dont_use $::env(DONT_USE_CELLS)
   }
 
-  if { ![info exists ::env(SKIP_INCREMENTAL_REPAIR)] } {
-    if {[info exist ::env(DETAILED_METRICS)]} {
+  if { !$::env(SKIP_INCREMENTAL_REPAIR) } {
+    if { $::env(DETAILED_METRICS) } {
       report_metrics 5 "global route pre repair design"
     }
 
     # Repair design using global route parasitics
     puts "Perform buffer insertion..."
     repair_design
-    if {[info exist ::env(DETAILED_METRICS)]} {
+    if { $::env(DETAILED_METRICS) } {
       report_metrics 5 "global route post repair design"
     }
 
@@ -74,7 +74,7 @@ proc global_route_helper {} {
 
     repair_timing_helper
 
-    if {[info exist ::env(DETAILED_METRICS)]} {
+    if { $::env(DETAILED_METRICS) } {
       report_metrics 5 "global route post repair timing"
     }
 
@@ -86,17 +86,7 @@ proc global_route_helper {} {
     global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
   }
 
-  if { [info exists ::env(RECOVER_POWER)] } {
-    puts "Downsizing/switching to higher Vt  for non critical gates for power recovery"
-    puts "Percent of paths optimized $::env(RECOVER_POWER)"
-    report_tns
-    report_wns
-    report_power
-    repair_timing -recover_power $::env(RECOVER_POWER)
-    report_tns
-    report_wns
-    report_power
-  }
+  recover_power
 
   if {![info exist ::env(SKIP_ANTENNA_REPAIR)]} {
     puts "Repair antennas..."

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -29,3 +29,18 @@ proc repair_timing_helper { {hold_margin 1} } {
   puts "repair_timing [join $additional_args " "]"
   repair_timing {*}$additional_args
 }
+
+proc recover_power {} {
+  if { $::env(RECOVER_POWER) == 0 } {
+    return
+  }
+  puts "Downsizing/switching to higher Vt for non critical gates for power recovery"
+  puts "Percent of paths optimized $::env(RECOVER_POWER)"
+  report_tns
+  report_wns
+  report_power
+  repair_timing -recover_power $::env(RECOVER_POWER)
+  report_tns
+  report_wns
+  report_power
+}


### PR DESCRIPTION
@jeffng-or FYI

https://en.wikipedia.org/wiki/Principle_of_least_astonishment

Moving in this direction every time I get a papercut...

A few driveby fixes of the same...

move towards a default value of a variables instead of checking of the existence of an env var.

For example `make SKIP_INCREMENTAL_REPAIR=0` or `make SKIP_INCREMENTAL_REPAIR=`  will disable that option, as opposed to enable it.

Also, this opens up for renaming this option to GLOBAL_ROUTING_INCREMENTAL_REPAIR with a default value of 1, which is more POLA: Why do negative options exist?
