### PR TITLE
floorplan: replace surprises and documentation with actionable error messages

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -274,6 +274,8 @@ configuration file.
 | `MACRO_HALO_X`         | Set macro halo for x-direction. Only available for ASAP7 PDK. |
 | `MACRO_HALO_Y`         | Set macro halo for y-direction. Only available for ASAP7 PDK. |
 
+The various methods to specify the die and core area(`FLOORPLAN_DEF`, `FOOTPRINT`, `DIE_AREA`, `CORE_AREA` and `CORE_UTILIZATION`) are mutually exclusive. If two methods are specified, floorplan.tcl will exit with an error requiring that a single method is used.
+
 #### Placement
 
 

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -275,7 +275,7 @@ configuration file.
 | `MACRO_HALO_X`         | Set macro halo for x-direction. Only available for ASAP7 PDK. |
 | `MACRO_HALO_Y`         | Set macro halo for y-direction. Only available for ASAP7 PDK. |
 
-The various methods to specify the die and core area(`FLOORPLAN_DEF`, `FOOTPRINT`, `DIE_AREA`, `CORE_AREA` and `CORE_UTILIZATION`) are mutually exclusive. If two methods are specified, floorplan.tcl will exit with an error requiring that a single method is used.
+The various methods to specify the die and core area(`FLOORPLAN_DEF`, `FOOTPRINT`, `DIE_AREA` and `CORE_UTILIZATION`) are mutually exclusive. If two methods are specified, floorplan.tcl will exit with an error requiring that a single method is used.
 
 #### Placement
 

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -264,11 +264,11 @@ configuration file.
 
 | Variable              | Description                                                                                                                                                                                                                                |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `CORE_UTILIZATION`    | The core utilization percentage (0-100). Overrides `DIE_AREA` and `CORE_AREA`.                                                                                                                                                                   |
-| `CORE_ASPECT_RATIO`   | The core aspect ratio (height / width). This values is ignored if `CORE_UTILIZATION` undefined.                                                                                                                                            |
-| `CORE_MARGIN`         | The margin between the core area and die area, in multiples of SITE heights. The margin is applied to each side. This variable is ignored if `CORE_UTILIZATION` is undefined.                                                              |
-| `DIE_AREA`            | The die area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2). This variable is ignored if `CORE_UTILIZATION` and `CORE_ASPECT_RATIO` are defined.                                                       |
-| `CORE_AREA`           | The core area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2). This variable is ignored if `CORE_UTILIZATION` and `CORE_ASPECT_RATIO` are defined.                                                      |
+| `CORE_UTILIZATION`    | The core utilization percentage (0-100). |
+| `CORE_ASPECT_RATIO`   | The core aspect ratio (height / width). This values is ignored if `CORE_UTILIZATION` undefined. |
+| `CORE_MARGIN`         | The margin between the core area and die area, in multiples of SITE heights. The margin is applied to each side. This variable is ignored if `CORE_UTILIZATION` is undefined. |
+| `DIE_AREA`            | The die area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2). |
+| `CORE_AREA`           | The core area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2). |
 | `RESYNTH_AREA_RECOVER` | Enable re-synthesis for area reclaim. |
 | `RESYNTH_TIMING_RECOVER` | Enable re-synthesis for timing optimization. | 
 | `MACRO_HALO_X`         | Set macro halo for x-direction. Only available for ASAP7 PDK. |

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -145,6 +145,9 @@ export RECOVER_POWER ?= 0
 export SKIP_INCREMENTAL_REPAIR ?= 0
 export DETAILED_METRICS ?= 0
 export EQUIVALENCE_CHECK ?= 0
+export CORE_UTILIZATION ?=
+export DIE_AREA ?=
+export CORE_AREA ?=
 
 # If we are running headless use offscreen rendering for save_image
 ifndef DISPLAY

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -55,7 +55,7 @@ set use_core_utilization [env_var_exists_and_non_empty CORE_UTILIZATION]
 
 set methods_defined [expr {$use_floorplan_def + $use_footprint + $use_die_and_core_area + $use_core_utilization}]
 if {$methods_defined > 1} {
-    puts "ERROR: More than one floorplan initialization method specified"
+    puts "ERROR: Floorplan initialization methods are mutually exclusive, pick one."
     exit 1
 }
 


### PR DESCRIPTION
I've been suckerpunched several times by CORE_UTILIZATION overriding DIE/CORE_AREA.

Remove documentation/rules and replace it with checks and actionable error messages.

A floorplan config suckerpunch can manifest itself as late as in macro placement with an [inactionable error message](https://github.com/The-OpenROAD-Project/OpenROAD/pull/5735)....