### PR TITLE
grt: add logging

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -58,10 +58,10 @@ proc global_route_helper {} {
 
     # Running DPL to fix overlapped instances
     # Run to get modified net by DPL
-    global_route -start_incremental
-    detailed_placement
+    log_cmd global_route -start_incremental
+    log_cmd detailed_placement
     # Route only the modified net by DPL
-    global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_design.rpt
+    log_cmd global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_design.rpt
 
     # Repair timing using global route parasitics
     puts "Repair setup and hold violations..."
@@ -75,16 +75,17 @@ proc global_route_helper {} {
 
     # Running DPL to fix overlapped instances
     # Run to get modified net by DPL
-    global_route -start_incremental
-    detailed_placement
+    log_cmd global_route -start_incremental
+    log_cmd detailed_placement
     # Route only the modified net by DPL
-    global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
+    log_cmd global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
   }
 
-  global_route -start_incremental
-  recover_power
+
+  log_cmd global_route -start_incremental
+  log_cmd recover_power
   # Route the modified nets by rsz journal restore
-  global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_recover_power.rpt
+  log_cmd global_route -end_incremental -congestion_report_file $::env(REPORTS_DIR)/congestion_post_recover_power.rpt
 
   if {![env_var_equals SKIP_ANTENNA_REPAIR 1]} {
     puts "Repair antennas..."


### PR DESCRIPTION
global routing normally fails in the main global route, but it can fail incremental global routing and power recovery.

Add logging of all global route invocations to reduce confusion upon these more rare failures and also make it easier to follow the incremental global routing.