### PR TITLE
added option for padding == 0 in asap7 mock-alu AutoTuner config

### DIFF
--- a/flow/designs/asap7/mock-alu/autotuner.json
+++ b/flow/designs/asap7/mock-alu/autotuner.json
@@ -35,16 +35,16 @@
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
-            1,
-            5
+            0,
+            4
         ],
         "step": 1
     },
     "CELL_PAD_IN_SITES_DETAIL_PLACEMENT": {
         "type": "int",
         "minmax": [
-            1,
-            5
+            0,
+            4
         ],
         "step": 1
     },


### PR DESCRIPTION
Updated asap7 mock-alu AutoTuner config to support detailed/global placement padding of 0.

63 AutoTuner errors all of type DRT-0255| (Maze Route cannot find path of net...)
