### PR TITLE
open: fix non-aborting incorrect operation when there is no routing

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -1,3 +1,13 @@
+# This script is used to launch the OpenROAD user ineterface
+# console as well as GUI mode. The user interface will remain
+# go from batch to interactive mode after this script has
+# been executed, whether it failed or not. For instance,
+# a failed global route run can be loaded to examine the
+# DRC errors.
+#
+# However, this script is also used to load the design and timing
+# in automation scripts, hence the script should fail upon
+# errors, not continue.
 source $::env(SCRIPTS_DIR)/util.tcl
 # Read liberty files
 source $::env(SCRIPTS_DIR)/read_liberty.tcl
@@ -44,8 +54,9 @@ proc read_timing {input_file} {
     if { [grt::have_routes] } {
       log_cmd estimate_parasitics -global_routing
     } else {
-      puts "No global routing results available, skipping estimate_parasitics"
-      puts "Load $::global_route_congestion_report for details"
+      error "No global routing results available,\
+      skipping estimate_parasitics,\
+      load $::global_route_congestion_report for details"
     }
   } elseif {$design_stage >= 3} {
     log_cmd estimate_parasitics -placement


### PR DESCRIPTION
When using open.tcl from automation, if there is no routing available as of stage 5 and on, fail rather than log and continue.

The user experience when running 'make gui_grt' is that an error is shown and a console prompt. The user can type 'gui::show' to show the GUI.

Ideally, 'make gui_grt' would run with the GUI hidden and show the GUI upon first error or warning, but that requires an update to OpenROAD.

Example use-case:

```
$ make gui_grt
ODB_FILE=.//results/asap7/BoomTile/base/5_1_grt.odb /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad -no_init -threads 16  /home/oyvind/OpenROAD-flow-scripts/flow/scripts/open.tcl
OpenROAD v2.0-16827-g02ce90d85 
Features included (+) or not (-): +Charts +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
[INFO ORD-0030] Using 16 thread(s).
GUI_TIMING=1 reading timing, takes a little while for large designs...
[WARNING GRT-0097] No global routing found for nets.
Error: open.tcl, 75 No global routing results available, skipping estimate_parasitics, load .//reports/asap7/BoomTile/base/congestion.rpt for details
[The GUI does not open, the console is shown, I can launch the GUI by running gui::show]
openroad> gui::show
```
