### PR TITLE
asap7/ethmac_lvt: constrain pins to edges to make test case less volatile

### DIFF
--- a/flow/designs/asap7/ethmac_lvt/config.mk
+++ b/flow/designs/asap7/ethmac_lvt/config.mk
@@ -22,3 +22,8 @@ export ADDITIONAL_LIBS        = $(LIB_DIR)/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib
 export ADDITIONAL_GDS         = $(PLATFORM_DIR)/gds/asap7sc7p5t_28_R_220121a.gds
 export ADDITIONAL_LEFS        = $(PLATFORM_DIR)/lef/asap7sc7p5t_28_R_1x_220121a.lef
 export RECOVER_POWER          = 1
+
+# Constrain the pins somewhat so a small change in initial conditions doesn't
+# completely change the test-case by moving all the pins to completely
+# different edges.
+export IO_CONSTRAINTS = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/io.tcl

--- a/flow/designs/asap7/ethmac_lvt/io.tcl
+++ b/flow/designs/asap7/ethmac_lvt/io.tcl
@@ -1,0 +1,19 @@
+proc match_pins { regex {direction .*} {is_clock 0}} {
+    set pins {}
+    # The regex for get_ports is not the tcl regex
+    foreach pin [get_ports -regex $regex] {
+        set name [get_property $pin name]
+        # We want the Tcl regex
+        if {![regexp $regex $name]} {
+            continue
+        }
+        lappend pins $name
+    }
+    return $pins
+}
+
+# wishbone pins on the left
+set left_pints m_wb_
+set_io_pin_constraint -region left:* -pin_names [match_pins $left_pints.*]
+# the rest of the pins on top
+set_io_pin_constraint -region top:* -pin_names [match_pins ^(?!$left_pints).*]


### PR DESCRIPTION
Slightly different initial conditions can lead to completely different pin placements, which can lead to real global routing failures.

Instead of letting pins be on any edge, constrain the test case a bit by having wishbone (a guess as to what wb_ means) to left edge and the rest of the pins to the top edge.