### PR TITLE
flow: don't use cell sg13g2_sdfbbp_1

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -31,7 +31,8 @@ export DONT_USE_CELLS += \
 sg13g2_lgcp_1 \
 sg13g2_sighold \
 sg13g2_slgcp_1 \
-sg13g2_dfrbp_2
+sg13g2_dfrbp_2 \
+sg13g2_sdfbbp_1
 
 
 # Define fill cells


### PR DESCRIPTION
Yosys can only infer flip-flops where the `next_state` property in the liberty file is a single pin or its negation. For `sg13g2_sdfbbp_1` it is `(SCE*SCD)+(SCE'*D)` so it prints a warning and ignores the cell. By adding the cell to the `DONT_USE_CELLS` list we can get rid of the warning.