### PR TITLE
mock-array: added report_activity_annotation -report_unannotated

### DIFF
--- a/flow/designs/asap7/mock-array/power.tcl
+++ b/flow/designs/asap7/mock-array/power.tcl
@@ -1,26 +1,27 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 foreach libFile $::env(LIB_FILES) {
   if {[lsearch -exact $::env(ADDITIONAL_LIBS) $libFile] == -1} {
     read_liberty $libFile
   }
 }
 
-read_verilog results/asap7/mock-array_Element/base/6_final.v
-read_verilog $::env(RESULTS_DIR)/6_final.v
-read_verilog $::env(PLATFORM_DIR)/verilog/stdcell/empty.v
+log_cmd read_verilog results/asap7/mock-array_Element/base/6_final.v
+log_cmd read_verilog $::env(RESULTS_DIR)/6_final.v
+log_cmd read_verilog $::env(PLATFORM_DIR)/verilog/stdcell/empty.v
+log_cmd link_design MockArray
 
-link_design MockArray
-
-read_sdc $::env(RESULTS_DIR)/6_final.sdc
-read_spef $::env(RESULTS_DIR)/6_final.spef
+log_cmd read_sdc $::env(RESULTS_DIR)/6_final.sdc
+log_cmd read_spef $::env(RESULTS_DIR)/6_final.spef
+puts "read_spef for ces_*_* macros"
 for {set x 0} {$x < 8} {incr x} {
   for {set y 0} {$y < 8} {incr y} {
     read_spef -path ces_${x}_${y} results/asap7/mock-array_Element/base/6_final.spef
   }
 }
 
-report_parasitic_annotation
-report_power
-read_vcd -scope TOP/MockArray $::env(RESULTS_DIR)/MockArrayTestbench.vcd
+log_cmd report_power
+log_cmd read_vcd -scope TOP/MockArray $::env(RESULTS_DIR)/MockArrayTestbench.vcd
 
 set ces {}
 for {set x 0} {$x < 8} {incr x} {
@@ -29,5 +30,9 @@ for {set x 0} {$x < 8} {incr x} {
   }
 }
 
+puts {report_power -instances [get_cells $ces]}
 report_power -instances [get_cells $ces]
-report_power
+log_cmd report_power
+
+log_cmd report_parasitic_annotation
+log_cmd report_activity_annotation -report_unannotated


### PR DESCRIPTION
Works:

```
read_verilog results/asap7/mock-array_Element/base/6_final.v
read_verilog ./results/asap7/mock-array/base/6_final.v
read_verilog /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/verilog/stdcell/empty.v
link_design MockArray
read_sdc ./results/asap7/mock-array/base/6_final.sdc
read_spef ./results/asap7/mock-array/base/6_final.spef
read_spef for ces_*_* macros
Group                  Internal  Switching    Leakage      Total
                          Power      Power      Power      Power (Watts)
----------------------------------------------------------------
Sequential             2.07e+00   2.05e-01   2.59e-05   2.28e+00  27.9%
Combinational          2.09e+00   3.26e+00   3.25e-05   5.35e+00  65.6%
Clock                  2.73e-01   2.55e-01   2.48e-06   5.28e-01   6.5%
Macro                  0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
Pad                    0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
----------------------------------------------------------------
Total                  4.43e+00   3.72e+00   6.06e-05   8.15e+00 100.0%
                          54.3%      45.7%       0.0%
report_power (97 seconds)
Annotated 2062114 pin activities.
read_vcd -scope TOP/MockArray ./results/asap7/mock-array/base/MockArrayTestbench.vcd (7 seconds)
report_power -instances [get_cells $ces]
   Internal  Switching    Leakage      Total
      Power      Power      Power      Power (Watts)
--------------------------------------------
   7.21e-02   6.12e-02   9.47e-07   1.33e-01 ces_3_6
[deleted]
   5.72e-02   4.56e-02   9.47e-07   1.03e-01 ces_0_7
Group                  Internal  Switching    Leakage      Total
                          Power      Power      Power      Power (Watts)
----------------------------------------------------------------
Sequential             7.42e-01   2.49e-03   3.00e-05   7.44e-01  57.6%
Combinational          7.04e-03   1.44e-02   5.83e-05   2.15e-02   1.7%
Clock                  2.73e-01   2.55e-01   2.48e-06   5.28e-01  40.9%
Macro                  0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
Pad                    0.00e+00   0.00e+00   0.00e+00   0.00e+00   0.0%
----------------------------------------------------------------
Total                  1.02e+00   2.72e-01   9.09e-05   1.29e+00 100.0%
                          78.9%      21.1%       0.0%
report_power (33 seconds)
Found 9030 unannotated drivers.
Found 3976 partially unannotated drivers.
report_parasitic_annotation
vcd         2062114
unannotated     0
Unannotated pins:
report_activity_annotation -report_unannotated
```
