### PR TITLE
floorplan: use 2_floorplan.sdc in floorplan, written by floorplan.tcl

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -786,7 +786,7 @@ $(eval $(call do-step,5_3_fillcell,$(RESULTS_DIR)/5_2_route.odb,fillcell))
 
 $(eval $(call do-copy,5_route,5_3_fillcell.odb))
 
-$(eval $(call do-copy,5_route,4_cts.sdc,,.sdc))
+$(eval $(call do-copy,5_route,5_1_grt.sdc,,.sdc))
 
 .PHONY: do-route
 do-route:

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -1,6 +1,6 @@
 utl::set_metrics_stage "detailedroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 5_1_grt.odb 4_cts.sdc
+load_design 5_1_grt.odb 5_1_grt.sdc
 if {![grt::have_routes]} {
   error "Global routing failed, run `make gui_grt` and load $::global_route_congestion_report \
         in DRC viewer to view congestion"

--- a/flow/scripts/fillcell.tcl
+++ b/flow/scripts/fillcell.tcl
@@ -1,7 +1,7 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables route
 if {[env_var_exists_and_non_empty FILL_CELLS]} {
-  load_design 5_2_route.odb 4_cts.sdc
+  load_design 5_2_route.odb 5_1_grt.sdc
 
   set_propagated_clock [all_clocks]
 

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -109,6 +109,7 @@ proc global_route_helper {} {
 
   write_guides $::env(RESULTS_DIR)/route.guide
   write_db $::env(RESULTS_DIR)/5_1_grt.odb
+  write_sdc -no_timestamp $::env(RESULTS_DIR)/5_1_grt.sdc
 }
 
 global_route_helper

--- a/flow/scripts/io_placement_random.tcl
+++ b/flow/scripts/io_placement_random.tcl
@@ -2,7 +2,7 @@ source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
 
 if {![env_var_equals IS_CHIP 1]} {
-  load_design 2_1_floorplan.odb 1_synth.sdc
+  load_design 2_1_floorplan.odb 2_floorplan.sdc
   lappend ::env(PLACE_PINS_ARGS) -random
   source $::env(SCRIPTS_DIR)/io_placement_util.tcl
   write_db $::env(RESULTS_DIR)/2_2_floorplan_io.odb

--- a/flow/scripts/macro_place.tcl
+++ b/flow/scripts/macro_place.tcl
@@ -1,6 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
-load_design 2_3_floorplan_tdms.odb 1_synth.sdc
+load_design 2_3_floorplan_tdms.odb 2_floorplan.sdc
 
 source $::env(SCRIPTS_DIR)/macro_place_util.tcl
 

--- a/flow/scripts/pdn.tcl
+++ b/flow/scripts/pdn.tcl
@@ -1,6 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
-load_design 2_5_floorplan_tapcell.odb 1_synth.sdc
+load_design 2_5_floorplan_tapcell.odb 2_floorplan.sdc
 
 source $::env(PDN_TCL)
 pdngen

--- a/flow/scripts/tapcell.tcl
+++ b/flow/scripts/tapcell.tcl
@@ -1,7 +1,7 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
 
-load_design 2_4_floorplan_macro.odb 1_synth.sdc
+load_design 2_4_floorplan_macro.odb 2_floorplan.sdc
 
 if {[env_var_exists_and_non_empty TAPCELL_TCL]} {
     source $::env(TAPCELL_TCL)

--- a/flow/scripts/tdms_place.tcl
+++ b/flow/scripts/tdms_place.tcl
@@ -20,7 +20,7 @@ proc find_macros {} {
 if {!([env_var_exists_and_non_empty MACRO_PLACEMENT] ||
       [env_var_exists_and_non_empty MACRO_PLACEMENT_TCL]) &&
     ![env_var_equals RTLMP_FLOW 1]} {
-  load_design 2_2_floorplan_io.odb 1_synth.sdc
+  load_design 2_2_floorplan_io.odb 2_floorplan.sdc
 
   set_dont_use $::env(DONT_USE_CELLS)
 


### PR DESCRIPTION
Since floorplan.tcl can do retiming, it is important to use post retiming .sdc file in subsequent steps to avoid incorrect timing information.

Note that loading 1_synth.sdc would appear to work in the case that the SDC_FILE is using patterns, rather than specific names written out longhand in 2_floorplan.sdc.

fixes #2485