### PR TITLE
makefile: fix one more do-floorplan gaffe

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -667,7 +667,7 @@ $(RESULTS_DIR)/2_floorplan.sdc: $(RESULTS_DIR)/2_1_floorplan.odb
 
 .PHONY: do-floorplan
 do-floorplan:
-	$(UNSET_AND_MAKE) do-2_1_floorplan do-2_2_floorplan_io do-2_3_floorplan_macro do-2_4_floorplan_tapcell do-2_5_floorplan_pdn do-2_floorplan
+	$(UNSET_AND_MAKE) do-2_1_floorplan do-2_2_floorplan_io do-2_3_floorplan_macro do-2_4_floorplan_tapcell do-2_5_floorplan_pdn do-2_floorplan do-2_floorplan.sdc
 
 .PHONY: clean_floorplan
 clean_floorplan:


### PR DESCRIPTION
Missed one. I was sure that I ran `test/test-do-stage.sh` locally before previous PR to fix do-floorplan; apparently not.