### PR TITLE
synth: nudge .rtlil towards cleaner and more canonical

### DIFF
--- a/flow/scripts/synth_canonicalize.tcl
+++ b/flow/scripts/synth_canonicalize.tcl
@@ -2,5 +2,8 @@ source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 hierarchy -check -top $::env(DESIGN_NAME)
 # Get rid of unused modules
 opt_clean -purge
+# This is reloaded in the next stage, reduce file size and nudge towards
+# more canonical version of .rtlil
+delete =A:liberty_cell
 # The hash of this file will not change if files not part of synthesis do not change
 write_rtlil $::env(RESULTS_DIR)/1_synth.rtlil


### PR DESCRIPTION
@povik A small step per your tip in https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2689#issuecomment-2602747185 and also a non-trivial reduction in size(the effect is the largest on smallest designs).

```
$ wc -l results/nangate45/gcd/*/1_synth.rtlil 
   990 results/nangate45/gcd/base/1_synth.rtlil
  9524 results/nangate45/gcd/master/1_synth.rtlil
 10514 total
```
