### PR TITLE
Removed invariant minmax from asap7 aes/aes-block/ibex autotuner configs

### DIFF
--- a/flow/designs/asap7/aes-block/autotuner.json
+++ b/flow/designs/asap7/aes-block/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [

--- a/flow/designs/asap7/aes/autotuner.json
+++ b/flow/designs/asap7/aes/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
@@ -63,14 +55,6 @@
             0.2
         ],
         "step": 0
-    },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
     },
    "CTS_CLUSTER_SIZE": {
         "type": "int",

--- a/flow/designs/asap7/ibex/autotuner.json
+++ b/flow/designs/asap7/ibex/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
@@ -63,14 +55,6 @@
             0.2
         ],
         "step": 0
-    },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
     },
     "CTS_CLUSTER_SIZE": {
         "type": "int",


### PR DESCRIPTION
### asap7 ibex

No errors

### asap7 aes

|Stage | Error Code | Description | Count |
|-|-|-|-|
|IFP|IFP-0055 |Die area must contain core area |9|

### asap7 aes-block

|Stage | Error Code | Description | Count |
|-|-|-|-|
| MPL | MPL-0003 | There are no valid tilings for mixed cluster | 32 |
| MPL | MPL-0016 | The instance area considering the macros' halos exceeds the floorplan area | 6 |
| GPL | GPL-0305 | RePlAce diverged at newStepLength | 9 |
