### PR TITLE
gpl: swerv wrapper only virtual timing-driven iterations

### DIFF
--- a/flow/designs/nangate45/swerv_wrapper/config.mk
+++ b/flow/designs/nangate45/swerv_wrapper/config.mk
@@ -33,3 +33,4 @@ export TNS_END_PERCENT        = 100
 
 export FASTROUTE_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/fastroute.tcl
 
+export GPL_KEEP_OVERFLOW = 0

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -17,6 +17,9 @@ if {$::env(GPL_ROUTABILITY_DRIVEN)} {
 # Parameters for timing driven mode in global placement
 if {$::env(GPL_TIMING_DRIVEN)} {
   lappend global_placement_args {-timing_driven}
+  if {[info exists ::env(GPL_KEEP_OVERFLOW)] && $::env(GPL_KEEP_OVERFLOW) ne ""} {
+    lappend global_placement_args -keep_resize_below_overflow $::env(GPL_KEEP_OVERFLOW)
+  }
 }
 
 proc do_placement {global_placement_args} {

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -17,7 +17,7 @@ if {$::env(GPL_ROUTABILITY_DRIVEN)} {
 # Parameters for timing driven mode in global placement
 if {$::env(GPL_TIMING_DRIVEN)} {
   lappend global_placement_args {-timing_driven}
-  if {[info exists ::env(GPL_KEEP_OVERFLOW)] && $::env(GPL_KEEP_OVERFLOW) ne ""} {
+  if {[info exists ::env(GPL_KEEP_OVERFLOW)]} {
     lappend global_placement_args -keep_resize_below_overflow $::env(GPL_KEEP_OVERFLOW)
   }
 }


### PR DESCRIPTION
Set swerv_wrapper to execute only virtual iterations during gpl timing-driven runs, undoing rsz work in each iteration. 

The change in area from non-virtual iterations seems to be causing gpl to diverge.

This should unblock @povik's and @LucasYuki's changes while a proper solution is under work.

I see no failing metrics on a local run:

```
make DESIGN_CONFIG=./designs/nangate45/swerv_wrapper/config.mk metadata 
./logs/nangate45/swerv_wrapper/base
Log                            Elapsed seconds Peak Memory/MB
1_1_yosys                                  366            529
1_1_yosys_canonicalize                      12           1122
1_1_yosys_stats                            329            411
2_1_floorplan                              843            552
2_2_floorplan_io                             0            281
2_3_floorplan_macro                         29            826
2_4_floorplan_tapcell                        0            231
2_5_floorplan_pdn                            3            359
3_1_place_gp_skip_io                        41            522
3_2_place_iop                                1            301
3_3_place_gp                               724           1512
3_4_place_resized                           93            737
3_5_place_dp                               101           1043
4_1_cts                                    686           1309
5_1_grt                                    654           2572
5_2_route                                 2116           6590
5_3_fillcell                                 3            903
6_1_fill                                     1            449
6_1_merge                                   10           1310
6_report                                   298           2759
Total                                     6310           6590
[WARN] Overwriting Tag finish__runtime__total
[WARN] Overwriting Tag finish__cpu__total
[WARN] Overwriting Tag finish__mem__peak
[INFO] synth__design__instance__area__stdcell pass test: 642482.568 <= 737362.47
[INFO] constraints__clocks__count pass test: 1.0 == 1.0
[INFO] placeopt__design__instance__area pass test: 694500.0 <= 783985.0
[INFO] placeopt__design__instance__count__stdcell pass test: 108191.0 <= 123213.0
[INFO] detailedplace__design__violations pass test: 0.0 == 0.0
[INFO] cts__design__instance__count__setup_buffer pass test: 43.0 <= 10714.0
[INFO] cts__design__instance__count__hold_buffer pass test: 1505.0 <= 10714.0
[INFO] globalroute__antenna_diodes_count pass test: 0.0 <= 0.0
[INFO] detailedroute__route__wirelength pass test: 4835212.0 <= 5712360.0
[INFO] detailedroute__route__drc_errors pass test: 0.0 <= 0.0
[INFO] detailedroute__antenna__violating__nets pass test: 0.0 <= 0.0
[INFO] detailedroute__antenna_diodes_count pass test: 0.0 <= 0.0
[INFO] finish__timing__setup__ws pass test: -0.828659 >= -1.05
[INFO] finish__design__instance__area pass test: 700881.0 <= 790704.0
[INFO] finish__timing__drv__setup_violation_count pass test: 1431.0 <= 5357.0
[INFO] finish__timing__drv__hold_violation_count pass test: 447.0 <= 1089.0
[INFO] finish__timing__wns_percent_delay pass test: -24.854538 >= -35.9
All metadata rules passed (17 rules)
```
