### PR TITLE
[DO NOT REVIEW] synthesis: ABC_AREA=0 now uses 'if -s'

### DIFF
--- a/flow/scripts/abc_speed.script
+++ b/flow/scripts/abc_speed.script
@@ -4,27 +4,27 @@
 &nf
 &st
 &syn2
-&if -g -K 6
+&if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
-&if -g -K 6
+&if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
-&if -g -K 6
+&if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
-&if -g -K 6
+&if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
-&if -g -K 6
+&if -s -g -K 6
 &synch2
 &nf
 &put

--- a/flow/scripts/abc_speed.script
+++ b/flow/scripts/abc_speed.script
@@ -4,26 +4,31 @@
 &nf
 &st
 &syn2
+&retime
 &if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
+&retime
 &if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
+&retime
 &if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
+&retime
 &if -s -g -K 6
 &synch2
 &nf
 &st
 &syn2
+&retime
 &if -s -g -K 6
 &synch2
 &nf


### PR DESCRIPTION
@jeffng-or @maliberty FYI, experiment with abc retiming.

retime/results/asap7/BoomTile/1/1_1_yosys.v is below with this PR, so not enormously different in number of lines of code:

```
$ wc -l retime/results/asap7/BoomTile/1/1_1_yosys.v retime2/results/asap7/BoomTile/1/1_synth.v
  7225342 retime/results/asap7/BoomTile/1/1_1_yosys.v
  7245717 retime2/results/asap7/BoomTile/1/1_synth.v
```

Just like the megaboom documentation states, the multiplier needs to be retimed:

```
   Iter   | Removed | Resized | Inserted | Cloned |  Pin  |    WNS   |   TNS      |  Viol  | Worst
          | Buffers |  Gates  | Buffers  |  Gates | Swaps |          |            | Endpts | Endpt
---------------------------------------------------------------------------------------------------
        0 |       0 |       0 |        0 |      0 |     0 | -1476.095 | -22178186.0 |     23 | core.alu_exe_unit_2.PipelinedMulUnit.imul.io_resp_bits_data_pipe_b\[63\]$_DFFE_PP_/D
```
