### PR TITLE
Makefile POLA and less repetition tweaks

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -144,6 +144,7 @@ export ROUTING_LAYER_ADJUSTMENT ?= 0.5
 export RECOVER_POWER ?= 0
 export SKIP_INCREMENTAL_REPAIR ?= 0
 export DETAILED_METRICS ?= 0
+export EQUIVALENCE_CHECK ?= 0
 
 # If we are running headless use offscreen rendering for save_image
 ifndef DISPLAY

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -2,6 +2,11 @@
 # file to avoid having to adding the to the make command line.
 -include settings.mk
 
+# Include design and platform configuration before setting default options
+# in this file. This allows the DESIGN_CONFIG to set different defaults than
+# this file.
+include $(DESIGN_CONFIG)
+
 # ==============================================================================
 # Uncomment or add the design to run
 # ==============================================================================
@@ -190,10 +195,6 @@ export WORK_HOME     ?= .
 export UTILS_DIR     ?= $(FLOW_HOME)/util
 export SCRIPTS_DIR   ?= $(FLOW_HOME)/scripts
 export TEST_DIR      ?= $(FLOW_HOME)/test
-
-#-------------------------------------------------------------------------------
-# Include design and platform configuration
-include $(DESIGN_CONFIG)
 
 PUBLIC=nangate45 sky130hd sky130hs asap7 ihp-sg13g2 gf180
 

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -72,13 +72,13 @@ if {[info exist ::env(CTS_SNAPSHOTS)]} {
 }
 
 if {[info exists ::env(SKIP_CTS_REPAIR_TIMING)] == 0 || $::env(SKIP_CTS_REPAIR_TIMING) == 0} {
-  if {[info exists ::env(EQUIVALENCE_CHECK)] && $::env(EQUIVALENCE_CHECK) == 1} {
+  if {$::env(EQUIVALENCE_CHECK)} {
       write_eqy_verilog 4_before_rsz.v
   }
 
   repair_timing_helper
 
-  if {[info exists ::env(EQUIVALENCE_CHECK)] && $::env(EQUIVALENCE_CHECK) == 1} {
+  if {$::env(EQUIVALENCE_CHECK)} {
       run_equivalence_test
   }
 


### PR DESCRIPTION
Fewer surprises and less reptition.

Printing the default value now works:

```
$ make DESIGN_CONFIG=designs/asap7/mock-array/config.mk print-EQUIVALENCE_CHECK
EQUIVALENCE_CHECK = 0
$ make DESIGN_CONFIG=designs/asap7/aes/config.mk print-EQUIVALENCE_CHECK
EQUIVALENCE_CHECK = 1
```
