### PR TITLE
variables: flesh out some variables used in bazel-orfs

### DIFF
--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -80,6 +80,13 @@ CORE_AREA:
 SKIP_REPORT_METRICS:
   description: >
     If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds.
+  stages:
+    - floorplan
+    - place
+    - cts
+    - grt
+    - route
+    - final
 PROCESS:
   description: >
     Technology node or process in use.
@@ -165,6 +172,11 @@ FLOORPLAN_DEF:
     Use the DEF file to initialize floorplan.
   stages:
     - floorplan
+REMOVE_ABC_BUFFERS:
+  description: >
+    Remove abc buffers from the netlist.
+  stages:
+    - floorplan
 PLACE_SITE:
   description: >
     Placement site for core cells defined in the technology LEF file.
@@ -216,6 +228,12 @@ MAKE_TRACKS:
     Tcl file that defines add routing tracks to a floorplan.
   stages:
     - floorplan
+IO_CONSTRAINTS:
+  description: >
+    File path to the IO constraints .tcl file.
+  stages:
+    - floorplan
+    - place
 IO_PLACER_H:
   description: >
     The metal layer on which to place the I/O pins horizontally (top and bottom of the die).
@@ -234,6 +252,8 @@ GUI_NO_TIMING:
 FILL_CELLS:
   description: >
     Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.
+  stages:
+    - route
 TAP_CELL_NAME:
   description: >
     Name of the cell to use in tap cell insertion.
@@ -250,6 +270,12 @@ CELL_PAD_IN_SITES_DETAIL_PLACEMENT:
     - place
     - cts
     - grt
+PLACE_PINS_ARGS:
+  description: >
+    Arguments to place_pins
+  stages:
+    - place
+    - floorplan
 PLACE_DENSITY:
   description: >
     The desired placement density of cells. It reflects how spread the cells would be on the core area.
@@ -324,6 +350,7 @@ MIN_ROUTING_LAYER:
     - place
     - grt
     - route
+    - final
 MAX_ROUTING_LAYER:
   description: >
     The highest metal layer name to be used in routing.
@@ -331,6 +358,7 @@ MAX_ROUTING_LAYER:
     - place
     - grt
     - route
+    - final
 DETAILED_ROUTE_ARGS:
   description: >
     Add additional arguments for debugging purposes during detail route.
@@ -378,6 +406,16 @@ SDC_FILE:
   required: true
   description: >
     The path to design constraint (SDC) file.
+  stages:
+    - synth
+SDC_GUT:
+  description: >
+    Load design and remove all internal logic before doing synthesis. This
+    is useful when creating a mock .lef abstract that has a smaller area
+    than the amount of logic would allow. bazel-orfs uses this to mock
+    SRAMs, for instance.
+  stages:
+    - synth
 ADDITIONAL_FILES:
   description: >
     Additional files to be added to `make issue` archive.
@@ -421,9 +459,13 @@ ABC_AREA:
 PWR_NETS_VOLTAGES:
   description: >
     Used for IR Drop calculation.
+  stages:
+    - final
 GND_NETS_VOLTAGES:
   description: >
     Used for IR Drop calculation.
+  stages:
+    - final
 BLOCKS:
   description: >
     Blocks used as hard macros in a hierarchical flow. Do note that you have to


### PR DESCRIPTION
FlowVariables.md is not re-generated to avoid merge conflicts but was tested locally