### PR TITLE
Wrapped operators synthesis flow

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -184,6 +184,7 @@ configuration file.
 | <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| 0| |
 | <a name="SYNTH_MEMORY_MAX_BITS"></a>SYNTH_MEMORY_MAX_BITS| Maximum number of bits for memory synthesis.| 4096| |
 | <a name="SYNTH_NETLIST_FILES"></a>SYNTH_NETLIST_FILES| Skips synthesis and uses the supplied netlist files. If the netlist files contains duplicate modules, which can happen when using hierarchical synthesis on indvidual netlist files and combining here, subsequent modules are silently ignored and only the first module is used.| | |
+| <a name="SYNTH_WRAPPED_OPERATORS"></a>SYNTH_WRAPPED_OPERATORS| Synthesize multiple architectural options for each arithmetic operator in the design. These options are available for switching among in later stages of the flow.| | |
 | <a name="TAPCELL_TCL"></a>TAPCELL_TCL| Path to Endcap and Welltie cells file.| | |
 | <a name="TAP_CELL_NAME"></a>TAP_CELL_NAME| Name of the cell to use in tap cell insertion.| | |
 | <a name="TECH_LEF"></a>TECH_LEF| A technology LEF file of the PDK that includes all relevant information regarding metal layers, vias, and spacing requirements.| | |
@@ -213,6 +214,7 @@ configuration file.
 - [SYNTH_HIERARCHICAL](#SYNTH_HIERARCHICAL)
 - [SYNTH_MEMORY_MAX_BITS](#SYNTH_MEMORY_MAX_BITS)
 - [SYNTH_NETLIST_FILES](#SYNTH_NETLIST_FILES)
+- [SYNTH_WRAPPED_OPERATORS](#SYNTH_WRAPPED_OPERATORS)
 - [TIEHI_CELL_AND_PORT](#TIEHI_CELL_AND_PORT)
 - [TIELO_CELL_AND_PORT](#TIELO_CELL_AND_PORT)
 - [VERILOG_FILES](#VERILOG_FILES)

--- a/flow/scripts/abc_speed_gia_only.script
+++ b/flow/scripts/abc_speed_gia_only.script
@@ -1,0 +1,28 @@
+&st
+&dch
+&nf
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf
+&st
+&syn2
+&if -g -K 6
+&synch2
+&nf

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -35,7 +35,7 @@ json -o $::env(RESULTS_DIR)/mem.json
 # Run report and check here so as to fail early if this synthesis run is doomed
 exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
 
-if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+if {![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS]} {
   synth -top $::env(DESIGN_NAME) -run fine: {*}$::env(SYNTH_FULL_ARGS)
 } else {
   source $::env(SCRIPTS_DIR)/synth_wrap_operators.tcl
@@ -82,7 +82,7 @@ if {[env_var_exists_and_non_empty DFF_LIB_FILE]} {
 }
 opt
 
-if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+if {![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS]} {
   log_cmd abc {*}$abc_args
 } else {
   scratchpad -set abc9.script scripts/abc_speed_gia_only.script
@@ -115,7 +115,7 @@ tee -o $::env(REPORTS_DIR)/synth_check.txt check
 tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$stat_libs
 
 # check the design is composed exclusively of target cells, and check for other problems
-if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+if {![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS]} {
   check -assert -mapped
 } else {
   # Wrapped operator synthesis leaves around $buf cells which `check -mapped`

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -34,7 +34,13 @@ if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
 json -o $::env(RESULTS_DIR)/mem.json
 # Run report and check here so as to fail early if this synthesis run is doomed
 exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
-synth -top $::env(DESIGN_NAME) -run fine: {*}$::env(SYNTH_FULL_ARGS)
+
+if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+  synth -top $::env(DESIGN_NAME) -run fine: {*}$::env(SYNTH_FULL_ARGS)
+} else {
+  source $::env(SCRIPTS_DIR)/synth_wrap_operators.tcl
+}
+
 # Get rid of indigestibles
 chformal -remove
 
@@ -76,7 +82,15 @@ if {[env_var_exists_and_non_empty DFF_LIB_FILE]} {
 }
 opt
 
-log_cmd abc {*}$abc_args
+if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+  log_cmd abc {*}$abc_args
+} else {
+  scratchpad -set abc9.script scripts/abc_speed_gia_only.script
+  # crop out -script from arguments
+  set abc_args [lrange $abc_args 2 end]
+  log_cmd abc_new {*}$abc_args
+  delete {t:$specify*}
+}
 
 # Replace undef values with defined constants
 setundef -zero
@@ -104,7 +118,7 @@ tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$stat_libs
 check -assert -mapped
 
 # Write synthesized design
-write_verilog -noexpr -nohex -nodec $::env(RESULTS_DIR)/1_1_yosys.v
+write_verilog -nohex -nodec $::env(RESULTS_DIR)/1_1_yosys.v
 # One day a more sophisticated synthesis will write out a modified
 # .sdc file after synthesis. For now, just copy the input .sdc file,
 # making synthesis more consistent with other stages.

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -115,7 +115,14 @@ tee -o $::env(REPORTS_DIR)/synth_check.txt check
 tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$stat_libs
 
 # check the design is composed exclusively of target cells, and check for other problems
-check -assert -mapped
+if {![env_var_exists_and_non_empty NEW_OPERATOR_SYNTHESIS]} {
+  check -assert -mapped
+} else {
+  # Wrapped operator synthesis leaves around $buf cells which `check -mapped`
+  # gets confused by, once Yosys#4931 is merged we can remove this branch and
+  # always run `check -assert -mapped`
+  check -assert
+}
 
 # Write synthesized design
 write_verilog -nohex -nodec $::env(RESULTS_DIR)/1_1_yosys.v

--- a/flow/scripts/synth_wrap_operators-booth.v
+++ b/flow/scripts/synth_wrap_operators-booth.v
@@ -1,0 +1,4 @@
+(* techmap_wrap = "booth" *)
+(* techmap_celltype = "$macc" *)
+module _70_macc;
+endmodule

--- a/flow/scripts/synth_wrap_operators.tcl
+++ b/flow/scripts/synth_wrap_operators.tcl
@@ -1,0 +1,74 @@
+set deferred_cells {
+  {
+    \$alu
+    ALU_{A_WIDTH}_{A_SIGNED}_{B_WIDTH}_{B_SIGNED}_{Y_WIDTH}{%unused}
+    {HAN_CARLSON -map +/choices/han-carlson.v}
+    {KOGGE_STONE -map +/choices/kogge-stone.v}
+    {SKLANSKY -map +/choices/sklansky.v}
+    {BRENT_KUNG}
+  }
+  {
+    \$macc
+    MACC_{CONFIG}_{Y_WIDTH}{%unused}
+    {BASE -map +/choices/han-carlson.v}
+  }
+}
+
+techmap {*}[join [lmap cell $deferred_cells {string cat "-dont_map [lindex $cell 0]"}] " "]
+
+foreach info $deferred_cells {
+  set type [lindex $info 0]
+  set naming_template [lindex $info 1]
+  # default architecture and its suffix
+  set default [lindex $info 2]
+  set default_suffix [lindex $default 0]
+
+  log -header "Generating architectural options for $type"
+  log -push
+
+  wrapcell \
+    -setattr arithmetic_operator \
+    -setattr copy_pending \
+    -formatattr implements_operator $naming_template \
+    -formatattr architecture $default_suffix \
+    -formatattr source_cell $type \
+    -name ${naming_template}_${default_suffix} \
+    t:$type r:A_WIDTH>=10 r:Y_WIDTH>=14 %i %i
+
+  # make per-architecture copies of the unmapped module
+  foreach modname [tee -q -s result.string select -list-mod A:arithmetic_operator A:copy_pending] {
+    setattr -mod -unset copy_pending $modname
+
+    # iterate over non-default architectures
+    foreach arch [lrange $info 3 end] {
+      set suffix [lindex $arch 0]
+      set base [rtlil::get_attr -string -mod $modname implements_operator]
+      set newname ${base}_${suffix}
+      yosys copy $modname $newname
+      yosys setattr -mod -set architecture \"$suffix\" $newname
+    }
+  }
+
+  # iterate over all architectures, both the default and non-default
+  foreach arch [lrange $info 2 end] {
+    set suffix [lindex $arch 0]
+    set extra_map_args [lrange $arch 1 end]
+
+    # inject booth before we have techmap support for it
+    #booth A:source_cell=$type A:architecture=$suffix %i
+
+    # map all operator copies which were selected to have this architecture
+    techmap -map +/techmap.v {*}$extra_map_args A:source_cell=$type A:architecture=$suffix %i
+  }
+
+  log -pop
+}
+
+opt -fast -full
+memory_map
+opt -full
+# Get rid of indigestibles
+chformal -remove
+setattr -mod -set abc9_script {"+&dch;&nf -R 5;"} A:arithmetic_operator
+setattr -mod -set abc9_box 1 A:arithmetic_operator
+techmap -map +/choices/han-carlson.v

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -239,10 +239,10 @@ MAX_UNGROUP_SIZE:
     platform's standard cell library. The default value is platform specific.
   stages:
     - synth
-NEW_OPERATOR_SYNTHESIS:
+SYNTH_WRAPPED_OPERATORS:
   description: >
     Synthesize multiple architectural options for each arithmetic operator in the
-    design. These options are available for switching between in later stages of
+    design. These options are available for switching among in later stages of
     the flow.
   stages:
     - synth

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -239,6 +239,13 @@ MAX_UNGROUP_SIZE:
     platform's standard cell library. The default value is platform specific.
   stages:
     - synth
+NEW_OPERATOR_SYNTHESIS:
+  description: >
+    Synthesize multiple architectural options for each arithmetic operator in the
+    design. These options are available for switching between in later stages of
+    the flow.
+  stages:
+    - synth
 FLOORPLAN_DEF:
   description: |
     Use the DEF file to initialize floorplan.


### PR DESCRIPTION
This is a synthesis flow which

 * preserves arithmetic operator boundaries (boundaries of what Yosys considers an `$alu` and `$macc` cell)
 * generates alternative architectures for those preserved operators, and exports those as uninstantiated modules in the final netlist

It's gated on the `NEW_OPERATOR_SYNTHESIS` option which I left undocumented. This option will only work once Yosys is bumped to 0.48 (~pending in #2620~; done)