### PR TITLE
[DO NOT REVIEW] synthesis: add SYNTH_STRIP to improve canonicalization

### DIFF
--- a/flow/scripts/synth_canonicalize.tcl
+++ b/flow/scripts/synth_canonicalize.tcl
@@ -2,5 +2,11 @@ source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 hierarchy -check -top $::env(DESIGN_NAME)
 # Get rid of unused modules
 opt_clean -purge
+
+if {$::env(SYNTH_STRIP)} {
+  puts "Stripping source code information"
+  attrmap -remove \src
+}
+
 # The hash of this file will not change if files not part of synthesis do not change
 write_rtlil $::env(RESULTS_DIR)/1_synth.rtlil

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -166,6 +166,16 @@ SYNTH_GUT:
     SRAMs, for instance.
   stages:
     - synth
+SYNTH_STRIP:
+  description: >
+    Strip all debug information, such as source and line numbers.
+
+    Use-case: avoid many hours of rebuilds in bazel in architectural
+    exploration where Verilog line numbers can change without RTL
+    changing.
+  stages:
+    - synth
+  default: 0
 SYNTH_HIERARCHICAL:
   description: >
     Enable to Synthesis hierarchically, otherwise considered flat synthesis.


### PR DESCRIPTION
@povik I was hoping that you could help me. I'm trying to reduce the number of rebuilds when working with bazel. I'm doing architectural exploration and this can move around the line numbers in the Verilog code, which results in an .rtlil file that changes, even when the underlying RTL does not change.

Is there a way to make the .rtlil maximally canonical so that I minimze the number of downstread ORFS builds?

```
make SYNTH_STRIP=1 clean_synth synth
```

Here are examples of lines that I'd like not to not emit or not change when I change line numbers in the Verilog files or .lib files when I invoke `write_rtlil`:

```
# Generated by Yosys 0.48 (git sha1 aaa534749, clang++ 18.1.3 -fPIC -O3)
attribute \src "/home/oyvind/OpenROAD-flow-scripts/flow/designs/src/gcd/gcd.v:109.1-320.10"
cell $_AND_ $auto$liberty.cc:108:parse_func_reduce$1
wire $eq$/home/oyvind/OpenROAD-flow-scripts/flow/designs/src/gcd/gcd.v:195$994_Y
connect \ZN $auto$rtlil.cc:2977:AndGate$2
```

