### PR TITLE
Fix jenkins nightly pipeline so the build shows in openroad dashboard

### DIFF
--- a/jenkins/public_nightly.Jenkinsfile
+++ b/jenkins/public_nightly.Jenkinsfile
@@ -64,6 +64,8 @@ node {
     }
 
     stage ('Cleanup and Reporting') {
+        env.CHANGE_BRANCH = 'nightly'
+        env.BRANCH_NAME = 'nightly'
         finalReport(DOCKER_IMAGE);
     }
 


### PR DESCRIPTION
We've been having an issue in which the latest nightly builds were not showing up in the dashboard.
Turns out that in the scripts we use to upload the metadata, it uses the Jenkins environment variables `$CHANGE_BRANCH` and `$BRANCH_NAME` that are only available for multibranch pipelines which is not the case for our nightly build pipeline, making those variables `null` and thus not showing in the dashboard.

After replaying a few builds I got the [5033](https://jenkins.openroad.tools/job/OpenROAD-flow-scripts-Nightly-Public/5033) working and showing by just setting these 2 variables in the proper stage:
![image](https://github.com/user-attachments/assets/ddc01ef8-8dfb-40f5-abcf-cdce1b8b7227)
