### PR TITLE
sky130hd/uW: allow mpl2 SA boundary pushing

### DIFF
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -23,7 +23,6 @@ export ADDITIONAL_LIBS = $(wildcard $(microwatt_DIR)/lib/*.lib)
 
 export SYNTH_HIERARCHICAL = 1
 
-export RTLMP_BOUNDARY_WT = 0
 export MACRO_PLACE_HALO = 100 100
 export MACRO_PLACE_CHANNEL = 200 200
 


### PR DESCRIPTION
Running a new Test-CI for #2553 resulted in a GRT congestion failure even with the routing layer adjustment decrease made in [#5809](https://github.com/The-OpenROAD-Project/OpenROAD/pull/5809).

As I was investigating, I realized that with the IO constraints PR merged, we can turn on the mpl2 SA boundary pushing again - which is manually turned off for uW. The problematic pin access blockages used inside the macro placer that were the root for this default config no longer exist.