### PR TITLE
Makefile: add run script target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1152,6 +1152,10 @@ test-unset-and-make-%: ; $(UNSET_AND_MAKE) $*
 klayout:
 	$(KLAYOUT_CMD)
 
+.phony: run
+run:
+	$(OPENROAD_CMD) -no_splash $(RUN_SCRIPT)
+
 # Utilities
 #-------------------------------------------------------------------------------
 include $(UTILS_DIR)/utils.mk


### PR DESCRIPTION
Useful for automation.

Example(normally a user-provided script, just using floorplan.tcl as an example here):

make RUN_SCRIPT=scripts/floorplan.tcl run