### PR TITLE
makefile: make issue, retire buggy confusing .gdb and .tcl files

### DIFF
--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -63,9 +63,7 @@ done
 ISSUE_CP_FILES+="${ISSUE_CP_FILES_PLATFORM} \
     $UTILS_DIR/def2stream.py \
     ${RUN_ME_SCRIPT} \
-    $VARS_BASENAME.sh \
-    $VARS_BASENAME.tcl \
-    $VARS_BASENAME.gdb"
+    $VARS_BASENAME.sh"
 
 cat > ${RUN_ME_SCRIPT} <<EOF
 #!/usr/bin/env bash


### PR DESCRIPTION
These are broken when FLOW_HOME is not defined(.tcl version is broken even with FLOW_HOME defined), which is indicative to me that these files are not being used.

They should either be fixed.

.gdb file can't be fixed because the .gdb format lacks the required sophistication.

.tcl file could be fixed, but why have more than a canonical robust well trodden path to reproduce issues?


Example of .tcl file not working:

```
$ . ~/OpenROAD-flow-scripts/env.sh 
OPENROAD: /home/oyvind/OpenROAD-flow-scripts/tools/OpenROAD
$ echo $FLOW_HOME
/home/oyvind/OpenROAD-flow-scripts/flow
$ openroad
OpenROAD v2.0-18021-g74c7c59d2 
Features included (+) or not (-): +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
openroad> source vars-fs-mul-mod-q-asap7-base.tcl 
Error: vars-fs-mul-mod-q-asap7-base.tcl, 8 can't read "FLOW_HOME": no such variable
while evaluating source vars-fs-mul-mod-q-asap7-base.tcl 
openroad> 
```
