### PR TITLE
makefile: variables in make issue are now sorted

### DIFF
--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -90,7 +90,7 @@ $(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)
-export ISSUE_VARIABLES_NAMES := $(call get_variables,environment% default automatic)
+export ISSUE_VARIABLES_NAMES := $(sort $(filter-out \n get_variables, $(call get_variables,environment% default automatic)))
 export ISSUE_VARIABLES := $(foreach V, $(ISSUE_VARIABLES_NAMES), $(if $($V),$V=$($V),$V='')${\n})
 export COMMAND_LINE_ARGS := $(foreach V,$(.VARIABLES),$(if $(filter command% line, $(origin $V)),$(V)))
 


### PR DESCRIPTION
Less eyestrain when looking for something in vars*.sh

also, "\n get_variables" are removed from ISSEU_VARIABLES_NAMES.

These two superfluous words were there previously, don't know why or how, but not easily spotted in an unsorted list.

I ran the command below to test before/after + we have CI tests for make issue:

make print-ISSUE_VARIABLES_NAMES