### PR TITLE
[DO NOT REVIEW] mock-array: report error if all pins are not in .vcd for read_vcd

### DIFF
--- a/flow/designs/asap7/mock-array/power.tcl
+++ b/flow/designs/asap7/mock-array/power.tcl
@@ -1,3 +1,5 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 foreach libFile $::env(LIB_FILES) {
   if {[lsearch -exact $::env(ADDITIONAL_LIBS) $libFile] == -1} {
     read_liberty $libFile
@@ -18,9 +20,41 @@ for {set x 0} {$x < 8} {incr x} {
   }
 }
 
-report_parasitic_annotation
-report_power
-read_vcd -scope TOP/MockArray $::env(RESULTS_DIR)/MockArrayTestbench.vcd
+log_cmd report_parasitic_annotation
+
+log_cmd report_power
+set vcd_file $::env(RESULTS_DIR)/MockArrayTestbench.vcd
+log_cmd read_vcd -scope TOP/MockArray $vcd_file
+
+puts "Total number of pins to be annotated: [llength [get_pins -hierarchical *]]"
+set no_vcd_activity {}
+set pins [get_pins -hierarchical *]
+foreach pin $pins {
+  set activity [get_property $pin activity]
+  set activity_origin [lindex $activity 2]
+  if {$activity_origin == "vcd"} {
+    continue
+  }
+  if {$activity_origin == "clock"} {
+    continue
+  }
+  set direction [get_property $pin direction]
+  if {$direction == "internal"} {
+    continue
+  }
+  lappend no_vcd_activity "[get_full_name $pin] $activity $direction"
+  if {[llength $no_vcd_activity] >= 10} {
+    break
+  }
+}
+
+if {[llength $no_vcd_activity] > 0} {
+  puts "Error: Listing [llength $no_vcd_activity] pins without activity from $vcd_file:"
+  foreach pin $no_vcd_activity {
+    puts $pin
+  }
+  exit 1
+}
 
 set ces {}
 for {set x 0} {$x < 8} {incr x} {


### PR DESCRIPTION
ces_0_0/io_lsbIns_1 exists in this .vcd file, but it doesn't have any activities set from vcd. The signal is 0 throughout the run.

To reproduce with sta only, untar and run [mock-array-read-vcd.tar.gz](https://drive.google.com/file/d/1OAmLDSzSwuVzv7sBwc2EbsLGRU_WpulL/view?usp=sharing)

The tar file was made from this PR and:

```
make DESIGN_CONFIG=designs/asap7/mock-array/config.mk final simulate power
```

Output:

```
[deleted]
read_vcd -scope TOP/MockArray ./results/asap7/mock-array/base/MockArrayTestbench.vcd
Annotated 1829222 pin activities.
Total number of pins to be annotated: 2339364
Error: Listing 10 pins without activity from ./results/asap7/mock-array/base/MockArrayTestbench.vcd:
ces_0_0/clock 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_1 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_2 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_3 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_4 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_5 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_6 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbIns_7 0.00000e+00 0.000 unknown input
ces_0_0/io_lsbOuts_0 0.00000e+00 0.000 unknown output
ces_0_0/io_lsbOuts_1 0.00000e+00 0.000 unknown output
[deleted]
```

![image](https://github.com/user-attachments/assets/01cfd83e-9710-41bb-b47a-5f47b76e6505)
