### PR TITLE
Updated GCD AutoTuner configs to change invariant minmaxs

### DIFF
--- a/flow/designs/asap7/gcd/autotuner.json
+++ b/flow/designs/asap7/gcd/autotuner.json
@@ -8,14 +8,6 @@
         ],
         "step": 0
     },
-   "CORE_MARGIN": {
-        "type": "int",
-        "minmax": [
-            2,
-            2
-        ],
-        "step": 0
-    },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",
         "minmax": [

--- a/flow/designs/ihp-sg13g2/gcd/autotuner.json
+++ b/flow/designs/ihp-sg13g2/gcd/autotuner.json
@@ -60,7 +60,7 @@
         "type": "int",
         "minmax": [
             1,
-            1
+            3
         ],
         "step": 1
     },

--- a/flow/designs/nangate45/gcd/autotuner.json
+++ b/flow/designs/nangate45/gcd/autotuner.json
@@ -11,10 +11,10 @@
    "CORE_MARGIN": {
         "type": "int",
         "minmax": [
-            2,
-            2
+            1,
+            3
         ],
-        "step": 0
+        "step": 1
     },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",

--- a/flow/designs/sky130hd/gcd/autotuner.json
+++ b/flow/designs/sky130hd/gcd/autotuner.json
@@ -27,10 +27,10 @@
     "CORE_MARGIN": {
         "type": "int",
         "minmax": [
-            2,
-            2
+            1,
+            3
         ],
-        "step": 0
+        "step": 1
     },
     "CELL_PAD_IN_SITES_GLOBAL_PLACEMENT": {
         "type": "int",


### PR DESCRIPTION
Updated nangate45, ihp-sg13g2, asap7, and sky130hd gcd AutoTuner configs. Replaced invariant minmaxs with minmaxs that vary. Removing the invariant minmaxs caused the sample/iterations smoke test to fail when it chose invalid configurations.
