### PR TITLE
gui: less click+wait, populate timing paths as part of loading timing

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -47,6 +47,10 @@ proc read_timing {input_file} {
   }
 
   fast_route
+
+  puts "Populating timing paths..."
+  # Warm up OpenSTA, so clicking on timing related buttons reacts faster
+  set _tmp [find_timing_paths]
 }
 
 if {![env_var_equals GUI_NO_TIMING 1]} {


### PR DESCRIPTION
This makes the GUI more responsive for large designs when interacting with timing.

report_checks returns instantaneously.

Use GUI_TIMING=0 when timing is not needed.