### PR TITLE
Makefile simpler with run

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -145,11 +145,8 @@ Note:
 | `IO_PLACER_H`         | The metal layer on which to place the I/O pins horizontally (top and bottom of the die).                                                                                         |
 | `IO_PLACER_V`         | The metal layer on which to place the I/O pins vertically (sides of the die).                                                                                                    |
 | `GUI_NO_TIMING`       | Skip loading timing for a faster GUI load.                                                                                                                                       |
-| `GUI_SOURCE` | Source the script. |
-| `GUI_ARGS` | OpenROAD command line options for gui_ and open_ targets, typically set tup `-exit` in combination with GUI_SOURCE to run a script and exit. |
 | `FILL_CELLS`          | Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.	    |
 | `TAP_CELL_NAME`       | Name of the cell to use in tap cell insertion. |
-
 
 ### Placement
 

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -614,7 +614,7 @@ endef
 define OPEN_GUI
 .PHONY: $(1)_$(2)
 $(1)_$(2):
-	$(3)=$(RESULTS_DIR)/$(2) $(4) $(GUI_ARGS) $(SCRIPTS_DIR)/gui.tcl
+	$(3)=$(RESULTS_DIR)/$(2) $(4) $(SCRIPTS_DIR)/gui.tcl
 endef
 
 # Separate dependency checking and doing a step. This can
@@ -1096,10 +1096,10 @@ $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): kl
 
 .PHONY: gui_synth
 gui_synth:
-	$(OPENROAD_GUI_CMD) $(GUI_ARGS) $(SCRIPTS_DIR)/sta-synth.tcl
+	$(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
 .PHONY: open_synth
 open_synth:
-	$(OPENROAD_NO_EXIT_CMD) $(GUI_ARGS) $(SCRIPTS_DIR)/sta-synth.tcl
+	$(OPENROAD_NO_EXIT_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
 
 $(eval $(call OPEN_GUI_SHORTCUT,floorplan,2_floorplan.odb))
 $(eval $(call OPEN_GUI_SHORTCUT,place,3_place.odb))

--- a/flow/scripts/gui.tcl
+++ b/flow/scripts/gui.tcl
@@ -52,7 +52,3 @@ proc read_timing {input_file} {
 if {![info exist ::env(GUI_NO_TIMING)]} {
   read_timing $input_file
 }
-
-if {[info exist env(GUI_SOURCE)]} {
-  source $::env(GUI_SOURCE)
-}

--- a/flow/scripts/sta-synth.tcl
+++ b/flow/scripts/sta-synth.tcl
@@ -1,6 +1,2 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_synth.v 1_synth.sdc
-
-if {[info exist env(GUI_SOURCE)]} {
-  source $::env(GUI_SOURCE)
-}


### PR DESCRIPTION
Revert "makefile: add GUI_ARGS and GUI_SOURCE env vars"
    
This reverts commit b8b12da6ab455d8037e16ebe7d98555951c4f0e2.
    
Obsolete after 0eaec59385e9b790347c742b69cc80a290e2eba6

Example of simplification:  https://github.com/The-OpenROAD-Project/bazel-orfs/pull/167