### PR TITLE
flow: designs: ihp-sg13g2: i2c-gpio-expander: Fix missing IO pwr/gnd

### DIFF
--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/pad.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/pad.tcl
@@ -76,8 +76,8 @@ place_pad -row IO_WEST -location [calc_vertical_pad_location 0 5] {sg13g2_IOPad_
 place_pad -row IO_WEST -location [calc_vertical_pad_location 1 5] {sg13g2_IOPad_io_gpio_6} -master sg13g2_IOPadInOut16mA
 # IO pin io_gpio_7
 place_pad -row IO_WEST -location [calc_vertical_pad_location 2 5] {sg13g2_IOPad_io_gpio_7} -master sg13g2_IOPadInOut16mA
-place_pad -row IO_WEST -location [calc_vertical_pad_location 3 5] {sg13g2_IOPadVss_west_3} -master sg13g2_IOPadVss
-place_pad -row IO_WEST -location [calc_vertical_pad_location 4 5] {sg13g2_IOPadVdd_west_4} -master sg13g2_IOPadVdd
+place_pad -row IO_WEST -location [calc_vertical_pad_location 3 5] {sg13g2_IOPadIOVss_west_3} -master sg13g2_IOPadIOVss
+place_pad -row IO_WEST -location [calc_vertical_pad_location 4 5] {sg13g2_IOPadIOVdd_west_4} -master sg13g2_IOPadIOVdd
 # Place Corner Cells and Filler
 place_corners sg13g2_Corner
 

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
@@ -11,6 +11,10 @@ add_global_connection -net {VSS} -pin_pattern {^VSSE$}
 add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
 add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
 
+# padframe io power pins
+add_global_connection -net {IOVDD} -pin_pattern {^iovdd$} -power
+add_global_connection -net {IOVSS} -pin_pattern {^iovss$} -ground
+
 global_connect
 
 # core voltage domain


### PR DESCRIPTION
Change two IOPad{Vss,Vdd} pads to IOPadIO{Vss,Vdd}, since only those are connected to the iovss and iovdd nets.

Also connect the iovss and iovdd nets during power routing.