### PR TITLE
don't save drt modifications on the odb guides

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -20,7 +20,7 @@ append_env_var additional_args DISABLE_VIA_GEN -disable_via_gen 0
 append_env_var additional_args REPAIR_PDN_VIA_LAYER -repair_pdn_vias 1
 append_env_var additional_args DETAILED_ROUTE_END_ITERATION -droute_end_iter 1
 
-append additional_args " -save_guide_updates -verbose 1"
+append additional_args " -verbose 1"
 
 # DETAILED_ROUTE_ARGS is used when debugging detailed, route, e.g. append
 # "-droute_end_iter 5" to look at routing violations after only 5 iterations,


### PR DESCRIPTION
Fixes https://github.com/The-OpenROAD-Project/OpenROAD/issues/6037.

When saving the guide updates made by DRT, it is not possible to estimate parasitics using the guides in odb, because the changes make the connectivity of the guides to get lost.