### PR TITLE
[Autotuner] openroad_autotuner entrypoint

### DIFF
--- a/docs/user/InstructionsForAutoTuner.md
+++ b/docs/user/InstructionsForAutoTuner.md
@@ -124,23 +124,23 @@ The following commands should be run from `./tools/AutoTuner`.
 
 #### Tune only 
 
-* AutoTuner: `python3 -m autotuner.distributed tune -h`
+* AutoTuner: `openroad_autotuner tune -h`
 
 Example:
 
 ```shell
-python3 -m autotuner.distributed --design gcd --platform sky130hd \
+openroad_autotuner --design gcd --platform sky130hd \
                        --config ../../flow/designs/sky130hd/gcd/autotuner.json \
                        tune --samples 5
 ```
 #### Sweep only 
 
-* Parameter sweeping: `python3 -m autotuner.distributed sweep -h`
+* Parameter sweeping: `openroad_autotuner sweep -h`
 
 Example:
 
 ```shell
-python3 -m autotuner.distributed --design gcd --platform sky130hd \
+openroad_autotuner --design gcd --platform sky130hd \
                        --config src/autotuner/distributed-sweep-example.json \
                        sweep
 ```

--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -28,6 +28,9 @@ if [ "$PLATFORM" == "asap7" ] && [ "$DESIGN_NAME" == "gcd" ]; then
 
   echo "Running AutoTuner resume test (only once)"
   python3 -m unittest tools.AutoTuner.test.resume_check.ResumeCheck.test_tune_resume
+
+  echo "Running AutoTuner binary check (only once)"
+  openroad_autotuner -h
 fi
 
 exit $ret

--- a/tools/AutoTuner/pyproject.toml
+++ b/tools/AutoTuner/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 requires-python = ">= 3.8"
 dynamic = ["dependencies", "optional-dependencies"]
 
+[project.scripts]
+openroad_autotuner = "autotuner.distributed:main"
+
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 optional-dependencies.dev = { file = ["requirements-dev.txt"] }

--- a/tools/AutoTuner/src/autotuner/distributed.py
+++ b/tools/AutoTuner/src/autotuner/distributed.py
@@ -648,5 +648,6 @@ def main():
     elif args.mode == "sweep":
         sweep()
 
+
 if __name__ == "__main__":
     main()

--- a/tools/AutoTuner/src/autotuner/distributed.py
+++ b/tools/AutoTuner/src/autotuner/distributed.py
@@ -3,25 +3,25 @@ This scripts handles sweeping and tuning of OpenROAD-flow-scripts parameters.
 Dependencies are documented in pip format at distributed-requirements.txt
 
 For both sweep and tune modes:
-    python3 -m autotuner.distributed -h
+    openroad_autotuner -h
 
 Note: the order of the parameters matter.
 Arguments --design, --platform and --config are always required and should
 precede the <mode>.
 
 AutoTuner:
-    python3 -m autotuner.distributed tune -h
-    python3 -m autotuner.distributed --design gcd --platform sky130hd \
+    openroad_autotuner tune -h
+    openroad_autotuner --design gcd --platform sky130hd \
                            --config ../designs/sky130hd/gcd/autotuner.json \
                            tune
     Example:
 
 Parameter sweeping:
-    python3 -m autotuner.distributed sweep -h
+    openroad_autotuner sweep -h
     Example:
-    python3 -m autotuner.distributed --design gcd --platform sky130hd \
-                           --config distributed-sweep-example.json \
-                           sweep
+    openroad_autotuner --design gcd --platform sky130hd \
+                       --config distributed-sweep-example.json \
+                       sweep
 """
 
 import argparse
@@ -594,7 +594,7 @@ def sweep():
     print("[INFO TUN-0010] Sweep complete.")
 
 
-if __name__ == "__main__":
+def main():
     args = parse_arguments()
 
     # Read config and original files before handling where to run in case we
@@ -647,3 +647,6 @@ if __name__ == "__main__":
             sys.exit(1)
     elif args.mode == "sweep":
         sweep()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Maintains backward compatibility with original `python3 -m autotuner.distributed ...` interface, gives an option for a simpler entrypoint for CLI-based users