### PR TITLE
tcl: use utility functions instead of inconsistent idioms

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -40,7 +40,7 @@ set num_instances [llength [get_cells -hier *]]
 puts "number instances in verilog is $num_instances"
 
 set additional_args ""
-append_env_var additinal_args ADDITIONAL_SITES -additional_sites 1
+append_env_var additional_args ADDITIONAL_SITES -additional_sites 1
 
 set use_floorplan_def [env_var_exists_and_non_empty FLOORPLAN_DEF]
 set use_footprint [env_var_exists_and_non_empty FOOTPRINT]

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -40,13 +40,7 @@ set num_instances [llength [get_cells -hier *]]
 puts "number instances in verilog is $num_instances"
 
 set additional_args ""
-if { [info exists ::env(ADDITIONAL_SITES)]} {
-  append additional_args " -additional_sites $::env(ADDITIONAL_SITES)"
-}
-
-proc env_var_exists_and_non_empty {env_var} {
-    return [expr {[info exists ::env($env_var)] && ![string equal $::env($env_var) ""]}]
-}
+append_env_var additinal_args ADDITIONAL_SITES -additional_sites 1
 
 set use_floorplan_def [env_var_exists_and_non_empty FLOORPLAN_DEF]
 set use_footprint [env_var_exists_and_non_empty FOOTPRINT]
@@ -97,7 +91,7 @@ if {$use_floorplan_def} {
     exit 1
 }
 
-if { [info exists ::env(MAKE_TRACKS)] } {
+if { [env_var_exists_and_non_empty MAKE_TRACKS] } {
   source $::env(MAKE_TRACKS)
 } elseif {[file exists $::env(PLATFORM_DIR)/make_tracks.tcl]} {
   source $::env(PLATFORM_DIR)/make_tracks.tcl
@@ -105,11 +99,11 @@ if { [info exists ::env(MAKE_TRACKS)] } {
   make_tracks
 }
 
-if {[info exists ::env(FOOTPRINT_TCL)]} {
+if {[env_var_exists_and_non_empty FOOTPRINT_TCL]} {
   source $::env(FOOTPRINT_TCL)
 }
 
-if { [info exists ::env(REMOVE_ABC_BUFFERS)] && $::env(REMOVE_ABC_BUFFERS) == 1 } {
+if { [env_var_equals REMOVE_ABC_BUFFERS 1] } {
   # remove buffers inserted by yosys/abc
   remove_buffers
 } else {
@@ -117,7 +111,7 @@ if { [info exists ::env(REMOVE_ABC_BUFFERS)] && $::env(REMOVE_ABC_BUFFERS) == 1 
 }
 
 ##### Restructure for timing #########
-if { [info exist ::env(RESYNTH_TIMING_RECOVER)] && $::env(RESYNTH_TIMING_RECOVER) == 1 } {
+if { [env_var_equals RESYNTH_TIMING_RECOVER 1] } {
   repair_design
   repair_timing
   # pre restructure area/timing report (ideal clocks)
@@ -156,7 +150,7 @@ report_units
 report_units_metric
 report_metrics 2 "floorplan final" false false
 
-if { [info exist ::env(RESYNTH_AREA_RECOVER)] && $::env(RESYNTH_AREA_RECOVER) == 1 } {
+if { [env_var_equals RESYNTH_AREA_RECOVER 1] } {
 
   utl::push_metrics_stage "floorplan__{}__pre_restruct"
   set num_instances [llength [get_cells -hier *]]
@@ -194,7 +188,7 @@ if { [info exist ::env(RESYNTH_AREA_RECOVER)] && $::env(RESYNTH_AREA_RECOVER) ==
   utl::pop_metrics_stage
 }
 
-if { [info exists ::env(POST_FLOORPLAN_TCL)] } {
+if { [env_var_exists_and_non_empty POST_FLOORPLAN_TCL] } {
   source $::env(POST_FLOORPLAN_TCL)
 }
 

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -126,13 +126,3 @@ proc run_equivalence_test {} {
       puts "Repair timing output passed equivalence test"
     }
 }
-
-proc append_env_var {list_name var_name prefix has_arg} {
-  upvar $list_name list
-  if {[info exist ::env($var_name)]} {
-    lappend list $prefix
-    if {$has_arg} {
-      lappend list $::env($var_name)
-    }
-  }
-}

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -66,7 +66,7 @@ proc find_sdc_file {input_file} {
 }
 
 proc env_var_equals {env_var value} {
-    return [info exists ::env($env_var)] && $::env($env_var) == $value
+    return [expr {[info exists ::env($env_var)] && $::env($env_var) == $value}]
 }
 
 proc env_var_exists_and_non_empty {env_var} {

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -64,3 +64,21 @@ proc find_sdc_file {input_file} {
     }
     return [list $design_stage $sdc_file]
 }
+
+proc env_var_equals {env_var value} {
+    return [info exists ::env($env_var)] && $::env($env_var) == $value
+}
+
+proc env_var_exists_and_non_empty {env_var} {
+    return [expr {[info exists ::env($env_var)] && ![string equal $::env($env_var) ""]}]
+}
+
+proc append_env_var {list_name var_name prefix has_arg} {
+  upvar $list_name list
+  if {[info exist ::env($var_name)]} {
+    lappend list $prefix
+    if {$has_arg} {
+      lappend list $::env($var_name)
+    }
+  }
+}


### PR DESCRIPTION
Less code and fewer surprises, make FOO= should generally turn off a feature, not run the feature with an empty argument.