### PR TITLE
Removed invariant minmax for sky130hd gcd AutoTuner config

### DIFF
--- a/flow/designs/sky130hd/gcd/autotuner.json
+++ b/flow/designs/sky130hd/gcd/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [


### PR DESCRIPTION
AutoTuner failed runs

|Stage|Error Code|Description|Count|
|-|-|-|-|
|DPL|DPL-0036|Detailed placement failed|6|