### PR TITLE
make: open/gui_ logs seconds for operations that take longer than 10 seconds

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -2,6 +2,15 @@ source $::env(SCRIPTS_DIR)/util.tcl
 # Read liberty files
 source $::env(SCRIPTS_DIR)/read_liberty.tcl
 
+proc log_seconds {cmd args} {
+  set start_time_seconds [clock seconds]
+  log_cmd $cmd {*}$args
+  set total [expr {[clock seconds] - $start_time_seconds}]
+  if {$total > 0} {
+    puts "  $total seconds"
+  }
+}
+
 # Read def
 if {[env_var_exists_and_non_empty DEF_FILE]} {
     # Read lef
@@ -16,7 +25,7 @@ if {[env_var_exists_and_non_empty DEF_FILE]} {
     read_def $input_file
 } else {
     set input_file $::env(ODB_FILE)
-    read_db $input_file
+    log_seconds read_db $input_file
 }
 
 proc read_timing {input_file} {
@@ -27,7 +36,7 @@ proc read_timing {input_file} {
   if {$sdc_file == ""} {
     set sdc_file $::env(SDC_FILE)
   }
-  read_sdc $sdc_file
+  log_seconds read_sdc $sdc_file
   if [file exists $::env(PLATFORM_DIR)/derate.tcl] {
     source $::env(PLATFORM_DIR)/derate.tcl
   }
@@ -39,22 +48,20 @@ proc read_timing {input_file} {
   }
   
   if {$design_stage >= 6 && [file exist $::env(RESULTS_DIR)/6_final.spef]} {
-    log_cmd read_spef $::env(RESULTS_DIR)/6_final.spef
+    log_seconds read_spef $::env(RESULTS_DIR)/6_final.spef
   } elseif {$design_stage >= 5} {
     if { [grt::have_routes] } {
-      log_cmd estimate_parasitics -global_routing
+      log_seconds estimate_parasitics -global_routing
     } else {
       puts "No global routing results available, skipping estimate_parasitics"
       puts "Load $::global_route_congestion_report for details"
     }
   } elseif {$design_stage >= 3} {
-    log_cmd estimate_parasitics -placement
+    log_seconds estimate_parasitics -placement
   }
 
-  puts -nonewline "Populating timing paths..."
   # Warm up OpenSTA, so clicking on timing related buttons reacts faster
-  set _tmp [find_timing_paths]
-  puts "OK"
+  log_seconds find_timing_paths
 }
 
 if {[ord::openroad_gui_compiled]} {
@@ -67,7 +74,7 @@ if {[env_var_equals GUI_TIMING 1]} {
   read_timing $input_file
   if {[gui::enabled]} {
     gui::select_chart "Endpoint Slack"
-    log_cmd gui::update_timing_report
+    log_seconds gui::update_timing_report
   }
 }
 


### PR DESCRIPTION
Example `make gui_cts` output for operations that take longer than 10 seconds.

This does make the logging output non-idempontent, let us see if that breaks any tests. For bazel-orfs it is not a problem, because the .log files are not a dependency on subsequent targets.

```
read_db .../4_cts.odb
  11 seconds
GUI_TIMING=1 reading timing, takes a little while for large designs...
read_sdc .../4_cts.sdc
  13 seconds
estimate_parasitics -placement
  345 seconds
gui::update_timing_report 
  952 seconds
```