### PR TITLE
makefile: support specifying input to do-6_report

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -148,6 +148,7 @@ export EQUIVALENCE_CHECK ?= 0
 export CORE_UTILIZATION ?=
 export DIE_AREA ?=
 export CORE_AREA ?=
+export FINAL_FILE_STEM ?= 6_1_fill
 
 # If we are running headless use offscreen rendering for save_image
 ifeq ($(DISPLAY),)

--- a/flow/scripts/final_report.tcl
+++ b/flow/scripts/final_report.tcl
@@ -1,6 +1,6 @@
 utl::set_metrics_stage "finish__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 6_1_fill.odb 6_1_fill.sdc
+load_design $::env(FINAL_FILE_STEM).odb $::env(FINAL_FILE_STEM).sdc
 
 set_propagated_clock [all_clocks]
 


### PR DESCRIPTION
It can be useful to "flush the pipe" with information from earlier stages in the flow to reduce turnaround times. Although the result is not valid, it can still find problems with the flow more quickly.

To generate a report based upon information available at place time, run:

make FINAL_FILE_STEM=3_place do-6_report