### PR TITLE
synthesis: improve error messages

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -540,7 +540,8 @@ do-yosys:
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	($(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SCRIPTS_DIR)/synth_canonicalize.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_canonicalize.log)
+	# NOTE! YOSYS_FLAGS is omitted here because "-v 3" silences helpful error messages
+	($(TIME_CMD) $(YOSYS_EXE) -c $(SCRIPTS_DIR)/synth_canonicalize.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_canonicalize.log)
 
 $(RESULTS_DIR)/1_synth.rtlil: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize


### PR DESCRIPTION
YOSYS_FLAGS=-v 3 will silence error messages, such as the below.

However, without this option, synthesis will give an enormous amount of output.

Fortunately, the most common error messages, like unknown top module, is shown during canonicalization and not specifying -v 3 doesn't increase the logging noise noticably during the canonicalization stage.

To test:

1. modify gcd.v to rename "gcd" module to "gcdxxx"
2. Run "make synth"

Now it fails with a helpful error message

[deleted]
4. Executing HIERARCHY pass (managing design hierarchy). ERROR: Module `gcd' not found!
ERROR: TCL interpreter returned an error: Yosys command produced an error Command exited with non-zero status 1