### PR TITLE
synthesis: better reports for exploring MAX_UNGROUP_SIZE

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -180,7 +180,7 @@ include $(PLATFORM_DIR)/config.mk
 
 # Enables hierarchical yosys
 export SYNTH_HIERARCHICAL ?= 0
-export SYNTH_STOP_MODULE_SCRIPT = $(RESULTS_DIR)/keep_hierarchy.tcl
+export SYNTH_STATS = $(RESULTS_DIR)/synth_stats.txt
 export HIER_REPORT_SCRIPT = $(SCRIPTS_DIR)/synth_hier_report.tcl
 export MAX_UNGROUP_SIZE ?= 0
 
@@ -519,7 +519,7 @@ clean_synth:
 	rm -f $(RESULTS_DIR)/1_* $(RESULTS_DIR)/mem.json
 	rm -f $(REPORTS_DIR)/synth_*
 	rm -f $(LOG_DIR)/1_*
-	rm -f $(SYNTH_STOP_MODULE_SCRIPT)
+	rm -f $(SYNTH_STATS)
 	rm -f $(SDC_FILE_CLOCK_PERIOD)
 	rm -rf _tmp_yosys-abc-*
 

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -8,19 +8,19 @@ if { $::env(MAX_UNGROUP_SIZE) > 0 } {
   puts "Ungroup modules of size greater than $ungroup_threshold"
 }
 
-set fp [open $::env(SYNTH_STOP_MODULE_SCRIPT) r]
+set fp [open $::env(SYNTH_STATS) r]
 while {[gets $fp line] != -1} {
     set fields [split $line " "]
     set area [lindex $fields 0]
     set module_name [lindex $fields 1]
 
     if {[expr $area > $ungroup_threshold]} {
-      puts "Keeping $area $module_name"
+      puts "Keeping module $module_name (area: $area)"
       select -module $module_name
       setattr -mod -set keep_hierarchy 1
       select -clear
     } else {
-      puts "Flattening $area $module_name"
+      puts "Flattening module $module_name (area: $area)"
     }
 }
 close $fp

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -1,9 +1,31 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-source $::env(SYNTH_STOP_MODULE_SCRIPT)
+hierarchy -check -top $::env(DESIGN_NAME)
+
+set ungroup_threshold 0
+if { $::env(MAX_UNGROUP_SIZE) > 0 } {
+  set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
+  puts "Ungroup modules of size greater than $ungroup_threshold"
+}
+
+set fp [open $::env(SYNTH_STOP_MODULE_SCRIPT) r]
+while {[gets $fp line] != -1} {
+    set fields [split $line " "]
+    set area [lindex $fields 0]
+    set module_name [lindex $fields 1]
+
+    if {[expr $area > $ungroup_threshold]} {
+      puts "Keeping $area $module_name"
+      select -module $module_name
+      setattr -mod -set keep_hierarchy 1
+      select -clear
+    } else {
+      puts "Flattening $area $module_name"
+    }
+}
+close $fp
 
 if { [env_var_equals SYNTH_GUT 1] } {
-  hierarchy -check -top $::env(DESIGN_NAME)
   # /deletes all cells at the top level, which will quickly optimize away
   # everything else, including macros.
   delete $::env(DESIGN_NAME)/c:*

--- a/flow/scripts/synth_hier_report.tcl
+++ b/flow/scripts/synth_hier_report.tcl
@@ -2,7 +2,7 @@ source $::env(SCRIPTS_DIR)/util.tcl
 
 proc write_keep_hierarchy {} {
   if { ![env_var_equals SYNTH_HIERARCHICAL 1] } {
-    set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
+    set out_script_ptr [open $::env(SYNTH_STATS) w]
     close $out_script_ptr
     return
   }
@@ -65,7 +65,7 @@ proc write_keep_hierarchy {} {
   }
   set areas [lsort -index 0 -real $areas]
 
-  set out_script_ptr [open $::env(SYNTH_STOP_MODULE_SCRIPT) w]
+  set out_script_ptr [open $::env(SYNTH_STATS) w]
   foreach {line} $areas {
     puts $out_script_ptr $line
   }


### PR DESCRIPTION
Seperate the concern of collecting area of modules and implementing a policy.

First a report is collected, such as:

```
$ cat results/asap7/riscv32i/base/keep_hierarchy.tcl
0.291600 $paramod\mux2\WIDTH=s32'00000000000000000000000000000001
0.306180 \magcompare2c
...
3.076380 \aludec
4.009500 \maindec
```

In synthesis, MAX_UNGROUP_SIZE is used to select which of these modules to keep and which to flatten.

For some design there is little guesswork involved when looking at this report and picking a MAX_UNGROUP_SIZE.

The names of targets in the makefile, variables and report names could be revised to reflect this seperation of concerns to improve readability, but leave that for a followup PR.