### PR TITLE
Removed invariant minmax from sky130hd AutoTuner configs

### DIFF
--- a/flow/designs/sky130hd/aes/autotuner.json
+++ b/flow/designs/sky130hd/aes/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
@@ -63,14 +55,6 @@
             0.2
         ],
         "step": 0
-    },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
     },
     "CTS_CLUSTER_SIZE": {
         "type": "int",

--- a/flow/designs/sky130hd/ibex/autotuner.json
+++ b/flow/designs/sky130hd/ibex/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
@@ -63,14 +55,6 @@
             0.2
         ],
         "step": 0
-    },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
     },
     "CTS_CLUSTER_SIZE": {
         "type": "int",

--- a/flow/designs/sky130hd/jpeg/autotuner.json
+++ b/flow/designs/sky130hd/jpeg/autotuner.json
@@ -24,14 +24,6 @@
         ],
         "step": 0
     },
-    "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [
@@ -63,14 +55,6 @@
             0.2
         ],
         "step": 0
-    },
-    "_PINS_DISTANCE": {
-        "type": "int",
-        "minmax": [
-            1,
-            1
-        ],
-        "step": 1
     },
     "CTS_CLUSTER_SIZE": {
         "type": "int",


### PR DESCRIPTION
### aes

|Stage|Error code| Description | Count |
|-|-|-|-|
|GRT|GRT-0116 | Global routing finished with congestion |6|
|GRT|GRT-0232 | Routing congestion too high |2|
|DPL|DPL-0036 | Detailed placement failed - density 0.8066801432365491| 1|

### ibex
|Stage|Error code| Description | Count |
|-|-|-|-|
|GRT|GRT-0116 | Global routing finished with congestion |1|
|GRT|GRT-0232 | Routing congestion too high |3|
|DPL|DPL-0036 | Detailed placement failed - density 0.753235324222441| 1|

### jpeg

No AutoTuner failed runs
