### PR TITLE
global route: fix GENERATE_ARTIFACTS_ON_FAILURE use-case

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -31,6 +31,7 @@ proc global_route_helper {} {
     if {[expr !$::env(GENERATE_ARTIFACTS_ON_FAILURE) || \
         ![file exists $::global_route_congestion_report] || \
         [file size $::global_route_congestion_report] == 0]} {
+      write_sdc -no_timestamp $::env(RESULTS_DIR)/5_1_grt.sdc
       write_db $::env(RESULTS_DIR)/5_1_grt-failed.odb
       error $errMsg
     }

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -31,10 +31,10 @@ proc global_route_helper {} {
     if {[expr !$::env(GENERATE_ARTIFACTS_ON_FAILURE) || \
         ![file exists $::global_route_congestion_report] || \
         [file size $::global_route_congestion_report] == 0]} {
-      write_sdc -no_timestamp $::env(RESULTS_DIR)/5_1_grt.sdc
       write_db $::env(RESULTS_DIR)/5_1_grt-failed.odb
       error $errMsg
     }
+    write_sdc -no_timestamp $::env(RESULTS_DIR)/5_1_grt.sdc
     write_db $::env(RESULTS_DIR)/5_1_grt.odb
     return
   }


### PR DESCRIPTION
the .sdc file must be written out alongside the .odb file and .rpt file in the failing test case whenGENERATE_ARTIFACTS_ON_FAILURE=1.

I suppose copying would have worked too, but write_sdc should be fine.