### PR TITLE
makefile: improve  out of ORFS tree use-case

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -123,7 +123,7 @@ SHELL          := /usr/bin/env bash
 #   location
 # - default is current install / clone directory
 ifeq ($(origin FLOW_HOME), undefined)
-FLOW_HOME := $(shell pwd)
+FLOW_HOME := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
 endif
 export FLOW_HOME
 


### PR DESCRIPTION
FLOW_HOME now defaults to the folder of the Makefile, not pwd.

To use ORFS for a project that is out of tree, no need to set FLOW_HOME, simply invoke as:

    make --file=~/OpenROAD-flow-scripts/flow/Makefile DESIGN_CONFIG=mydesign/config.mk ...
