### PR TITLE
Update README to fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Document for detailed local build from sources and installation steps found [her
   individual flows commands, see the documentation
   [here](https://openroad.readthedocs.io/en/latest/).
 - For details about automated flow setup, see ORFS docs
-  [here](https://openroad-flow-scripts.readthedocs.io/en/latest/user/GettingStarted.html).
+  [here](https://openroad-flow-scripts.readthedocs.io/en/latest/index2.html).
 - Flow tutorial to run the complete OpenROAD based flow from
   RTL-GDSII, see the tutorial
   [here](https://openroad-flow-scripts.readthedocs.io/en/latest/tutorials/FlowTutorial.html).


### PR DESCRIPTION
Update link to point to Getting Started with ORFS in OpenROAD docs. The old one was broken. Please confirm the new one is correct. 