### PR TITLE
mock-array: fix large negative slack for Element

### DIFF
--- a/flow/designs/src/mock-array/Element.v
+++ b/flow/designs/src/mock-array/Element.v
@@ -52,10 +52,10 @@ module Element(
   reg [63:0] REG_5;
   reg [63:0] REG_6;
   reg [63:0] REG_7;
-  reg [31:0] io_outs_left_REG;
-  reg [31:0] io_outs_up_REG;
-  reg [31:0] io_outs_right_REG;
-  reg [31:0] io_outs_down_REG;
+  reg [15:0] io_outs_left_REG;
+  reg [15:0] io_outs_up_REG;
+  reg [15:0] io_outs_right_REG;
+  reg [15:0] io_outs_down_REG;
   reg  REG_8;
   multiplier io_outs_left_mult (
     .a(io_outs_left_mult_a),
@@ -85,10 +85,10 @@ module Element(
     .rst(io_outs_down_mult_rst),
     .clk(io_outs_down_mult_clk)
   );
-  assign io_outs_down = {{32'd0}, io_outs_down_REG};
-  assign io_outs_right = {{32'd0}, io_outs_right_REG};
-  assign io_outs_up = {{32'd0}, io_outs_up_REG};
-  assign io_outs_left = {{32'd0}, io_outs_left_REG};
+  assign io_outs_down = {{48'd0}, io_outs_down_REG};
+  assign io_outs_right = {{48'd0}, io_outs_right_REG};
+  assign io_outs_up = {{48'd0}, io_outs_up_REG};
+  assign io_outs_left = {{48'd0}, io_outs_left_REG};
   assign io_lsbOuts_0 = io_lsbIns_1;
   assign io_lsbOuts_1 = io_lsbIns_2;
   assign io_lsbOuts_2 = io_lsbIns_3;
@@ -122,10 +122,10 @@ module Element(
     REG_5 <= io_ins_right;
     REG_6 <= io_ins_left;
     REG_7 <= io_ins_up;
-    io_outs_left_REG <= io_outs_left_mult_o;
-    io_outs_up_REG <= io_outs_up_mult_o;
-    io_outs_right_REG <= io_outs_right_mult_o;
-    io_outs_down_REG <= io_outs_down_mult_o;
+    io_outs_left_REG <= io_outs_left_mult_o[15:0];
+    io_outs_up_REG <= io_outs_up_mult_o[15:0];
+    io_outs_right_REG <= io_outs_right_mult_o[15:0];
+    io_outs_down_REG <= io_outs_down_mult_o[15:0];
     REG_8 <= io_lsbIns_4;
   end
 endmodule

--- a/flow/designs/src/mock-array/src/main/scala/MockArray.scala
+++ b/flow/designs/src/mock-array/src/main/scala/MockArray.scala
@@ -97,7 +97,8 @@ class MockArray(width: Int, height: Int, singleElementWidth: Int)
         // save some area and complexity by not having reset
         mult.io.rst := false.B
         mult.io.clk := clock
-        mult.io.o
+        // reduce output bit-width until we slight negative slack
+        mult.io.o(15, 0)
       })
     }
 


### PR DESCRIPTION
we want slight negative slack for testing purposes.

Ended up with the simplest solution I could think of, just reduce the output width of the multiplier and let synthesis optimize away the rest.

The simpler Element also speeds up Verilator significantly.

![image](https://github.com/user-attachments/assets/cd236245-b098-497a-a894-6111e25c1dd2)
