### PR TITLE
setup: avoid confusion when user is not up to date

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,8 +10,20 @@ if [ $EUID -ne 0 ]; then
   exit 1
 fi
 
-if git submodule status --recursive | grep -q "^-"; then
-  git submodule update --init --recursive
+tmpfile=$(mktemp)
+# any error messages from this command will stand out
+# more clearly when run as a separate command rather than
+# being piped
+git submodule status --recursive > "$tmpfile"
+
+if grep -q "^-" "$tmpfile"; then
+  sudo -u $SUDO_USER git submodule update --init --recursive
+elif grep -q "^+" "$tmpfile"; then
+  # Make it easy for users who are not hacking ORFS to do the right thing,
+  # run with current submodules, at the cost of having ORFS
+  # hackers disable this test manually when hacking setup.sh
+  echo "Submodules are not up to date, run 'git submodule update --recursive' and try again"
+  exit 1
 fi
 
 "$DIR/etc/DependencyInstaller.sh" -base


### PR DESCRIPTION
A colleague of mine got confused by out of date submodules and root ownership yesterday after having updated to latest main and trying to run `sudo ./setup.sh` and I got confused today because I logged into a laptop I haven't used in a while and didn't think to submodules before running `sudo ./setup.sh`.

It is a pattern...

These changes should make it easier for users not to get caught in these snags...