### PR TITLE
mock-array: works fine with default number of iterations

### DIFF
--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -62,9 +62,6 @@ export DETAILED_ROUTE_END_ITERATION = 6
 export MAX_ROUTING_LAYER = M9
 export ROUTING_LAYER_ADJUSTMENT = 0.45
 
-# works with 28 or more iterations as of writing, so give it a few more.
-export GLOBAL_ROUTE_ARGS=-congestion_iterations 40 -verbose
-
 # ensure we have some rows, so we don't get a bad clock skew.
 export MACRO_HALO_X            = 0.5
 export MACRO_HALO_Y            = 0.5


### PR DESCRIPTION
default is 30, no need to specify more