### PR TITLE
timing repair: allow negative HOLD_SLACK_MARGIN in floorplan

### DIFF
--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -15,11 +15,10 @@ proc fast_route {} {
   }
 }
 
-# -hold_margin is only set when hold_margin is set, default 1
 proc repair_timing_helper { {hold_margin 1} } {
   set additional_args "-verbose"
   append_env_var additional_args SETUP_SLACK_MARGIN -setup_margin 1
-  if {$hold_margin} {
+  if {$hold_margin || $::env(HOLD_SLACK_MARGIN) < 0} {
     append_env_var additional_args HOLD_SLACK_MARGIN -hold_margin 1
   }
   append_env_var additional_args TNS_END_PERCENT -repair_tns 1

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -335,10 +335,22 @@ HOLD_SLACK_MARGIN:
     Specifies a time margin for the slack when fixing hold violations.
     This option allows you to overfix or underfix(negative value, terminate
     retiming before 0 or positive slack).
+
+    Use min of HOLD_SLACK_MARGIN and 0(default hold slack margin) in floorplan.
+
+    This avoids overrepair in floorplan for hold by default, but allows skipping
+    hold repair using a negative HOLD_SLACK_MARGIN.
+
+    Exiting timing repair early is useful in exploration where
+
+    the .sdc has a fixed clock period at designs target clock period and where
+    HOLD/SETUP_SLACK_MARGIN is used to avoid overrepair(extremelly long running times)
+    when exploring different parameter settings.
   stages:
     - cts
     - floorplan
     - grt
+  default: 0
 SETUP_SLACK_MARGIN:
   description: >
     Specifies a time margin for the slack when fixing setup violations.
@@ -348,6 +360,7 @@ SETUP_SLACK_MARGIN:
     - cts
     - floorplan
     - grt
+  default: 0
 SKIP_GATE_CLONING:
   description: >
     Do not use gate cloning transform to fix timing violations (default: use gate cloning).


### PR DESCRIPTION
can save hours of running time in futile hold repair