### PR TITLE
ihp-sg32g2: update pdn.tcl to connect IO pads by default

### DIFF
--- a/flow/platforms/ihp-sg13g2/pdn.tcl
+++ b/flow/platforms/ihp-sg13g2/pdn.tcl
@@ -1,11 +1,15 @@
 ####################################
 # global connections
 ####################################
+# standard cells
 add_global_connection -net {VDD} -pin_pattern {^VDD$} -power
 add_global_connection -net {VDD} -pin_pattern {^VDDPE$}
 add_global_connection -net {VDD} -pin_pattern {^VDDCE$}
 add_global_connection -net {VSS} -pin_pattern {^VSS$} -ground
 add_global_connection -net {VSS} -pin_pattern {^VSSE$}
+# I/O pads
+add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
+add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
 global_connect
 ####################################
 # voltage domains
@@ -21,4 +25,7 @@ add_pdn_stripe -grid {grid} -layer {Metal5}     -width {2.200} -pitch {75.6} -of
 add_pdn_stripe -grid {grid} -layer {TopMetal1}  -width {1.800} -pitch {75.6} -offset {13.570}             -extend_to_core_ring
 add_pdn_connect -grid {grid} -layers {Metal1 Metal5}
 add_pdn_connect -grid {grid} -layers {Metal5 TopMetal1}
+# I/O pads
+add_pdn_connect -grid {grid} -layers {Metal5 TopMetal2}
+add_pdn_connect -grid {grid} -layers {TopMetal1 TopMetal2}
 ####################################


### PR DESCRIPTION
IHP's new I/O pads connect power on TopMetal2 with pins called "vdd" and "vss". This change adds the pin names and the necessary layer connections to `pdn.tcl` such that the I/O pads connect to the PDN by default.