### PR TITLE
detail route: fix gaffe in check if there's congestion

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -1,7 +1,7 @@
 utl::set_metrics_stage "detailedroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 if {[file exists $::global_route_congestion_report]} {
-  if {[file size $::global_route_congestion_report] != 0]} {
+  if {[file size $::global_route_congestion_report] != 0} {
     error "Global routing failed, run `make gui_grt` and load $::global_route_congestion_report \
           in DRC viewer to view congestion"
   }


### PR DESCRIPTION
@maliberty Fix for breakage in master.

Something changed on master so that an empty congestion.rpt is always written now(perfectly legal), which triggers the bug that I introduced.