### PR TITLE
results: add 3_2_place_iop.tcl and 2_3_floorplan_macro.tcl to results

### DIFF
--- a/flow/scripts/io_placement.tcl
+++ b/flow/scripts/io_placement.tcl
@@ -5,6 +5,7 @@ if {![env_var_equals IS_CHIP 1]} {
   load_design 3_1_place_gp_skip_io.odb 2_floorplan.sdc
   source $::env(SCRIPTS_DIR)/io_placement_util.tcl
   write_db $::env(RESULTS_DIR)/3_2_place_iop.odb
+  write_pin_placement $::env(RESULTS_DIR)/3_2_place_iop.tcl
 } else {
   log_cmd exec cp $::env(RESULTS_DIR)/3_1_place_gp_skip_io.odb $::env(RESULTS_DIR)/3_2_place_iop.odb
 }

--- a/flow/scripts/macro_place.tcl
+++ b/flow/scripts/macro_place.tcl
@@ -5,3 +5,4 @@ load_design 2_2_floorplan_io.odb 2_1_floorplan.sdc
 source $::env(SCRIPTS_DIR)/macro_place_util.tcl
 
 write_db $::env(RESULTS_DIR)/2_3_floorplan_macro.odb
+write_macro_placement $::env(RESULTS_DIR)/2_3_floorplan_macro.tcl


### PR DESCRIPTION
Useful when testing a failure in master to check if it is due to macro or pin placement

I wanted to try this on: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2694

Confirming that the failure is not in synthesis. A slight change in initial conditions cause a significant change in IO placement, which causes a grt failure.

First I run on master with https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2727

```
make FLOW_VARIANT=master DESIGN_CONFIG=designs/asap7/ethmac_lvt/config.mk place
make FLOW_VARIANT=master DESIGN_CONFIG=designs/asap7/ethmac_lvt/config.mk gui_3_2_place_iop
```

![image](https://github.com/user-attachments/assets/d5d5a853-6aa0-4f56-969b-43489045da66)


Then I run with this https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2694, but with macro and pin placement from master and pin placement is unchanged:

```
make DESIGN_CONFIG=designs/asap7/ethmac_lvt/config.mk IO_CONSTRAINTS=results/asap7/ethmac_lvt/master/3_2_place_iop.tcl do-3_2_place_iop
```

![image](https://github.com/user-attachments/assets/123ca98c-8312-40f3-a76e-a75da17a602a)


global route then passes:

![image](https://github.com/user-attachments/assets/340b215c-0b46-404c-bd96-11865fd2969e)
