### PR TITLE
variables: FLOORPLAN_DEF is also used in place stage

### DIFF
--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -184,6 +184,7 @@ FLOORPLAN_DEF:
     Use the DEF file to initialize floorplan.
   stages:
     - floorplan
+    - place
 REMOVE_ABC_BUFFERS:
   description: >
     Remove abc buffers from the netlist.


### PR DESCRIPTION
See flow/scripts/global_place_skip_io.tcl which references this variable too.
Without the change, pin definitions in the DEF are simply ignored.