### PR TITLE
io_placement: spell out .tcl options to improve readability

### DIFF
--- a/flow/scripts/io_placement_util.tcl
+++ b/flow/scripts/io_placement_util.tcl
@@ -4,8 +4,8 @@ if {[env_var_exists_and_non_empty FLOORPLAN_DEF]} {
   if {[env_var_exists_and_non_empty IO_CONSTRAINTS]} {
     source $::env(IO_CONSTRAINTS)
   }
-  set args [list -hor_layer $::env(IO_PLACER_H) \
-           -ver_layer $::env(IO_PLACER_V) \
+  set args [list -hor_layers $::env(IO_PLACER_H) \
+           -ver_layers $::env(IO_PLACER_V) \
            {*}$::env(PLACE_PINS_ARGS)]
   log_cmd place_pins {*}$args
 }


### PR DESCRIPTION
the plural form tells the reader that multiple metal layers can be used