### PR TITLE
generate_abstract: ABSTRACT_SOURCE=5_1_grt now works

### DIFF
--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -2,9 +2,11 @@ source $::env(SCRIPTS_DIR)/load.tcl
 
 set stem [expr {[info exists ::env(ABSTRACT_SOURCE)] ? $::env(ABSTRACT_SOURCE) : "6_final"}]
 
-set design_stage [lindex [split [file tail $stem] "_"] 0]
+set result [find_sdc_file $stem.odb]
+set design_stage [lindex $result 0]
+set sdc_file [lindex $result 1]
 
-load_design $stem.odb $stem.sdc
+load_design $stem.odb [file tail $sdc_file]
 
 if {$design_stage >= 6 && [file exists $::env(RESULTS_DIR)/$stem.spef]} {
   read_spef $::env(RESULTS_DIR)/$stem.spef

--- a/flow/scripts/gui.tcl
+++ b/flow/scripts/gui.tcl
@@ -19,18 +19,11 @@ if {[info exist ::env(DEF_FILE)]} {
     read_db $input_file
 }
 
-if {![info exist ::env(GUI_NO_TIMING)]} {
-  # Determine design stage (1 ... 6)
-  set design_stage [lindex [split [file tail $input_file] "_"] 0]
-  
-  # Read SDC, first try to find the most recent SDC file for the stage
-  set sdc_file ""
-  for {set s $design_stage} {$s > 0} {incr s -1} {
-    set sdc_file [glob -nocomplain -directory $::env(RESULTS_DIR) -types f "${s}_\[A-Za-z\]*\.sdc"]
-    if {$sdc_file != ""} {
-      break
-    }
-  }
+proc read_timing {input_file} {
+  set result [find_sdc_file $input_file]
+  set design_stage [lindex $result 0]
+  set sdc_file [lindex $result 1]
+
   if {$sdc_file == ""} {
     set sdc_file $::env(SDC_FILE)
   }
@@ -54,9 +47,10 @@ if {![info exist ::env(GUI_NO_TIMING)]} {
   }
 
   fast_route
-  
-  # Cleanup temporary variables
-  unset sdc_file s design_stage
+}
+
+if {![info exist ::env(GUI_NO_TIMING)]} {
+  read_timing $input_file
 }
 
 if {[info exist env(GUI_SOURCE)]} {

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -44,3 +44,18 @@ proc recover_power {} {
   report_wns
   report_power
 }
+
+proc find_sdc_file {input_file} {
+    # Determine design stage (1 ... 6)
+    set design_stage [lindex [split [file tail $input_file] "_"] 0]
+
+    # Read SDC, first try to find the most recent SDC file for the stage
+    set sdc_file ""
+    for {set s $design_stage} {$s > 0} {incr s -1} {
+        set sdc_file [glob -nocomplain -directory $::env(RESULTS_DIR) -types f "${s}_\[A-Za-z\]*\.sdc"]
+        if {$sdc_file != ""} {
+            break
+        }
+    }
+    return [list $design_stage $sdc_file]
+}


### PR DESCRIPTION
gui.tcl smarts to find .sdc file belonging to .odb now centralized and used by generate_abstract.