### PR TITLE
route: fix error message after failed global route

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -1,3 +1,9 @@
+if {[expr [file exists $::env(REPORTS_DIR)/congestion.rpt] && \
+    [file size $::env(REPORTS_DIR)/congestion.rpt] != 0]} {
+  error "Global routing failed, run `make gui_grt` and load $::env(REPORTS_DIR)/congestion.rpt \
+    in DRC viewer to view congestion"
+}
+
 utl::set_metrics_stage "detailedroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 5_1_grt.odb 4_cts.sdc

--- a/flow/scripts/fillcell.tcl
+++ b/flow/scripts/fillcell.tcl
@@ -1,9 +1,3 @@
-if {[expr [file exists $::env(REPORTS_DIR)/congestion.rpt] && \
-    [file size $::env(REPORTS_DIR)/congestion.rpt] != 0]} {
-  error "Global routing failed, run `make gui_grt` and load $::env(REPORTS_DIR)/congestion.rpt \
-    in DRC viewer to view congestion"
-}
-
 source $::env(SCRIPTS_DIR)/load.tcl
 if {[env_var_exists_and_non_empty FILL_CELLS]} {
   load_design 5_2_route.odb 4_cts.sdc


### PR DESCRIPTION
detailed route now happens immediately after global route.

```
$ build/make do-5_2_route 
build/make: 27: [[: not found
Running detail_route.tcl, stage 5_2_route
[INFO ORD-0030] Using 48 thread(s).
Error: detail_route.tcl, 5 Global routing failed, run `make gui_grt` and load .//reports/asap7/BoomTile/base/congestion.rpt  in DRC viewer to view congestion
Command exited with non-zero status 1
Elapsed time: 0:00.08[h:]min:sec. CPU time: user 0.04 sys 0.03 (101%). Peak memory: 99840KB.

```
