### PR TITLE
detail route: remove broken check that is handled inside detailed route

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -1,10 +1,6 @@
 utl::set_metrics_stage "detailedroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 5_1_grt.odb 5_1_grt.sdc
-if {![grt::have_routes]} {
-  error "Global routing failed, run `make gui_grt` and load $::global_route_congestion_report \
-        in DRC viewer to view congestion"
-}
 erase_non_stage_variables route
 set_propagated_clock [all_clocks]
 


### PR DESCRIPTION
Detailed route will fail once it loads the guides and see them congested.

Remove this fail-early, but broken check.

Perhaps detailed route will fail earlier in the future, but this check isn't doing anything now and is broken as is, so remove it.