### PR TITLE
Remove CORE_MARGIN from ihp-sg13g2 autotuner runs

### DIFF
--- a/flow/designs/ihp-sg13g2/aes/autotuner.json
+++ b/flow/designs/ihp-sg13g2/aes/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/gcd/autotuner.json
+++ b/flow/designs/ihp-sg13g2/gcd/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/ibex/autotuner.json
+++ b/flow/designs/ihp-sg13g2/ibex/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/spi/autotuner.json
+++ b/flow/designs/ihp-sg13g2/spi/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [


### PR DESCRIPTION
Updated core margin based on the PDN Tcl is 16.5 = (2 * width) + (1 * spacing) + core_offset. Width is 5.0, spacing is 2.0 and core_offset is 4.5. Core margin was previously 2 and all autotuner runs failed in PDN.

Here are the AutoTuner run errors:

 ### ibex
| Stage | Error Code | Error Description | Count |
| ---- | -----| ----| ----|
| GRT | GRT-0116 | Global routing finished with congestion | 8|
| DPL |  DPL-0036 | Detailed placement failed | 1 |
| DRT | DRT-02026 | checkConnectivity error. | 1|


### spi

| Stage | Error Code | Error Description | Count |
| ---- | -----| ----| ----|
| IFP | PDN-0185 | Insufficient width to add straps | 6 |
| DPL |  DPL-0036 | Detailed placement failed | 1 |

@maliberty @osamahammad21 , for the DRT/checkConnectivity error, do you want me to pack up the data as another example of https://github.com/The-OpenROAD-Project/OpenROAD/issues/6604? The other option is that I can keep that configuration around and then run it once Osama has a fix for 6604 and then just verify it using an updated OR.
