### PR TITLE
scripts: load CLKGATE_MAP_FILE as lib and techmap it

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -35,6 +35,11 @@ if {[env_var_exists_and_non_empty LATCH_MAP_FILE]} {
   techmap -map $::env(LATCH_MAP_FILE)
 }
 
+# Technology mapping of ICGs
+if {[env_var_exists_and_non_empty CLKGATE_MAP_FILE]} {
+  techmap -map $::env(CLKGATE_MAP_FILE)
+}
+
 set dfflibmap_args ""
 foreach cell $::env(DONT_USE_CELLS) {
   lappend dfflibmap_args -dont_use $cell

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -48,7 +48,7 @@ if {[env_var_exists_and_non_empty VERILOG_TOP_PARAMS]} {
 
 # Read platform specific mapfile for OPENROAD_CLKGATE cells
 if {[env_var_exists_and_non_empty CLKGATE_MAP_FILE]} {
-  read_verilog -defer $::env(CLKGATE_MAP_FILE)
+  read_verilog -lib $::env(CLKGATE_MAP_FILE)
 }
 
 # Mark modules to keep from getting removed in flattening


### PR DESCRIPTION
The main idea is that if you use yosys `clockgate` to map ICGs to `OPENROAD_CLKGATE`, you need a blackbox to be present, which is missing at that time since currently it's loaded with `-defer`. That leads to `check` failures due to missing cells after `abc` which this PR fixes. Credit for the idea goes to @povik