### PR TITLE
[DO NOT REVIEW] makefile: SYNTH_HIERARCHICAL=1 keeps synth_hier_stat_temp_module.txt

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -461,6 +461,9 @@ do-synth-report:
 
 .PHONY: memory
 memory:
+	if [ -f $(RESULTS_DIR)/mem_hierarchical.json ]; then \
+		python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem_hierarchical.json; \
+	fi
 	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
 
 # ==============================================================================
@@ -516,7 +519,7 @@ $(RESULTS_DIR)/1_synth.v: $(RESULTS_DIR)/1_1_yosys.v
 
 .PHONY: clean_synth
 clean_synth:
-	rm -f $(RESULTS_DIR)/1_* $(RESULTS_DIR)/mem.json
+	rm -f $(RESULTS_DIR)/1_* $(RESULTS_DIR)/mem*.json
 	rm -f $(REPORTS_DIR)/synth_*
 	rm -f $(LOG_DIR)/1_*
 	rm -f $(SYNTH_STOP_MODULE_SCRIPT)

--- a/flow/designs/asap7/riscv32i/config.mk
+++ b/flow/designs/asap7/riscv32i/config.mk
@@ -2,7 +2,7 @@ export DESIGN_NICKNAME ?= riscv32i
 export DESIGN_NAME = riscv_top
 export PLATFORM    = asap7
 
-export SYNTH_HIERARCHICAL = 1
+export SYNTH_HIERARCHICAL ?= 1
 
 export RTLMP_MIN_INST = 1000
 export RTLMP_MAX_INST = 3500

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -9,7 +9,7 @@ if { [env_var_equals SYNTH_GUT 1] } {
   delete $::env(DESIGN_NAME)/c:*
 }
 
-synthesize_check $::env(SYNTH_FULL_ARGS)
+synthesize_check mem $::env(SYNTH_FULL_ARGS)
 
 # rename registers to have the verilog register name in its name
 # of the form \regName$_DFF_P_. We should fix yosys to make it the reg name.

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -73,7 +73,6 @@ proc write_keep_hierarchy {} {
         }
       }
     }
-    file delete -force $::env(REPORTS_DIR)/synth_hier_stat_temp_module.txt
   }
   close $out_script_ptr
 }

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -9,7 +9,7 @@ proc write_keep_hierarchy {} {
 
   source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-  synthesize_check {}
+  synthesize_check mem_hierarchical {}
 
   if { [env_var_exists_and_non_empty ADDER_MAP_FILE] && [file isfile $::env(ADDER_MAP_FILE)] } {
     techmap -map $::env(ADDER_MAP_FILE)

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -107,12 +107,12 @@ puts $constr "set_driving_cell $::env(ABC_DRIVER_CELL)"
 puts $constr "set_load $::env(ABC_LOAD_IN_FF)"
 close $constr
 
-proc synthesize_check {synth_args} {
+proc synthesize_check {report synth_args} {
   # Generic synthesis
   log_cmd synth -top $::env(DESIGN_NAME) -run :fine {*}$synth_args
-  json -o $::env(RESULTS_DIR)/mem.json
+  json -o $::env(RESULTS_DIR)/$report.json
   # Run report and check here so as to fail early if this synthesis run is doomed
-  exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
+  exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/$report.json
   synth -top $::env(DESIGN_NAME) -run fine: {*}$synth_args
   # Get rid of indigestibles
   chformal -remove


### PR DESCRIPTION
synth_hier_stat_temp_module.txt this can take hours to generate and there's no other evidence left behind from the policy decisions, so keep it.

This can be used to learn something interesting, like that SYNTH_HIERARCHICAL=0/1 only keeps the dmem module below, it is the only module above MAX_UNGROUP_SIZE.

dmem is a module that contains 4 fake memories.

```
$ make DESIGN_CONFIG=designs/asap7/riscv32i/config.mk print-MAX_UNGROUP_SIZE
MAX_UNGROUP_SIZE = 1000
$ grep Chip reports/asap7/riscv32i/base/synth_hier_stat_temp_module.txt
   Chip area for module '$paramod\flopr\WIDTH=s32'00000000000000000000000000100000': 15.367320
   Chip area for module '$paramod\mux2\WIDTH=s32'00000000000000000000000000000001': 0.291600
   Chip area for module '$paramod\mux2\WIDTH=s32'00000000000000000000000000000100': 0.801900
   Chip area for module '$paramod\mux2\WIDTH=s32'00000000000000000000000000000101': 0.991440
   Chip area for module '$paramod\mux2\WIDTH=s32'00000000000000000000000000100000': 6.794280
   Chip area for module '$paramod\mux3\WIDTH=s32'00000000000000000000000000100000': 12.874140
   Chip area for module '$paramod\mux5\WIDTH=s32'00000000000000000000000000100000': 20.032920
   Chip area for module '\ROM': 2.084940
   Chip area for module '\adder': 26.535600
   Chip area for module '\alu': 81.021060
   Chip area for module '\aludec': 3.076380
   Chip area for module '\controller': 1.341360
   Chip area for module '\datapath': 1.137240
   Chip area for module '\dmem': 1395.520940
   Chip area for module '\magcompare2b': 0.641520
   Chip area for module '\magcompare2c': 0.306180
   Chip area for module '\magcompare32': 0.145800
   Chip area for module '\maindec': 4.009500
   Chip area for module '\regfile': 848.964240
   Chip area for module '\riscv_top': 0.072900
   Chip area for module '\shifter': 78.921540
   Chip area for top module '$paramod\mux5\WIDTH=s32'00000000000000000000000000100000': 20.032920
```

Resulting floorplan, the fake SRAMs are lined up together:

![image](https://github.com/user-attachments/assets/5aa75883-f613-4187-8d88-5eac199fb1b8)

Whereas with SYNTH_HIERARCHICAL=0, we see:

![image](https://github.com/user-attachments/assets/a891a853-383f-4aec-92b0-f90326b834e2)
