### PR TITLE
Revert "mock-array: add --coverage-toggle report in simulation"

### DIFF
--- a/flow/designs/asap7/mock-array/simulate.sh
+++ b/flow/designs/asap7/mock-array/simulate.sh
@@ -22,8 +22,6 @@ verilator -Wall --cc \
   -Wno-DECLFILENAME \
   -Wno-UNUSEDSIGNAL \
   -Wno-PINMISSING \
-  --coverage-toggle \
-  --coverage-underscore \
   --Mdir $OBJ_DIR \
   --top-module MockArray \
   --trace \
@@ -33,8 +31,8 @@ verilator -Wall --cc \
   $PLATFORM_DIR/verilog/stdcell/asap7sc7p5t_SIMPLE_RVT_TT_201020.v \
   $PLATFORM_DIR/verilog/stdcell/dff.v \
   $PLATFORM_DIR/verilog/stdcell/empty.v \
-  $POST_DIR/MockArrayFinal.v \
-  $POST_DIR/MockArrayElement.v \
+  $FLOW_HOME/results/asap7/mock-array/base/6_final.v \
+  $FLOW_HOME/results/asap7/mock-array_Element/base/6_final.v \
   --exe \
   $FLOW_HOME/designs/src/mock-array/simulate.cpp
 
@@ -43,4 +41,3 @@ make -j16 -C $OBJ_DIR -f VMockArray.mk
 
 # Run the simulation
 $OBJ_DIR/VMockArray
-verilator_coverage $RESULTS_DIR/coverage.dat --annotate $REPORTS_DIR/

--- a/flow/designs/src/mock-array/simulate.cpp
+++ b/flow/designs/src/mock-array/simulate.cpp
@@ -89,9 +89,6 @@ int main(int argc, char** argv) {
     vcd->flush();
     vcd->close();
 
-    std::string coverage_file = std::string(getenv("RESULTS_DIR")) + "/coverage.dat";
-    Verilated::threadContextp()->coveragep()->write(coverage_file.c_str());
-
     top->final();
     delete top;
     return 0;


### PR DESCRIPTION
slows down things too much(10x?), not used. The idea was that this *might* be used to generate a .saif file.

This reverts commit 3673b2ab66caa3d9381423a54cf05f2dd0638773.