### PR TITLE
asap7: dff.v was missing internal signals

### DIFF
--- a/flow/platforms/asap7/verilog/stdcell/dff.v
+++ b/flow/platforms/asap7/verilog/stdcell/dff.v
@@ -1,32 +1,41 @@
-// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R because
-// Verialtor doesn't support and has no plans to support 1995 UDP
-// tables.
+// Quick and dirty reimplementation of DFFHQNx2_ASAP7_75t_R
+// because verilator doesn't support and has no plans to
+// support 1995 UDP tables.
 //
 // https://github.com/verilator/verilator/issues/5243
 
 module DFFHQNx1_ASAP7_75t_R (QN, D, CLK);
-    output reg QN;
+    output QN;
     input D, CLK;
-
+    reg IQNN;
+    wire IQN;
     always @(posedge CLK) begin
-        QN <= ~D;
+        IQNN <= ~D;
     end
+    assign IQN = IQNN;
+    assign QN = IQN;
 endmodule
 
 module DFFHQNx2_ASAP7_75t_R (QN, D, CLK);
-    output reg QN;
+    output QN;
     input D, CLK;
-
+    reg IQNN;
+    wire IQN;
     always @(posedge CLK) begin
-        QN <= ~D;
+        IQNN <= D;
     end
+    assign IQN = IQNN;
+    assign QN = IQN;
 endmodule
 
 module DFFHQNx3_ASAP7_75t_R (QN, D, CLK);
-    output reg QN;
+    output QN;
     input D, CLK;
-
+    reg IQNN;
+    wire IQN;
     always @(posedge CLK) begin
-        QN <= ~D;
+        IQNN <= ~D;
     end
+    assign IQN = IQNN;
+    assign QN = IQN;
 endmodule


### PR DESCRIPTION
This caused .vcd files in mock-array not to have pin values for all pins.