### PR TITLE
env.sh: install folder should be before dependencies folder

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -11,9 +11,9 @@ fi
 export OPENROAD=${DIR}/tools/OpenROAD
 echo "OPENROAD: ${OPENROAD}"
 
+export PATH=${DIR}/dependencies/bin:$PATH
 export PATH=${DIR}/tools/install/OpenROAD/bin:$PATH
 export PATH=${DIR}/tools/install/yosys/bin:$PATH
-export PATH=${DIR}/dependencies/bin:$PATH
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   export PATH="/Applications/KLayout/klayout.app/Contents/MacOS:$PATH"


### PR DESCRIPTION
Reduces confusion: Makefile and path now use the same version of yosys