### PR TITLE
makefile: make RUN_LOG_NAME_STEM=foo run to specify name of log

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1051,8 +1051,6 @@ test-unset-and-make-%: ; $(UNSET_AND_MAKE) $*
 klayout:
 	$(KLAYOUT_CMD)
 
-export RUN_LOG_NAME_STEM ?= run
-
 .phony: run
 run:
 	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1051,10 +1051,12 @@ test-unset-and-make-%: ; $(UNSET_AND_MAKE) $*
 klayout:
 	$(KLAYOUT_CMD)
 
+export RUN_LOG_NAME_STEM ?= run
+
 .phony: run
 run:
 	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/run.log))
+	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/$(RUN_LOG_NAME_STEM).log))
 
 # Utilities
 #-------------------------------------------------------------------------------

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -875,3 +875,12 @@ GDS_ALLOW_EMPTY:
     Regular expression of module names of macros that have no .gds file
   stages:
     - final
+RUN_SCRIPT:
+  description: >
+    Path to script to run from `make run`, python or tcl script detected by
+    .py or .tcl extension.
+RUN_LOG_NAME_STEM:
+  description: >
+    Stem of the log file name, the log file will be named
+    `$(LOG_DIR)/$(RUN_LOG_NAME_STEM).log`.
+  default: run


### PR DESCRIPTION
Short explanation: simpler scripting, better impedance match with makefiles and bazel.