### PR TITLE
add flag to enforce cell footprint honoring in all sizing operations

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -210,6 +210,9 @@ export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 0
 export ENABLE_DPO ?= 1
 export DPO_MAX_DISPLACEMENT ?= 5 1
 
+# Settings for Sizing
+export HONOR_CELL_FOOTPRINT ?= 0
+
 # Setup working directories
 export DESIGN_NICKNAME ?= $(DESIGN_NAME)
 

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -211,7 +211,7 @@ export ENABLE_DPO ?= 1
 export DPO_MAX_DISPLACEMENT ?= 5 1
 
 # Settings for Sizing
-export HONOR_CELL_FOOTPRINT ?= 0
+export MATCH_CELL_FOOTPRINT ?= 0
 
 # Setup working directories
 export DESIGN_NICKNAME ?= $(DESIGN_NAME)

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -113,8 +113,8 @@ if { [env_var_equals REMOVE_ABC_BUFFERS 1] } {
 
 ##### Restructure for timing #########
 if { [env_var_equals RESYNTH_TIMING_RECOVER 1] } {
-  repair_design
-  repair_timing
+  repair_design_helper
+  repair_timing_helper
   # pre restructure area/timing report (ideal clocks)
   puts "Post synth-opt area"
   report_design_area
@@ -133,8 +133,8 @@ if { [env_var_equals RESYNTH_TIMING_RECOVER 1] } {
 
   # post restructure area/timing report (ideal clocks)
   remove_buffers
-  repair_design
-  repair_timing
+  repair_design_helper
+  repair_timing_helper
 
   puts "Post restructure-opt wns"
   report_worst_slack -max -digits 3

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -51,8 +51,7 @@ proc global_route_helper {} {
     }
 
     # Repair design using global route parasitics
-    puts "Perform buffer insertion..."
-    repair_design
+    repair_design_helper
     if { $::env(DETAILED_METRICS) } {
       report_metrics 5 "global route post repair design"
     }

--- a/flow/scripts/resize.tcl
+++ b/flow/scripts/resize.tcl
@@ -21,18 +21,7 @@ if { ![env_var_exists_and_non_empty FOOTPRINT] } {
   }
 }
 
-puts "Perform buffer insertion..."
-set additional_args ""
-if { [env_var_exists_and_non_empty CAP_MARGIN] && $::env(CAP_MARGIN) > 0.0} {
-  puts "Cap margin $::env(CAP_MARGIN)"
-  append additional_args " -cap_margin $::env(CAP_MARGIN)"
-}
-if { [env_var_exists_and_non_empty SLEW_MARGIN] && $::env(SLEW_MARGIN) > 0.0} {
-  puts "Slew margin $::env(SLEW_MARGIN)"
-  append additional_args " -slew_margin $::env(SLEW_MARGIN)"
-}
-
-repair_design {*}$additional_args
+repair_design_helper
 
 if { [env_var_exists_and_non_empty TIE_SEPARATION] } {
   set tie_separation $env(TIE_SEPARATION)

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -27,8 +27,21 @@ proc repair_timing_helper { {hold_margin 1} } {
   append_env_var additional_args SKIP_GATE_CLONING -skip_gate_cloning 0
   append_env_var additional_args SKIP_BUFFER_REMOVAL -skip_buffer_removal 0
   append_env_var additional_args SKIP_LAST_GASP -skip_last_gasp 0
+  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
   puts "repair_timing [join $additional_args " "]"
   repair_timing {*}$additional_args
+}
+
+proc repair_design_helper {} {
+  puts "Perform buffer insertion and gate resizing..."
+
+  set additional_args ""
+  append_env_var additional_args CAP_MARGIN -cap_margin 1
+  append_env_var additional_args SLEW_MARGIN -slew_margin 1
+  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
+  puts "repair_design [join $additional_args " "]"
+
+  repair_design {*}$additional_args
 }
 
 proc recover_power {} {
@@ -40,7 +53,10 @@ proc recover_power {} {
   report_tns
   report_wns
   report_power
-  repair_timing -recover_power $::env(RECOVER_POWER)
+  set additional_args ""
+  append_env_var additional_args RECOVER_POWER -recover_power 1
+  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
+  repair_timing {*}$additional_args
   report_tns
   report_wns
   report_power

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -27,7 +27,7 @@ proc repair_timing_helper { {hold_margin 1} } {
   append_env_var additional_args SKIP_GATE_CLONING -skip_gate_cloning 0
   append_env_var additional_args SKIP_BUFFER_REMOVAL -skip_buffer_removal 0
   append_env_var additional_args SKIP_LAST_GASP -skip_last_gasp 0
-  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
+  append_env_var additional_args MATCH_CELL_FOOTPRINT -match_cell_footprint 0
   puts "repair_timing [join $additional_args " "]"
   repair_timing {*}$additional_args
 }
@@ -38,7 +38,7 @@ proc repair_design_helper {} {
   set additional_args ""
   append_env_var additional_args CAP_MARGIN -cap_margin 1
   append_env_var additional_args SLEW_MARGIN -slew_margin 1
-  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
+  append_env_var additional_args MATCH_CELL_FOOTPRINT -match_cell_footprint 0
   puts "repair_design [join $additional_args " "]"
 
   repair_design {*}$additional_args
@@ -55,7 +55,7 @@ proc recover_power {} {
   report_power
   set additional_args ""
   append_env_var additional_args RECOVER_POWER -recover_power 1
-  append_env_var additional_args HONOR_CELL_FOOTPRINT -match_cell_footprint 0
+  append_env_var additional_args MATCH_CELL_FOOTPRINT -match_cell_footprint 0
   repair_timing {*}$additional_args
   report_tns
   report_wns

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -622,3 +622,10 @@ GLOBAL_ROUTE_ARGS:
   stages:
     - grt
   default: -congestion_iterations 30 -congestion_report_iter_step 5 -verbose
+HONOR_CELL_FOOTPRINT:
+  description: >
+    Enforce sizing operations to only swap cells that have the same layout boundary.
+  stages:
+    - floorplan
+    - place
+    - cts

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -622,10 +622,11 @@ GLOBAL_ROUTE_ARGS:
   stages:
     - grt
   default: -congestion_iterations 30 -congestion_report_iter_step 5 -verbose
-HONOR_CELL_FOOTPRINT:
+MATCH_CELL_FOOTPRINT:
   description: >
     Enforce sizing operations to only swap cells that have the same layout boundary.
   stages:
     - floorplan
     - place
     - cts
+    - route


### PR DESCRIPTION
Resolves one of the top level tasks in [#5577](https://github.com/The-OpenROAD-Project/OpenROAD/issues/5577).

Changes:
- New helper for repair_design like the one that already exists for repair_timing including the -match_cell_footprint new flag.
- Include -match_cell_footprint new flag in repair_timing_helper
- Change the "raw" calls for repair_design and repair_timing inside RESYNTH_TIMING_RECOVER (@precisionmoon I think you worked on this part, could you please take a look if that's correct?)
- Add -match_cell_footprint flag in the repair_timing call inside RECOVER_POWER - We should be careful to use the helper throughout elsewhere when/if adding new repair_timing calls, this is an exception.