### PR TITLE
detailed route: add DETAILED_ROUTE_END_ITERATION variable

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -192,6 +192,7 @@ Note:
 | `DETAILED_ROUTE_ARGS` | Add additional arguments for debugging purpose during detail route.                               |
 | `MACRO_EXTENSION`     | Sets the number of GCells added to the blockages boundaries from macros.                          |
 | `RECOVER_POWER`       | Specifies how many percent of paths with positive slacks can be slowed for power savings [0-100]. |
+| `DETAILED_ROUTE_END_ITERATION` | Maximum number of iterations, default 64. |
 
 
 ### Extraction

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -19,6 +19,7 @@ append_env_var additional_args VIA_IN_PIN_MIN_LAYER -via_in_pin_bottom_layer 1
 append_env_var additional_args VIA_IN_PIN_MAX_LAYER -via_in_pin_top_layer 1
 append_env_var additional_args DISABLE_VIA_GEN -disable_via_gen 0
 append_env_var additional_args REPAIR_PDN_VIA_LAYER -repair_pdn_vias 1
+append_env_var additional_args DETAILED_ROUTE_END_ITERATION -droute_end_iter 1
 
 append additional_args " -save_guide_updates -verbose 1"
 


### PR DESCRIPTION
Useful for debugging and also most designs either finish quickly or it is hopeless aftger a few iterations, so dialing down number of iterations in CI speeds up turnaround times.