### PR TITLE
Makefile: use env for time

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -262,7 +262,7 @@ YOSYS_FLAGS += -v 3
 
 #-------------------------------------------------------------------------------
 # setup all commands used within this flow
-export TIME_BIN   ?= /usr/bin/time
+export TIME_BIN   ?= env time
 TIME_CMD = $(TIME_BIN) -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.'
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
 ifeq (,$(strip $(TIME_TEST)))


### PR DESCRIPTION
This PR retains the idea behind this line of Makefile. `env` is a builtin of `bash` so all systems will have this and will resolve it to the `time` command in `PATH` rather than the builtin bash `time`. On Linux NixOS, these otherwise common paths are invalid, as the only file in `/usr/bin/` is in fact `/usr/bin/env`