### PR TITLE
Added POSITIVE_SLACK variable to choose alternate SDC file for asap7 ibex

### DIFF
--- a/flow/designs/asap7/ibex/config.mk
+++ b/flow/designs/asap7/ibex/config.mk
@@ -4,7 +4,14 @@ export DESIGN_NICKNAME        = ibex
 export DESIGN_NAME            = ibex_core
 
 export VERILOG_FILES         = $(sort $(wildcard $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/*.v))
+
+# if FLOW_VARIANT == pos_slack, use an SDC file that has a larger clock
+# resulting in positive slack
+ifeq ($(FLOW_VARIANT),pos_slack)
+export SDC_FILE              = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint_pos_slack.sdc
+else
 export SDC_FILE              = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
+endif
 
 export CORE_UTILIZATION       =  40
 export CORE_ASPECT_RATIO      = 1

--- a/flow/designs/asap7/ibex/constraint_pos_slack.sdc
+++ b/flow/designs/asap7/ibex/constraint_pos_slack.sdc
@@ -1,0 +1,13 @@
+set clk_name  core_clock
+set clk_port_name clk_i
+set clk_period 1468
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay  [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs 
+set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]


### PR DESCRIPTION
Most of our config.mk's are configured to have a negative slack value in order to continually improve the tools. In some cases, we want to have a version of a design that closes timing.

I've added a variable called POSITIVE_SLACK for the asap7 ibex example, which will choose an alternate SDC file for the run. The SDC has a larger clock period, which results in positive slack in the final design (4.12).

@tspyrou, FYI