### PR TITLE
Removed _FR_GR_OVERFLOW from autotuner.json files, since no-op

### DIFF
--- a/flow/designs/gf180/ibex/autotuner.json
+++ b/flow/designs/gf180/ibex/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/gf180/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/gf180/fastroute.tcl"
 }

--- a/flow/designs/gf180/jpeg/autotuner.json
+++ b/flow/designs/gf180/jpeg/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/gf180/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/gf180/fastroute.tcl"
 }

--- a/flow/designs/ihp-sg13g2/aes/autotuner.json
+++ b/flow/designs/ihp-sg13g2/aes/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl"
 }

--- a/flow/designs/ihp-sg13g2/gcd/autotuner.json
+++ b/flow/designs/ihp-sg13g2/gcd/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl"
 }

--- a/flow/designs/ihp-sg13g2/ibex/autotuner.json
+++ b/flow/designs/ihp-sg13g2/ibex/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl"
 }

--- a/flow/designs/ihp-sg13g2/jpeg/autotuner.json
+++ b/flow/designs/ihp-sg13g2/jpeg/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl"
 }

--- a/flow/designs/ihp-sg13g2/spi/autotuner.json
+++ b/flow/designs/ihp-sg13g2/spi/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/ihp-sg13g2/fastroute.tcl"
 }

--- a/flow/designs/sky130hd/aes/autotuner.json
+++ b/flow/designs/sky130hd/aes/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl"
 }

--- a/flow/designs/sky130hd/gcd/autotuner.json
+++ b/flow/designs/sky130hd/gcd/autotuner.json
@@ -80,13 +80,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl"
 }

--- a/flow/designs/sky130hd/ibex/autotuner.json
+++ b/flow/designs/sky130hd/ibex/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "../../../platforms/sky130hd/fastroute.tcl"
 }

--- a/flow/designs/sky130hd/jpeg/autotuner.json
+++ b/flow/designs/sky130hd/jpeg/autotuner.json
@@ -88,13 +88,5 @@
         ],
         "step": 1
     },
-    "_FR_FILE_PATH": "fastroute.tcl",
-    "_FR_GR_OVERFLOW": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 0
-    }
+    "_FR_FILE_PATH": "fastroute.tcl"
 }


### PR DESCRIPTION
Removed AutoTuner variable _FR_GR_OVERFLOW which isn't referenced in the AT code, nor in the ORFS scripts