### PR TITLE
open/gui: when loading a failed global route, advertise congestion report

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -1,11 +1,10 @@
-if {[expr [file exists $::env(REPORTS_DIR)/congestion.rpt] && \
-    [file size $::env(REPORTS_DIR)/congestion.rpt] != 0]} {
-  error "Global routing failed, run `make gui_grt` and load $::env(REPORTS_DIR)/congestion.rpt \
-    in DRC viewer to view congestion"
-}
-
 utl::set_metrics_stage "detailedroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
+if {[expr [file exists $::global_route_congestion_report] && \
+    [file size $::global_route_congestion_report] != 0]} {
+  error "Global routing failed, run `make gui_grt` and load $::global_route_congestion_report \
+    in DRC viewer to view congestion"
+}
 load_design 5_1_grt.odb 4_cts.sdc
 erase_non_stage_variables route
 set_propagated_clock [all_clocks]

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -18,7 +18,7 @@ proc global_route_helper {} {
   # If GLOBAL_ROUTE_ARGS is specified, then we do only what the
   # GLOBAL_ROUTE_ARGS specifies.
   proc do_global_route {} {
-    set all_args [concat [list -congestion_report_file $::env(REPORTS_DIR)/congestion.rpt] \
+    set all_args [concat [list -congestion_report_file $::global_route_congestion_report] \
       [expr {[env_var_exists_and_non_empty GLOBAL_ROUTE_ARGS] ? $::env(GLOBAL_ROUTE_ARGS) : \
       {-congestion_iterations 30 -congestion_report_iter_step 5 -verbose}}]]
 
@@ -29,8 +29,8 @@ proc global_route_helper {} {
 
   if {$result != 0} {
     if {[expr !$::env(GENERATE_ARTIFACTS_ON_FAILURE) || \
-        ![file exists $::env(REPORTS_DIR)/congestion.rpt] || \
-        [file size $::env(REPORTS_DIR)/congestion.rpt] == 0]} {
+        ![file exists $::global_route_congestion_report] || \
+        [file size $::global_route_congestion_report] == 0]} {
       write_db $::env(RESULTS_DIR)/5_1_grt-failed.odb
       error $errMsg
     }

--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -44,7 +44,8 @@ proc read_timing {input_file} {
     if { [grt::have_routes] } {
       log_cmd estimate_parasitics -global_routing
     } else {
-      puts "No global routing results: load $::global_route_congestion_report for details"
+      puts "No global routing results available, skipping estimate_parasitics"
+      puts "Load $::global_route_congestion_report for details"
     }
   } elseif {$design_stage >= 3} {
     log_cmd estimate_parasitics -placement

--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -41,7 +41,11 @@ proc read_timing {input_file} {
   if {$design_stage >= 6 && [file exist $::env(RESULTS_DIR)/6_final.spef]} {
     log_cmd read_spef $::env(RESULTS_DIR)/6_final.spef
   } elseif {$design_stage >= 5} {
-    log_cmd estimate_parasitics -global_routing
+    if { [grt::have_routes] } {
+      log_cmd estimate_parasitics -global_routing
+    } else {
+      puts "No global routing results: load $::global_route_congestion_report for details"
+    }
   } elseif {$design_stage >= 3} {
     log_cmd estimate_parasitics -placement
   }

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -115,3 +115,4 @@ proc erase_non_stage_variables {stage_name} {
   }
 }
 
+set global_route_congestion_report $::env(REPORTS_DIR)/congestion.rpt


### PR DESCRIPTION
Instead of giving an error.

Single source of truth as to the name of the global routing congestion report.