### PR TITLE
mock-array: use read_vcd

### DIFF
--- a/flow/designs/asap7/mock-array/power.tcl
+++ b/flow/designs/asap7/mock-array/power.tcl
@@ -20,15 +20,14 @@ for {set x 0} {$x < 8} {incr x} {
 
 report_parasitic_annotation
 report_power
-read_power_activities -scope TOP/MockArray -vcd $::env(RESULTS_DIR)/MockArrayTestbench.vcd
-report_power
+read_vcd -scope TOP/MockArray $::env(RESULTS_DIR)/MockArrayTestbench.vcd
 
-# FIXME add an automated test to check that the top-level power is
-# smaller than the sum of the individual elements.
-
+set ces {}
 for {set x 0} {$x < 8} {incr x} {
   for {set y 0} {$y < 8} {incr y} {
-    puts "Power for ces_${x}_${y}"
-    report_power -instances ces_${x}_${y}
+    lappend ces ces_${x}_${y}
   }
 }
+
+report_power -instances [get_cells $ces]
+report_power


### PR DESCRIPTION
read_power_activities is deprecated

report_power now uses a table instead of one call to report_power per element in the array, much easier on the eye, much less verbose