### PR TITLE
floorplan: HOLD_SLACK_MARGIN is now applied in floorplan.tcl

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -108,7 +108,7 @@ if { [env_var_equals REMOVE_ABC_BUFFERS 1] } {
   # remove buffers inserted by yosys/abc
   remove_buffers
 } else {
-  repair_timing_helper 0
+  repair_timing_helper
 }
 
 ##### Restructure for timing #########

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -16,12 +16,10 @@ proc fast_route {} {
 }
 
 # -hold_margin is only set when hold_margin is set, default 1
-proc repair_timing_helper { {hold_margin 1} } {
+proc repair_timing_helper {} {
   set additional_args "-verbose"
   append_env_var additional_args SETUP_SLACK_MARGIN -setup_margin 1
-  if {$hold_margin} {
-    append_env_var additional_args HOLD_SLACK_MARGIN -hold_margin 1
-  }
+  append_env_var additional_args HOLD_SLACK_MARGIN -hold_margin 1
   append_env_var additional_args TNS_END_PERCENT -repair_tns 1
   append_env_var additional_args SKIP_PIN_SWAP -skip_pin_swap 0
   append_env_var additional_args SKIP_GATE_CLONING -skip_gate_cloning 0


### PR DESCRIPTION
My suspicion is that the difference in floorplan.tcl vs other places repair_timing_helper was invoked was unintentional copy and paste error