### PR TITLE
Enabled code coverage in AutoTuner smoke tests

### DIFF
--- a/tools/AutoTuner/test/autotuner_test_utils.py
+++ b/tools/AutoTuner/test/autotuner_test_utils.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+
+
+class AutoTunerTestUtils:
+    @staticmethod
+    def get_exec_cmd():
+        """
+        Returns the execution command based on whether this is a coverage run or
+        not.
+
+        Note that you need to run coverage combine after the runs complete to
+        get the coverage of the parent plus the child invocations
+        """
+
+        if "COVERAGE_RUN" in os.environ:
+            exec = "coverage run --parallel-mode --omit=*/site-packages/*,*/dist-packages/*"
+        else:  # pragma: no cover
+            exec = "python3"
+        return exec + " -m autotuner.distributed"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print(AutoTunerTestUtils.get_exec_cmd())

--- a/tools/AutoTuner/test/ref_file_check.py
+++ b/tools/AutoTuner/test/ref_file_check.py
@@ -1,38 +1,70 @@
 import unittest
 import subprocess
 import os
-
-cur_dir = os.path.dirname(os.path.abspath(__file__))
-src_dir = os.path.join(cur_dir, "../src/autotuner")
-orfs_dir = os.path.join(cur_dir, "../../../flow")
-os.chdir(src_dir)
+from autotuner_test_utils import AutoTunerTestUtils
 
 
 class RefFileCheck(unittest.TestCase):
-    # only test 1 platform/design.
-    platform = "asap7"
-    design = "gcd"
+    """
+    Tests situations where a referenced file (SDC or FastRoute) is not
+    defined in the AutoTuner config
+    """
 
     def setUp(self):
-        configs = [
-            "../../test/files/no_sdc_ref.json",
-            "../../test/files/no_fr_ref.json",
-        ]
-        self.commands = [
-            f"python3 distributed.py"
-            f" --design {self.design}"
-            f" --platform {self.platform}"
-            f" --config {c}"
-            f" tune --samples 1"
-            for c in configs
-        ]
+        self._cur_dir = os.path.dirname(os.path.abspath(__file__))
+        src_dir = os.path.join(self._cur_dir, "../src")
+        os.chdir(src_dir)
 
-    # Make this a test case
-    def test_files(self):
-        for c in self.commands:
-            out = subprocess.run(c, shell=True)
-            failed = out.returncode != 0
-            self.assertTrue(failed)
+        self._exec = AutoTunerTestUtils.get_exec_cmd()
+
+    def _execute_autotuner(self, platform, design, config_file, error_code=None):
+        full_path = os.path.abspath(os.path.join(self._cur_dir, config_file))
+
+        cmd = f"{self._exec} --design {design} --platform {platform} --config {full_path} tune --samples 1"
+
+        out = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+        failed = out.returncode != 0
+        self.assertTrue(failed, f"AT run with {config_file} passed")
+        if error_code:
+            self.assertTrue(
+                error_code in out.stdout,
+                f"Didn't find error code {error_code} in output '{out.stdout}'",
+            )
+
+    def test_asap_gcd_no_sdc(self):
+        """
+        Tests when SDC file is not defined, which is an error for all
+        platforms and designs
+        """
+
+        platform = "asap7"
+        design = "gcd"
+        config_file = "files/no_sdc_ref.json"
+        error_code = "[ERROR TUN-0020] No SDC reference"
+        self._execute_autotuner(platform, design, config_file, error_code)
+
+    def test_asap_gcd_no_fr(self):
+        """
+        Tests when FastRoute file is not defined, which is not an error for
+        asap platform. This test fails anyway
+        """
+
+        platform = "asap7"
+        design = "gcd"
+        config_file = "files/no_fr_ref.json"
+        self._execute_autotuner(platform, design, config_file)
+
+    def test_ihp_gcd_no_fr(self):
+        """
+        Tests when FastRoute file is not defined, which is not an error for
+        any non-asap7 platform.
+        """
+
+        platform = "ihp-sg13g2"
+        design = "gcd"
+        config_file = "files/no_fr_ref.json"
+        error_code = "[ERROR TUN-0021] No FastRoute Tcl"
+        self._execute_autotuner(platform, design, config_file, error_code)
 
 
 if __name__ == "__main__":

--- a/tools/AutoTuner/test/resume_check.py
+++ b/tools/AutoTuner/test/resume_check.py
@@ -2,11 +2,12 @@ import unittest
 import subprocess
 import os
 import time
+from autotuner_test_utils import AutoTunerTestUtils
 
 from contextlib import contextmanager
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
-src_dir = os.path.join(cur_dir, "../src/autotuner")
+src_dir = os.path.join(cur_dir, "../src")
 orfs_dir = os.path.join(cur_dir, "../../../flow")
 os.chdir(src_dir)
 
@@ -45,8 +46,9 @@ class ResumeCheck(unittest.TestCase):
         # Cast to 1 decimal place
         res_per_trial = float("{:.1f}".format(self.num_cpus / self.samples))
         options = ["", "--resume"]
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
         self.commands = [
-            f"python3 distributed.py"
+            f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --config {self.config}"

--- a/tools/AutoTuner/test/smoke_test_algo_eval.py
+++ b/tools/AutoTuner/test/smoke_test_algo_eval.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import os
+from autotuner_test_utils import AutoTunerTestUtils
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 orfs_dir = os.path.join(cur_dir, "../../../flow")
@@ -19,8 +20,9 @@ class BaseAlgoEvalSmokeTest(unittest.TestCase):
         _algo = ["hyperopt", "ax", "optuna", "pbt", "random"]
         _eval = ["default", "ppa-improv"]
         self.matrix = [(a, e) for a in _algo for e in _eval]
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
         self.commands = [
-            f"python3 -m autotuner.distributed"
+            f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --experiment {self.experiment}"

--- a/tools/AutoTuner/test/smoke_test_sample_iteration.py
+++ b/tools/AutoTuner/test/smoke_test_sample_iteration.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import os
+from autotuner_test_utils import AutoTunerTestUtils
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -16,8 +17,9 @@ class BaseSampleIterationSmokeTest(unittest.TestCase):
         )
         self.experiment = f"smoke-test-sample-iteration-{self.platform}"
         self.matrix = [(5, 1), (1, 5), (2, 2), (1, 1)]
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
         self.commands = [
-            f"python3 -m autotuner.distributed"
+            f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --experiment {self.experiment}"

--- a/tools/AutoTuner/test/smoke_test_sweep.py
+++ b/tools/AutoTuner/test/smoke_test_sweep.py
@@ -2,6 +2,7 @@ import unittest
 import subprocess
 import os
 import json
+from autotuner_test_utils import AutoTunerTestUtils
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -30,8 +31,9 @@ class BaseSweepSmokeTest(unittest.TestCase):
         core = os.cpu_count()
         self.jobs = 4 if core >= 4 else core
         self.experiment = f"smoke-test-sweep-{self.platform}"
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
         self.command = (
-            "python3 -m autotuner.distributed"
+            f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --experiment {self.experiment}"

--- a/tools/AutoTuner/test/smoke_test_tune.py
+++ b/tools/AutoTuner/test/smoke_test_tune.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import os
+from autotuner_test_utils import AutoTunerTestUtils
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -15,8 +16,9 @@ class BaseTuneSmokeTest(unittest.TestCase):
             f"../../../flow/designs/{self.platform}/{self.design}/autotuner.json",
         )
         self.experiment = f"smoke-test-tune-{self.platform}"
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
         self.command = (
-            "python3 -m autotuner.distributed"
+            f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --experiment {self.experiment}"


### PR DESCRIPTION
1. Enabled code coverage in AutoTuner smoke tests. Had to pull executable name into its own method so that there's one place that controls how we invoke the AutoTuner (current coverage is 66% statement: 100% in the test files, 66% in distributed.py and 45% in utils). I have a couple of branches that pulls code out into their own classes where we can unit test them more fully.
2. Includes fix to PPAImprov.evaluate which should allow us to add smoke_test_algo_eval.py to the CI tests