### PR TITLE
variables.yaml: move defaults from Makefile

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -52,7 +52,7 @@ configuration file.
 
 | Variable | Description | Default | Deprecated |
 | --- | --- | --- | --- |
-| <a name="ABC_AREA"></a>ABC_AREA| Strategies for Yosys ABC synthesis: Area/Speed. Default ABC_SPEED.| | |
+| <a name="ABC_AREA"></a>ABC_AREA| Strategies for Yosys ABC synthesis: Area/Speed. Default ABC_SPEED.| 0| |
 | <a name="ABC_CLOCK_PERIOD_IN_PS"></a>ABC_CLOCK_PERIOD_IN_PS| Clock period to be used by STA during synthesis. Default value read from `constraint.sdc`.| | |
 | <a name="ABC_DRIVER_CELL"></a>ABC_DRIVER_CELL| Default driver cell used during ABC synthesis.| | |
 | <a name="ABC_LOAD_IN_FF"></a>ABC_LOAD_IN_FF| During synthesis set_load value used.| | |
@@ -65,8 +65,8 @@ configuration file.
 | <a name="BLOCKS"></a>BLOCKS| Blocks used as hard macros in a hierarchical flow. Do note that you have to specify block-specific inputs file in the directory mentioned by Makefile.| | |
 | <a name="CAP_MARGIN"></a>CAP_MARGIN| Specifies a capacitance margin when fixing max capacitance violations. This option allows you to overfix.| | |
 | <a name="CDL_FILES"></a>CDL_FILES| Insert additional Circuit Description Language (`.cdl`) netlist files.| | |
-| <a name="CELL_PAD_IN_SITES_DETAIL_PLACEMENT"></a>CELL_PAD_IN_SITES_DETAIL_PLACEMENT| Cell padding on both sides in site widths to ease routability in detail placement.| | |
-| <a name="CELL_PAD_IN_SITES_GLOBAL_PLACEMENT"></a>CELL_PAD_IN_SITES_GLOBAL_PLACEMENT| Cell padding on both sides in site widths to ease routability during global placement.| | |
+| <a name="CELL_PAD_IN_SITES_DETAIL_PLACEMENT"></a>CELL_PAD_IN_SITES_DETAIL_PLACEMENT| Cell padding on both sides in site widths to ease routability in detail placement.| 0| |
+| <a name="CELL_PAD_IN_SITES_GLOBAL_PLACEMENT"></a>CELL_PAD_IN_SITES_GLOBAL_PLACEMENT| Cell padding on both sides in site widths to ease routability during global placement.| 0| |
 | <a name="CLKGATE_MAP_FILE"></a>CLKGATE_MAP_FILE| List of cells for gating clock treated as a black box by Yosys.| | |
 | <a name="CORE_AREA"></a>CORE_AREA| The core area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2).| | |
 | <a name="CORE_ASPECT_RATIO"></a>CORE_ASPECT_RATIO| The core aspect ratio (height / width). This value is ignored if `CORE_UTILIZATION` is undefined.| | |
@@ -87,8 +87,8 @@ configuration file.
 | <a name="DIE_AREA"></a>DIE_AREA| The die area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2).| | |
 | <a name="DONT_USE_CELLS"></a>DONT_USE_CELLS| Dont use cells eases pin access in detailed routing.| | |
 | <a name="DONT_USE_LIBS"></a>DONT_USE_LIBS| Set liberty files as `dont_use`.| | |
-| <a name="DPO_MAX_DISPLACEMENT"></a>DPO_MAX_DISPLACEMENT| Specifies how far an instance can be moved when optimizing.| | |
-| <a name="ENABLE_DPO"></a>ENABLE_DPO| Enable detail placement with improve_placement feature.| | |
+| <a name="DPO_MAX_DISPLACEMENT"></a>DPO_MAX_DISPLACEMENT| Specifies how far an instance can be moved when optimizing.| 5 1| |
+| <a name="ENABLE_DPO"></a>ENABLE_DPO| Enable detail placement with improve_placement feature.| 1| |
 | <a name="EQUIVALENCE_CHECK"></a>EQUIVALENCE_CHECK| Enable running equivalence checks to verify logical correctness of repair_timing.| 0| |
 | <a name="FASTROUTE_TCL"></a>FASTROUTE_TCL| Specifies a Tcl script with commands to run before FastRoute.| | |
 | <a name="FILL_CELLS"></a>FILL_CELLS| Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.| | |
@@ -99,8 +99,8 @@ configuration file.
 | <a name="GLOBAL_PLACEMENT_ARGS"></a>GLOBAL_PLACEMENT_ARGS| Use additional tuning parameters during global placement other than default args defined in global_place.tcl.| | |
 | <a name="GLOBAL_ROUTE_ARGS"></a>GLOBAL_ROUTE_ARGS| Replaces default arguments for global route.| -congestion_iterations 30 -congestion_report_iter_step 5 -verbose| |
 | <a name="GND_NETS_VOLTAGES"></a>GND_NETS_VOLTAGES| Used for IR Drop calculation.| | |
-| <a name="GPL_ROUTABILITY_DRIVEN"></a>GPL_ROUTABILITY_DRIVEN| Specifies whether the placer should use routability driven placement.| | |
-| <a name="GPL_TIMING_DRIVEN"></a>GPL_TIMING_DRIVEN| Specifies whether the placer should use timing driven placement.| | |
+| <a name="GPL_ROUTABILITY_DRIVEN"></a>GPL_ROUTABILITY_DRIVEN| Specifies whether the placer should use routability driven placement.| 1| |
+| <a name="GPL_TIMING_DRIVEN"></a>GPL_TIMING_DRIVEN| Specifies whether the placer should use timing driven placement.| 1| |
 | <a name="GUI_TIMING"></a>GUI_TIMING| Load timing information when opening GUI. For large designs, this can be quite time consuming. Useful to disable when investigating non-timing aspects like floorplan, placement, routing, etc.| 1| |
 | <a name="HOLD_SLACK_MARGIN"></a>HOLD_SLACK_MARGIN| Specifies a time margin for the slack when fixing hold violations. This option allows you to overfix or underfix(negative value, terminate retiming before 0 or positive slack). Use min of HOLD_SLACK_MARGIN and 0(default hold slack margin) in floorplan. This avoids overrepair in floorplan for hold by default, but allows skipping hold repair using a negative HOLD_SLACK_MARGIN. Exiting timing repair early is useful in exploration where the .sdc has a fixed clock period at designs target clock period and where HOLD/SETUP_SLACK_MARGIN is used to avoid overrepair(extremelly long running times) when exploring different parameter settings.| 0| |
 | <a name="IO_CONSTRAINTS"></a>IO_CONSTRAINTS| File path to the IO constraints .tcl file.| | |
@@ -120,9 +120,9 @@ configuration file.
 | <a name="MACRO_PLACE_HALO"></a>MACRO_PLACE_HALO| Horizontal/vertical halo around macros (microns). Used by automatic macro placement.| | |
 | <a name="MACRO_WRAPPERS"></a>MACRO_WRAPPERS| The wrapper file that replaces existing macros with their wrapped version.| | |
 | <a name="MAKE_TRACKS"></a>MAKE_TRACKS| Tcl file that defines add routing tracks to a floorplan.| | |
-| <a name="MATCH_CELL_FOOTPRINT"></a>MATCH_CELL_FOOTPRINT| Enforce sizing operations to only swap cells that have the same layout boundary.| | |
+| <a name="MATCH_CELL_FOOTPRINT"></a>MATCH_CELL_FOOTPRINT| Enforce sizing operations to only swap cells that have the same layout boundary.| 0| |
 | <a name="MAX_ROUTING_LAYER"></a>MAX_ROUTING_LAYER| The highest metal layer name to be used in routing.| | |
-| <a name="MAX_UNGROUP_SIZE"></a>MAX_UNGROUP_SIZE| For hierarchical synthesis, we ungroup modules of size given by this variable.| | |
+| <a name="MAX_UNGROUP_SIZE"></a>MAX_UNGROUP_SIZE| For hierarchical synthesis, we ungroup modules of size given by this variable.| 0| |
 | <a name="MIN_BUF_CELL_AND_PORTS"></a>MIN_BUF_CELL_AND_PORTS| Used to insert a buffer cell to pass through wires. Used in synthesis.| | |
 | <a name="MIN_ROUTING_LAYER"></a>MIN_ROUTING_LAYER| The lowest metal layer name to be used in routing.| | |
 | <a name="PDN_TCL"></a>PDN_TCL| File path which has a set of power grid policies used by pdn to be applied to the design, such as layers to use, stripe width and spacing to generate the actual metal straps.| | |
@@ -141,8 +141,8 @@ configuration file.
 | <a name="REMOVE_CELLS_FOR_EQY"></a>REMOVE_CELLS_FOR_EQY| String patterns directly passed to write_verilog -remove_cells <> for equivalence checks.| | |
 | <a name="REPAIR_PDN_VIA_LAYER"></a>REPAIR_PDN_VIA_LAYER| Remove power grid vias which generate DRC violations after detailed routing.| | |
 | <a name="REPORT_CLOCK_SKEW"></a>REPORT_CLOCK_SKEW| Report clock skew as part of reporting metrics, starting at CTS, before which there is no clock skew. This metric can be quite time-consuming, so it can be useful to disable.| 1| |
-| <a name="RESYNTH_AREA_RECOVER"></a>RESYNTH_AREA_RECOVER| Enable re-synthesis for area reclaim.| | |
-| <a name="RESYNTH_TIMING_RECOVER"></a>RESYNTH_TIMING_RECOVER| Enable re-synthesis for timing optimization.| | |
+| <a name="RESYNTH_AREA_RECOVER"></a>RESYNTH_AREA_RECOVER| Enable re-synthesis for area reclaim.| 0| |
+| <a name="RESYNTH_TIMING_RECOVER"></a>RESYNTH_TIMING_RECOVER| Enable re-synthesis for timing optimization.| 0| |
 | <a name="ROUTING_LAYER_ADJUSTMENT"></a>ROUTING_LAYER_ADJUSTMENT| Default routing layer adjustment| 0.5| |
 | <a name="SC_LEF"></a>SC_LEF| Path to technology standard cell LEF file.| | |
 | <a name="SDC_FILE"></a>SDC_FILE| The path to design constraint (SDC) file.| | |
@@ -157,9 +157,9 @@ configuration file.
 | <a name="SKIP_PIN_SWAP"></a>SKIP_PIN_SWAP| Do not use pin swapping as a transform to fix timing violations (default: use pin swapping).| | |
 | <a name="SKIP_REPORT_METRICS"></a>SKIP_REPORT_METRICS| If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds.| | |
 | <a name="SLEW_MARGIN"></a>SLEW_MARGIN| Specifies a slew margin when fixing max slew violations. This option allows you to overfix.| | |
-| <a name="SYNTH_ARGS"></a>SYNTH_ARGS| Optional synthesis variables for yosys.| | |
+| <a name="SYNTH_ARGS"></a>SYNTH_ARGS| Optional synthesis variables for yosys.| -flatten| |
 | <a name="SYNTH_GUT"></a>SYNTH_GUT| Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.| | |
-| <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| | |
+| <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| 0| |
 | <a name="TAPCELL_TCL"></a>TAPCELL_TCL| Path to Endcap and Welltie cells file.| | |
 | <a name="TAP_CELL_NAME"></a>TAP_CELL_NAME| Name of the cell to use in tap cell insertion.| | |
 | <a name="TECH_LEF"></a>TECH_LEF| A technology LEF file of the PDK that includes all relevant information regarding metal layers, vias, and spacing requirements.| | |

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -122,7 +122,7 @@ configuration file.
 | <a name="MAKE_TRACKS"></a>MAKE_TRACKS| Tcl file that defines add routing tracks to a floorplan.| | |
 | <a name="MATCH_CELL_FOOTPRINT"></a>MATCH_CELL_FOOTPRINT| Enforce sizing operations to only swap cells that have the same layout boundary.| 0| |
 | <a name="MAX_ROUTING_LAYER"></a>MAX_ROUTING_LAYER| The highest metal layer name to be used in routing.| | |
-| <a name="MAX_UNGROUP_SIZE"></a>MAX_UNGROUP_SIZE| For hierarchical synthesis, we ungroup modules of size given by this variable.| 0| |
+| <a name="MAX_UNGROUP_SIZE"></a>MAX_UNGROUP_SIZE| For hierarchical synthesis, we ungroup modules of larger area than given by this variable. The default value is > 0 platform specific.| | |
 | <a name="MIN_BUF_CELL_AND_PORTS"></a>MIN_BUF_CELL_AND_PORTS| Used to insert a buffer cell to pass through wires. Used in synthesis.| | |
 | <a name="MIN_ROUTING_LAYER"></a>MIN_ROUTING_LAYER| The lowest metal layer name to be used in routing.| | |
 | <a name="PDN_TCL"></a>PDN_TCL| File path which has a set of power grid policies used by pdn to be applied to the design, such as layers to use, stripe width and spacing to generate the actual metal straps.| | |

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -179,39 +179,14 @@ endif
 include $(PLATFORM_DIR)/config.mk
 
 # Enables hierarchical yosys
-export SYNTH_HIERARCHICAL ?= 0
 export SYNTH_STATS = $(RESULTS_DIR)/synth_stats.txt
 export SYNTH_STATS_SCRIPT = $(SCRIPTS_DIR)/synth_stats.tcl
-export MAX_UNGROUP_SIZE ?= 0
 
-# Enables Re-synthesis for area reclaim
-export RESYNTH_AREA_RECOVER ?= 0
-export RESYNTH_TIMING_RECOVER ?= 0
-export ABC_AREA ?= 0
-
-# User adjustable synthesis arguments
-export SYNTH_ARGS ?= -flatten
 # Not normally adjusted by user
 export SYNTH_OPERATIONS_ARGS ?= -extra-map $(FLOW_HOME)/platforms/common/lcu_kogge_stone.v
 export SYNTH_FULL_ARGS ?= $(SYNTH_ARGS) $(SYNTH_OPERATIONS_ARGS)
 
-# Global setting for Floorplan
-export PLACE_PINS_ARGS
-
 export FLOW_VARIANT ?= base
-
-export GPL_TIMING_DRIVEN ?= 1
-export GPL_ROUTABILITY_DRIVEN ?= 1
-
-# Cell padding in SITE widths to ease rout-ability.  Applied to both sides
-export CELL_PAD_IN_SITES_GLOBAL_PLACEMENT ?= 0
-export CELL_PAD_IN_SITES_DETAIL_PLACEMENT ?= 0
-
-export ENABLE_DPO ?= 1
-export DPO_MAX_DISPLACEMENT ?= 5 1
-
-# Settings for Sizing
-export MATCH_CELL_FOOTPRINT ?= 0
 
 # Setup working directories
 export DESIGN_NICKNAME ?= $(DESIGN_NAME)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -181,6 +181,8 @@ include $(PLATFORM_DIR)/config.mk
 # Enables hierarchical yosys
 export SYNTH_STATS = $(RESULTS_DIR)/synth_stats.txt
 export SYNTH_STATS_SCRIPT = $(SCRIPTS_DIR)/synth_stats.tcl
+# If the design, nor $(PLATFORM_DIR)/config.mk provided a default, provide one here
+export MAX_UNGROUP_SIZE ?= 0
 
 # Not normally adjusted by user
 export SYNTH_OPERATIONS_ARGS ?= -extra-map $(FLOW_HOME)/platforms/common/lcu_kogge_stone.v

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -139,6 +139,7 @@ SYNTH_HIERARCHICAL:
     Enable to Synthesis hierarchically, otherwise considered flat synthesis.
   stages:
     - synth
+  default: 0
 LATCH_MAP_FILE:
   description: >
     List of latches treated as a black box by Yosys.
@@ -191,6 +192,7 @@ MAX_UNGROUP_SIZE:
     For hierarchical synthesis, we ungroup modules of size given by this variable.
   stages:
     - synth
+  default: 0
 FLOORPLAN_DEF:
   description: >
     Use the DEF file to initialize floorplan.
@@ -289,6 +291,7 @@ CELL_PAD_IN_SITES_GLOBAL_PLACEMENT:
   stages:
     - place
     - floorplan
+  default: 0
 CELL_PAD_IN_SITES_DETAIL_PLACEMENT:
   description: >
     Cell padding on both sides in site widths to ease routability in detail placement.
@@ -296,12 +299,14 @@ CELL_PAD_IN_SITES_DETAIL_PLACEMENT:
     - place
     - cts
     - grt
+  default: 0
 PLACE_PINS_ARGS:
   description: >
     Arguments to place_pins
   stages:
     - place
     - floorplan
+  default: ""
 PLACE_DENSITY:
   description: >
     The desired placement density of cells. It reflects how spread the cells would be on the core area.
@@ -321,19 +326,23 @@ GLOBAL_PLACEMENT_ARGS:
 ENABLE_DPO:
   description: >
     Enable detail placement with improve_placement feature.
+  default: 1
 DPO_MAX_DISPLACEMENT:
   description: >
     Specifies how far an instance can be moved when optimizing.
+  default: 5 1
 GPL_TIMING_DRIVEN:
   description: >
     Specifies whether the placer should use timing driven placement.
   stages:
     - place
+  default: 1
 GPL_ROUTABILITY_DRIVEN:
   description: >
     Specifies whether the placer should use routability driven placement.
   stages:
     - place
+  default: 1
 CAP_MARGIN:
   description: >
     Specifies a capacitance margin when fixing max capacitance violations. This option allows you to overfix.
@@ -516,6 +525,7 @@ ABC_AREA:
     Strategies for Yosys ABC synthesis: Area/Speed. Default ABC_SPEED.
   stages:
     - synth
+  default: 0
 PWR_NETS_VOLTAGES:
   description: >
     Used for IR Drop calculation.
@@ -545,6 +555,7 @@ PRESERVE_CELLS:
 SYNTH_ARGS:
   description: >
     Optional synthesis variables for yosys.
+  default: -flatten
 VERILOG_TOP_PARAMS:
   description: >
     Apply toplevel params (if exist).
@@ -575,11 +586,13 @@ RESYNTH_AREA_RECOVER:
     Enable re-synthesis for area reclaim.
   stages:
     - synth
+  default: 0
 RESYNTH_TIMING_RECOVER:
   description: >
     Enable re-synthesis for timing optimization.
   stages:
     - synth
+  default: 0
 MACRO_HALO_X:
   description: >
     Set macro halo for x-direction. Only available for ASAP7 PDK.
@@ -651,3 +664,4 @@ MATCH_CELL_FOOTPRINT:
     - place
     - cts
     - route
+  default: 0

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -189,10 +189,10 @@ ABC_LOAD_IN_FF:
     - synth
 MAX_UNGROUP_SIZE:
   description: >
-    For hierarchical synthesis, we ungroup modules of size given by this variable.
+    For hierarchical synthesis, we ungroup modules of larger area than given by this
+    variable. The default value is > 0 platform specific.
   stages:
     - synth
-  default: 0
 FLOORPLAN_DEF:
   description: >
     Use the DEF file to initialize floorplan.


### PR DESCRIPTION
This is to reduce copying and pasting a pattern we're moving away from