### PR TITLE
scripts: tcl info exist/s cleanup

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -17,25 +17,17 @@ set cts_args [list \
           -sink_clustering_enable \
           -balance_levels]
 
-if {[info exist ::env(CTS_BUF_DISTANCE)]} {
-  lappend cts_args -distance_between_buffers $::env(CTS_BUF_DISTANCE)
-}
+append_env_var cts_args -distance_between_buffers CTS_BUF_DISTANCE 1
+append_env_var cts_args -sink_clustering_size CTS_CLUSTER_SIZE 1
+append_env_var cts_args -sink_clustering_max_diameter CTS_CLUSTER_DIAMETER 1
 
-if {[info exist ::env(CTS_CLUSTER_SIZE)]} {
-  lappend cts_args -sink_clustering_size $::env(CTS_CLUSTER_SIZE)
-}
-
-if {[info exist ::env(CTS_CLUSTER_DIAMETER)]} {
-  lappend cts_args -sink_clustering_max_diameter $::env(CTS_CLUSTER_DIAMETER)
-}
-
-if {[info exist ::env(CTS_ARGS)]} {
+if {[env_var_exists_and_non_empty CTS_ARGS]} {
   set cts_args $::env(CTS_ARGS)
 }
 
 log_cmd clock_tree_synthesis {*}$cts_args
 
-if {[info exist ::env(CTS_SNAPSHOTS)]} {
+if {[env_var_equals CTS_SNAPSHOTS 1]} {
   save_progress 4_1_pre_repair_clock_nets
 }
 
@@ -67,7 +59,7 @@ detailed_placement
 
 estimate_parasitics -placement
 
-if {[info exist ::env(CTS_SNAPSHOTS)]} {
+if {[env_var_equals CTS_SNAPSHOTS 1]} {
   save_progress 4_1_pre_repair_hold_setup
 }
 

--- a/flow/scripts/detail_place.tcl
+++ b/flow/scripts/detail_place.tcl
@@ -16,7 +16,7 @@ proc do_dpl {} {
   detailed_placement
   
   if {[env_var_equals ENABLE_DPO 1]} {
-    if {[info exist ::env(DPO_MAX_DISPLACEMENT)]} {
+    if {[env_var_exists_and_non_empty DPO_MAX_DISPLACEMENT]} {
       improve_placement -max_displacement $::env(DPO_MAX_DISPLACEMENT)
     } else {
       improve_placement

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -50,7 +50,7 @@ set_global_routing_layer_adjustment $env(MIN_ROUTING_LAYER)-$env(MAX_ROUTING_LAY
 set_routing_layers -signal $env(MIN_ROUTING_LAYER)-$env(MAX_ROUTING_LAYER)
 
 
-if {![info exist ::env(SKIP_ANTENNA_REPAIR_POST_DRT)]} {
+if {![env_var_equals SKIP_ANTENNA_REPAIR_POST_DRT 1]} {
   set repair_antennas_iters 1
   repair_antennas
   while {[check_antennas] && $repair_antennas_iters < 5} {

--- a/flow/scripts/final_report.tcl
+++ b/flow/scripts/final_report.tcl
@@ -17,11 +17,11 @@ write_def $::env(RESULTS_DIR)/6_final.def
 write_verilog $::env(RESULTS_DIR)/6_final.v
 
 # Run extraction and STA
-if {[info exist ::env(RCX_RULES)]} {
+if {[env_var_exists_and_non_empty RCX_RULES]} {
 
   # Set RC corner for RCX
   # Set in config.mk
-  if {[info exist ::env(RCX_RC_CORNER)]} {
+  if {[env_var_exists_and_non_empty RCX_RC_CORNER]} {
     set rc_corner $::env(RCX_RC_CORNER)
   }
 
@@ -37,7 +37,7 @@ if {[info exist ::env(RCX_RULES)]} {
   read_spef $::env(RESULTS_DIR)/6_final.spef
 
   # Static IR drop analysis
-  if {[info exist ::env(PWR_NETS_VOLTAGES)] && [string length $::env(PWR_NETS_VOLTAGES)] > 0} {
+  if {[env_var_exists_and_non_empty PWR_NETS_VOLTAGES]} {
     dict for {pwrNetName pwrNetVoltage}  {*}$::env(PWR_NETS_VOLTAGES) {
         set_pdnsim_net_voltage -net ${pwrNetName} -voltage ${pwrNetVoltage}
         analyze_power_grid -net ${pwrNetName} \
@@ -46,7 +46,7 @@ if {[info exist ::env(RCX_RULES)]} {
   } else {
     puts "IR drop analysis for power nets is skipped because PWR_NETS_VOLTAGES is undefined"
   }
-  if {[info exist ::env(GND_NETS_VOLTAGES)] && [string length $::env(GND_NETS_VOLTAGES)] > 0} {
+  if {[env_var_exists_and_non_empty GND_NETS_VOLTAGES]} {
     dict for {gndNetName gndNetVoltage}  {*}$::env(GND_NETS_VOLTAGES) {
         set_pdnsim_net_voltage -net ${gndNetName} -voltage ${gndNetVoltage}
         analyze_power_grid -net ${gndNetName} \

--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -24,7 +24,7 @@ puts "Generating abstract views"
 write_timing_model $::env(RESULTS_DIR)/$::env(DESIGN_NAME).lib
 write_abstract_lef -bloat_occupied_layers $::env(RESULTS_DIR)/$::env(DESIGN_NAME).lef
 
-if {[info exist ::env(CDL_FILES)]} {
+if {[env_var_exists_and_non_empty CDL_FILES]} {
   cdl read_masters $::env(CDL_FILES)
   cdl out $::env(RESULTS_DIR)/$stem.cdl
 }

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -41,7 +41,7 @@ if {$result != 0} {
 
 estimate_parasitics -placement
 
-if {[info exist ::env(CLUSTER_FLOPS)]} {
+if {[env_var_equals CLUSTER_FLOPS 1]} {
   cluster_flops
   estimate_parasitics -placement
 }

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -6,7 +6,7 @@ proc global_route_helper {} {
   source $::env(SCRIPTS_DIR)/load.tcl
   load_design 4_cts.odb 4_cts.sdc
 
-  if {[info exist ::env(PRE_GLOBAL_ROUTE)]} {
+  if {[env_var_exists_and_non_empty PRE_GLOBAL_ROUTE]} {
     source $::env(PRE_GLOBAL_ROUTE)
   }
 
@@ -45,7 +45,7 @@ proc global_route_helper {} {
   set_propagated_clock [all_clocks]
   estimate_parasitics -global_routing
 
-  if {[info exist ::env(DONT_USE_CELLS)]} {
+  if {[env_var_exists_and_non_empty DONT_USE_CELLS]} {
     set_dont_use $::env(DONT_USE_CELLS)
   }
 
@@ -88,7 +88,7 @@ proc global_route_helper {} {
 
   recover_power
 
-  if {![info exist ::env(SKIP_ANTENNA_REPAIR)]} {
+  if {![env_var_equals SKIP_ANTENNA_REPAIR 1]} {
     puts "Repair antennas..."
     repair_antennas -iterations 5
     check_placement -verbose

--- a/flow/scripts/gui.tcl
+++ b/flow/scripts/gui.tcl
@@ -3,11 +3,11 @@ source $::env(SCRIPTS_DIR)/util.tcl
 source $::env(SCRIPTS_DIR)/read_liberty.tcl
 
 # Read def
-if {[info exist ::env(DEF_FILE)]} {
+if {[env_var_exists_and_non_empty DEF_FILE]} {
     # Read lef
     read_lef $::env(TECH_LEF)
     read_lef $::env(SC_LEF)
-    if {[info exist ::env(ADDITIONAL_LEFS)]} {
+    if {[env_var_exists_and_non_empty ADDITIONAL_LEFS]} {
       foreach lef $::env(ADDITIONAL_LEFS) {
         read_lef $lef
       }
@@ -49,6 +49,6 @@ proc read_timing {input_file} {
   fast_route
 }
 
-if {![info exist ::env(GUI_NO_TIMING)]} {
+if {![env_var_equals GUI_NO_TIMING 1]} {
   read_timing $input_file
 }

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -14,7 +14,7 @@ proc load_design {design_file sdc_file} {
   if {$ext == ".v"} {
     read_lef $::env(TECH_LEF)
     read_lef $::env(SC_LEF)
-    if {[info exist ::env(ADDITIONAL_LEFS)]} {
+    if {[env_var_exists_and_non_empty ADDITIONAL_LEFS]} {
       foreach lef $::env(ADDITIONAL_LEFS) {
         read_lef $lef
       }
@@ -51,13 +51,13 @@ proc get_verilog_cells_for_design { } {
 }
 
 proc write_eqy_verilog {filename} {
-    # Filter out cells with no verilog/not needed for equivalence such
-    # as fillers and tap cells 
-    if {[info exist ::env(REMOVE_CELLS_FOR_EQY)]} {
-	write_verilog -remove_cells $::env(REMOVE_CELLS_FOR_EQY) $::env(RESULTS_DIR)/$filename
-    } else {
-	write_verilog  $::env(RESULTS_DIR)/$filename
-    }
+  # Filter out cells with no verilog/not needed for equivalence such
+  # as fillers and tap cells 
+  if {[env_var_exists_and_non_empty REMOVE_CELLS_FOR_EQY]} {
+    write_verilog -remove_cells $::env(REMOVE_CELLS_FOR_EQY) $::env(RESULTS_DIR)/$filename
+  } else {
+	  write_verilog  $::env(RESULTS_DIR)/$filename
+  }
 }
 
 proc write_eqy_script_for_sky130hd {} {

--- a/flow/scripts/resize.tcl
+++ b/flow/scripts/resize.tcl
@@ -33,7 +33,7 @@ if { [env_var_exists_and_non_empty SLEW_MARGIN] && $::env(SLEW_MARGIN) > 0.0} {
 
 repair_design {*}$additional_args
 
-if { [info exists env(TIE_SEPARATION)] } {
+if { [env_var_exists_and_non_empty TIE_SEPARATION] } {
   set tie_separation $env(TIE_SEPARATION)
 } else {
   set tie_separation 0

--- a/flow/scripts/save_images.tcl
+++ b/flow/scripts/save_images.tcl
@@ -1,3 +1,5 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 gui::save_display_controls
 
 set height [[[ord::get_db_block] getBBox] getDY]
@@ -35,7 +37,7 @@ gui::set_display_controls "Layers/*" visible false
 gui::set_display_controls "Instances/Physical/*" visible false
 save_image -resolution $resolution $::env(REPORTS_DIR)/final_placement.webp
 
-if {[info exist ::env(PWR_NETS_VOLTAGES)] && [string length $::env(PWR_NETS_VOLTAGES)] > 0} {
+if {[env_var_exists_and_non_empty PWR_NETS_VOLTAGES]} {
   gui::set_display_controls "Heat Maps/IR Drop" visible true
   gui::set_heatmap IRDrop Layer $::env(IR_DROP_LAYER)
   gui::set_heatmap IRDrop ShowLegend 1

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -2,7 +2,7 @@ source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
 source $::env(SYNTH_STOP_MODULE_SCRIPT)
 
-if { [info exist ::env(SYNTH_GUT)] && $::env(SYNTH_GUT) == 1 } {
+if { [env_var_equals SYNTH_GUT 1] } {
   hierarchy -check -top $::env(DESIGN_NAME)
   # /deletes all cells at the top level, which will quickly optimize away
   # everything else, including macros.
@@ -20,7 +20,7 @@ renames -wire
 opt -purge
 
 # Technology mapping of adders
-if {[info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)]} {
+if {[env_var_exists_and_non_empty ADDER_MAP_FILE] && [file isfile $::env(ADDER_MAP_FILE)]} {
   # extract the full adders
   extract_fa
   # map full adders
@@ -31,7 +31,7 @@ if {[info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)]} 
 }
 
 # Technology mapping of latches
-if {[info exist ::env(LATCH_MAP_FILE)]} {
+if {[env_var_exists_and_non_empty LATCH_MAP_FILE]} {
   techmap -map $::env(LATCH_MAP_FILE)
 }
 
@@ -42,7 +42,7 @@ foreach cell $::env(DONT_USE_CELLS) {
 
 # Technology mapping of flip-flops
 # dfflibmap only supports one liberty file
-if {[info exist ::env(DFF_LIB_FILE)]} {
+if {[env_var_exists_and_non_empty DFF_LIB_FILE]} {
   dfflibmap -liberty $::env(DFF_LIB_FILE) {*}$dfflibmap_args
 } else {
   dfflibmap -liberty $::env(DONT_USE_SC_LIB) {*}$dfflibmap_args

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -1,5 +1,7 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 proc write_keep_hierarchy {} {
-  if { ![info exist ::env(SYNTH_HIERARCHICAL)] || $::env(SYNTH_HIERARCHICAL) == 0 } {
+  if { ![env_var_equals SYNTH_HIERARCHICAL 1] } {
     set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
     close $out_script_ptr
     return
@@ -9,11 +11,11 @@ proc write_keep_hierarchy {} {
 
   synthesize_check {}
 
-  if { [info exist ::env(ADDER_MAP_FILE)] && [file isfile $::env(ADDER_MAP_FILE)] } {
+  if { [env_var_exists_and_non_empty ADDER_MAP_FILE] && [file isfile $::env(ADDER_MAP_FILE)] } {
     techmap -map $::env(ADDER_MAP_FILE)
   }
   techmap
-  if {[info exist ::env(DFF_LIB_FILE)]} {
+  if {[env_var_exists_and_non_empty DFF_LIB_FILE]} {
     dfflibmap -liberty $::env(DFF_LIB_FILE)
   } else {
     dfflibmap -liberty $::env(DONT_USE_SC_LIB)
@@ -24,7 +26,7 @@ proc write_keep_hierarchy {} {
   tee -o $::env(REPORTS_DIR)/synth_hier_stat.txt stat {*}$stat_libs
 
   set ungroup_threshold 0
-  if { [info exist ::env(MAX_UNGROUP_SIZE)] && $::env(MAX_UNGROUP_SIZE) > 0 } {
+  if { [env_var_exists_and_non_empty MAX_UNGROUP_SIZE] && $::env(MAX_UNGROUP_SIZE) > 0 } {
     set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
     puts "Ungroup modules of size $ungroup_threshold"
   }

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -2,9 +2,9 @@ yosys -import
 
 source $::env(SCRIPTS_DIR)/util.tcl
 
-if {[info exist ::env(CACHED_NETLIST)]} {
+if {[env_var_exists_and_non_empty CACHED_NETLIST]} {
   exec cp $::env(CACHED_NETLIST) $::env(RESULTS_DIR)/1_1_yosys.v
-  if {[info exist ::env(CACHED_REPORTS)]} {
+  if {[env_var_exists_and_non_empty CACHED_REPORTS]} {
     exec cp {*}$::env(CACHED_REPORTS) $::env(REPORTS_DIR)/.
   }
   exit
@@ -12,7 +12,7 @@ if {[info exist ::env(CACHED_NETLIST)]} {
 
 # Setup verilog include directories
 set vIdirsArgs ""
-if {[info exist ::env(VERILOG_INCLUDE_DIRS)]} {
+if {[env_var_exists_and_non_empty VERILOG_INCLUDE_DIRS]} {
   foreach dir $::env(VERILOG_INCLUDE_DIRS) {
     lappend vIdirsArgs "-I$dir"
   }
@@ -39,19 +39,19 @@ foreach file $::env(VERILOG_FILES) {
 read_liberty -lib {*}$::env(DONT_USE_LIBS)
 
 # Apply toplevel parameters (if exist)
-if {[info exist ::env(VERILOG_TOP_PARAMS)]} {
+if {[env_var_exists_and_non_empty VERILOG_TOP_PARAMS]} {
   dict for {key value} $::env(VERILOG_TOP_PARAMS) {
     chparam -set $key $value $::env(DESIGN_NAME)
   }
 }
 
 # Read platform specific mapfile for OPENROAD_CLKGATE cells
-if {[info exist ::env(CLKGATE_MAP_FILE)]} {
+if {[env_var_exists_and_non_empty CLKGATE_MAP_FILE]} {
   read_verilog -defer $::env(CLKGATE_MAP_FILE)
 }
 
 # Mark modules to keep from getting removed in flattening
-if {[info exist ::env(PRESERVE_CELLS)]} {
+if {[env_var_exists_and_non_empty PRESERVE_CELLS]} {
   # Expand hierarchy since verilog was read in with -defer
   hierarchy -check -top $::env(DESIGN_NAME)
   foreach cell $::env(PRESERVE_CELLS) {
@@ -77,13 +77,13 @@ set abc_args [list -script $abc_script \
 
 # Exclude dont_use cells. This includes macros that are specified via
 # LIB_FILES and ADDITIONAL_LIBS that are included in LIB_FILES.
-if {[info exist ::env(DONT_USE_CELLS)] && $::env(DONT_USE_CELLS) != ""} {
+if {[env_var_exists_and_non_empty DONT_USE_CELLS]} {
   foreach cell $::env(DONT_USE_CELLS) {
     lappend abc_args -dont_use $cell
   }
 }
 
-if {[info exist ::env(SDC_FILE_CLOCK_PERIOD)] && [file isfile $::env(SDC_FILE_CLOCK_PERIOD)]} {
+if {[env_var_exists_and_non_empty SDC_FILE_CLOCK_PERIOD] && [file isfile $::env(SDC_FILE_CLOCK_PERIOD)]} {
   puts "Extracting clock period from SDC file: $::env(SDC_FILE_CLOCK_PERIOD)"
   set fp [open $::env(SDC_FILE_CLOCK_PERIOD) r]
   set clock_period [string trim [read $fp]]

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -4,12 +4,12 @@ proc log_cmd {cmd args} {
 }
 
 proc fast_route {} {
-  if {[info exist ::env(FASTROUTE_TCL)]} {
+  if {[env_var_exists_and_non_empty FASTROUTE_TCL]} {
     source $::env(FASTROUTE_TCL)
   } else {
     set_global_routing_layer_adjustment $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) $::env(ROUTING_LAYER_ADJUSTMENT)
     set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
-    if {[info exist ::env(MACRO_EXTENSION)]} {
+    if {[env_var_exists_and_non_empty MACRO_EXTENSION]} {
       set_macro_extension $::env(MACRO_EXTENSION)
     }
   }

--- a/flow/util/write_net_rc_script.tcl
+++ b/flow/util/write_net_rc_script.tcl
@@ -7,7 +7,7 @@ source $::env(UTILS_DIR)/write_net_rc.tcl
 estimate_parasitics -placement
 record_wire_rc gpl
 
-if {[info exist env(FASTROUTE_TCL)]} {
+if {[env_var_exists_and_non_empty FASTROUTE_TCL]} {
   source $env(FASTROUTE_TCL)
 } else {
   set_global_routing_layer_adjustment $env(MIN_ROUTING_LAYER)-$env(MAX_ROUTING_LAYER) 0.5


### PR DESCRIPTION
info exists is the official method, but info exist works. Weird.

This made me miss cleanup in my sweep...

https://wiki.tcl-lang.org/page/info+exists

$ tclsh
% info exist ::env(lkajsfljsaf)
0
% info exists ::env(ljadsflkjasf)
0
% info exist ::env(PATH)
1
% info exists ::env(PATH)
1