### PR TITLE
mock-array: add --coverage-toggle report in simulation

### DIFF
--- a/flow/designs/asap7/mock-array/simulate.sh
+++ b/flow/designs/asap7/mock-array/simulate.sh
@@ -22,6 +22,8 @@ verilator -Wall --cc \
   -Wno-DECLFILENAME \
   -Wno-UNUSEDSIGNAL \
   -Wno-PINMISSING \
+  --coverage-toggle \
+  --coverage-underscore \
   --Mdir $OBJ_DIR \
   --top-module MockArray \
   --trace \
@@ -30,8 +32,8 @@ verilator -Wall --cc \
   $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v \
   $PLATFORM_DIR/verilog/stdcell/dff.v \
   $PLATFORM_DIR/verilog/stdcell/empty.v \
-  $FLOW_HOME/results/asap7/mock-array/base/6_final.v \
-  $FLOW_HOME/results/asap7/mock-array_Element/base/6_final.v \
+  $POST_DIR/MockArrayFinal.v \
+  $POST_DIR/MockArrayElement.v \
   --exe \
   $FLOW_HOME/designs/src/mock-array/simulate.cpp
 
@@ -40,3 +42,4 @@ make -j16 -C $OBJ_DIR -f VMockArray.mk
 
 # Run the simulation
 $OBJ_DIR/VMockArray
+verilator_coverage $RESULTS_DIR/coverage.dat --annotate $REPORTS_DIR/

--- a/flow/designs/src/mock-array/simulate.cpp
+++ b/flow/designs/src/mock-array/simulate.cpp
@@ -89,6 +89,9 @@ int main(int argc, char** argv) {
     vcd->flush();
     vcd->close();
 
+    std::string coverage_file = std::string(getenv("RESULTS_DIR")) + "/coverage.dat";
+    Verilated::threadContextp()->coveragep()->write(coverage_file.c_str());
+
     top->final();
     delete top;
     return 0;


### PR DESCRIPTION
https://github.com/verilator/verilator/issues/5037

Verilator does not support outputting .saif files to be used with OpenSTA read_saif for dynamic report_power reporting.

The problem with using .vcd files is that they can become giant, whereas .saif files are constant size.

I wonder if Verilator collects enough information via [--coverate-toggle](https://verilator.org/guide/latest/simulating.html#coverage-collection) that it could create a .saif file based on information collected.

If so, what is missing is missing is a bit of work to "connect the dots" and add a .saif reporting option for `--coverage-toggle` in Verilator.

This report enables `--coverate-toggle` for mock-array simulate target:

```
make DESIGN_CONFIG=designs/asap7/mock-array/config.mk simulate
```

This will output an annotated Verilog file reports/asap7/mock-array/base/MockArrayElement.v.

Snippet example:

```
            io_outs_right,
            io_outs_up);
 000319  input clock;
 000038  input io_lsbIns_1;
 000041  input io_lsbIns_2;
 000043  input io_lsbIns_3;
 000036  input io_lsbIns_4;
 000030  input io_lsbIns_5;
 000023  input io_lsbIns_6;
 000017  input io_lsbIns_7;
 000038  output io_lsbOuts_0;
 000041  output io_lsbOuts_1;
 000043  output io_lsbOuts_2;
 000036  output io_lsbOuts_3;
 000030  output io_lsbOuts_4;
%000004  input [63:0] io_ins_left;
```

So this means that the clock changed 319 times, which I can verify in gtkwave: I see 39875ps in gtkwave at 250ps clock, 39875/250*2=319.

![image](https://github.com/user-attachments/assets/615f18ac-f616-43c4-9549-a472e994fd8d)


