### PR TITLE
synth: replace silent error with some sort of error

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -47,7 +47,7 @@ renames -wire
 opt -purge
 
 # Technology mapping of adders
-if {[env_var_exists_and_non_empty ADDER_MAP_FILE] && [file isfile $::env(ADDER_MAP_FILE)]} {
+if {[env_var_exists_and_non_empty ADDER_MAP_FILE]} {
   # extract the full adders
   extract_fa
   # map full adders


### PR DESCRIPTION
If ADDER_MAP_FILE is not a file, then produce an error instead of silence.

Broken, an error should have been produced:

```
$ git log -1
commit 9325d2c0fe242ce6b98c40376405e4bb23132553 (HEAD, origin/master, origin/HEAD)
Merge: cea8b0ee 3e38a596
Author: Matt Liberty <mliberty@precisioninno.com>
Date:   Sat Feb 8 01:40:24 2025 +0000

    Merge pull request #2804 from The-OpenROAD-Project-staging/port-ibex-jpeg-intel16
    
    Ported ibex and jpeg from intel22 to intel16
$ make ADDER_MAP_FILE=blah do-yosys
[no error]
```

Fixed, an error is shown:

```
$ git fetch origin pull/2793/head && git checkout FETCH_HEAD && git log -1
[deleted]
commit 84269c8ca39ba3a00a62e955994abcda861fedd6 (HEAD)
Author: Øyvind Harboe <oyvind.harboe@zylin.com>
Date:   Thu Feb 6 22:15:53 2025 +0100

    synth: replace silent error with some sort of error
    
    If ADDER_MAP_FILE is not a file, then produce an error instead of
    silence:
    
    $ make ADDER_MAP_FILE=blah do-yosys
    [deleted]
    ERROR: Can't open input file `blah' for reading: No such file or directory
    ERROR: TCL interpreter returned an error: Yosys command produced an error
    
    Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
$ make ADDER_MAP_FILE=blah do-yosys
[deleted]
ERROR: Can't open input file `blah' for reading: No such file or directory ERROR: TCL interpreter returned an error: Yosys command produced an error
[deleted]
make: *** [Makefile:448: do-yosys] Error 1
$ 
```
