### PR TITLE
make: run now has a run.log

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1053,7 +1053,7 @@ klayout:
 
 .phony: run
 run:
-	$(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT)
+	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/run.log))
 
 # Utilities
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
consistent with other targets, useful for debugging and scripting