### PR TITLE
open.tcl: improve progress output a bit

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -51,9 +51,10 @@ proc read_timing {input_file} {
     log_cmd estimate_parasitics -placement
   }
 
-  puts "Populating timing paths..."
+  puts -nonewline "Populating timing paths..."
   # Warm up OpenSTA, so clicking on timing related buttons reacts faster
   set _tmp [find_timing_paths]
+  puts "OK"
 }
 
 if {[env_var_equals GUI_TIMING 1]} {


### PR DESCRIPTION
Currently the GUI does not always open, this extra output gives a clue that the GUI should have opened and that the user can manually open the GUI.