### PR TITLE
makefile: run can need any of these folders

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1053,6 +1053,7 @@ klayout:
 
 .phony: run
 run:
+	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
 	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/run.log))
 
 # Utilities


### PR DESCRIPTION
Make `make run` consistent with other stage targets: create the same various folders.

Especially useful in bazel-orfs context, though it is also possible to run into problems with these folders not existing in any scripting context
