### PR TITLE
docker shell mods to address reading makefiles in twice and enable op…

### DIFF
--- a/flow/util/docker_shell
+++ b/flow/util/docker_shell
@@ -29,7 +29,6 @@ docker run -u $(id -u ${USER}):$(id -g ${USER}) \
  -v $XAUTH:$XAUTH \
  -e XAUTHORITY=$XAUTH \
  -e FLOW_HOME=/OpenROAD-flow-scripts/flow/ \
- -e MAKEFILES=/OpenROAD-flow-scripts/flow/Makefile \
  -e YOSYS_EXE=$YOSYS_EXE \
  -e OPENROAD_EXE=$OPENROAD_EXE \
  -e KLAYOUT_CMD=$KLAYOUT_CMD \
@@ -40,5 +39,6 @@ docker run -u $(id -u ${USER}):$(id -g ${USER}) \
  bash -c "set -ex
  mkdir /tmp/xdg-run
  cd /OpenROAD-flow-scripts/flow
+ . ../env.sh
  $ARGUMENTS
 "


### PR DESCRIPTION
…enroad to be called without make

Removes MAKEFILES env var, which caused the flow/Makefile to be read in twice resulting in a yosys-abc failure when the merged.lib had duplicate cell entries.

Adds sourcing of the env.sh, so you can do a "util/docker_shell openroad -gui".