### PR TITLE
gui/open: minimize surprises, handle errors in reading timing

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -51,7 +51,9 @@ proc read_timing {input_file} {
 
 if {[env_var_equals GUI_TIMING 1]} {
   puts "GUI_TIMING=1 reading timing, takes a little while for large designs..."
-  read_timing $input_file
+  if {[catch {read_timing $input_file} errMsg]} {
+      puts "Error reading timing: $errMsg"
+  }
 }
 
 if {[env_var_equals GUI_SHOW 1]} {


### PR DESCRIPTION
read_timing can fail estimating parasitics for a failed global route .odb file and examining global route DRC .rpt files in the GUI, for instance.

The "surprise" for the user is that he has to type `gui::show`. This PR eliminates that surprise.

This is surprising because there is nothing in particular the user can do from the console, they probably have to open the GUI to examine the problem, such as loading DRC report from global routing.

Example output after fix(from MegaBoom):

```
$ tmp/make gui_grt
ODB_FILE=.//results/asap7/BoomTile/base/5_1_grt.odb /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init -threads 16  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/open.tcl
OpenROAD v2.0-16443-g372a00c48 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 16 thread(s).
GUI_TIMING=1 reading timing, takes a little while for large designs...
estimate_parasitics -global_routing
[WARNING GRT-0097] No global routing found for nets.
[ERROR RSZ-0005] Run global_route before estimating parasitics for global routing.
Error reading timing: RSZ-0005
[WARNING GUI-0076] QSocketNotifier: Can only be used with threads started with QThread
```
