### PR TITLE
Makefile log info

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -618,7 +618,7 @@ do-$(1): $(OBJECTS_DIR)/copyright.txt
 	@echo Running $(3).tcl, stage $(1)
 	@(set -eo pipefail; \
 	trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
-	$(OPENROAD_EXE) -exit -no_init $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
+	$(OPENROAD_EXE) $(OPENROAD_ARGS) -exit $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
 	$(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \
 	tee -a $(abspath $(LOG_DIR)/$(1).tmp.log))
 endef


### PR DESCRIPTION
Part deux https://github.com/The-OpenROAD-Project/OpenROAD/pull/5876

Manual test locally:


```
$ make do-2_3_floorplan_tdms 
Running tdms_place.tcl, stage 2_3_floorplan_tdms
exec cp ./results/nangate45/gcd/base/2_2_floorplan_io.odb ./results/nangate45/gcd/base/2_3_floorplan_tdms.odb
Elapsed time: 0:00.13[h:]min:sec. CPU time: user 0.10 sys 0.02 (100%). Peak memory: 100444KB.
$ head -n 10 logs/nangate45/gcd/base/2_3_floorplan_tdms.log 
OpenROAD v2.0-16257-g81b545063 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 12 thread(s).
exec cp ./results/nangate45/gcd/base/2_2_floorplan_io.odb ./results/nangate45/gcd/base/2_3_floorplan_tdms.odb
Elapsed time: 0:00.13[h:]min:sec. CPU time: user 0.10 sys 0.02 (100%). Peak memory: 100444KB.
```
