### PR TITLE
logging: stringly typed fixes

### DIFF
--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -1,11 +1,14 @@
 proc log_cmd {cmd args} {
   # log the command, escape arguments with spaces
-  puts -nonewline "$cmd[join [lmap arg $args {format " %s" [expr {[string match {* *} $arg] ? "\"$arg\"" : "$arg"}]}] ""]"
+  set log_cmd "$cmd[join [lmap arg $args {format " %s" [expr {[string match {* *} $arg] ? "\"$arg\"" : "$arg"}]}] ""]"
+  puts $log_cmd
   set start [clock seconds]
   $cmd {*}$args
   set time [expr {[clock seconds] - $start}]
   if {$time >= 5} {
-    puts -nonewline " ($time seconds)"
+    # Ideally we'd use a single line, but the command can output text
+    # and we don't want to mix it with the log, so output the time it took afterwards.
+    puts "Took $time seconds: $log_cmd"
   }
   puts ""
 }

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -1,6 +1,6 @@
 proc log_cmd {cmd args} {
   # log the command, escape arguments with spaces
-  puts -nonewline "$cmd[join [lmap arg $args {expr {[string match {* *} $arg] ? " \"$arg\"" : " $arg"}}] ""]"
+  puts -nonewline "$cmd[join [lmap arg $args {format " %s" [expr {[string match {* *} $arg] ? "\"$arg\"" : "$arg"}]}] ""]"
   set start [clock seconds]
   $cmd {*}$args
   set time [expr {[clock seconds] - $start}]


### PR DESCRIPTION
On master, wrong, missing space before "0":

```
repair_timing -setup_margin0
```

This PR fixes it:

```
repair_timing -setup_margin 0
```