### PR TITLE
enabled smoke_test_algo_eval in AutoTuner test script

### DIFF
--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -22,6 +22,9 @@ python3 -m unittest tools.AutoTuner.test.smoke_test_sweep.${PLATFORM_WITHOUT_DAS
 echo "Running Autotuner smoke tests for --sample and --iteration."
 python3 -m unittest tools.AutoTuner.test.smoke_test_sample_iteration.${PLATFORM_WITHOUT_DASHES}SampleIterationSmokeTest.test_sample_iteration
 
+echo "Running Autotuner smoke algorithm eval test"
+python3 -m unittest tools.AutoTuner.test.smoke_test_algo_eval.${PLATFORM_WITHOUT_DASHES}AlgoEvalSmokeTest.test_algo_eval
+
 if [ "$PLATFORM_WITHOUT_DASHES" == "asap7" ] && [ "$DESIGN_NAME" == "gcd" ]; then
   echo "Running Autotuner ref file test (only once)"
   python3 -m unittest tools.AutoTuner.test.ref_file_check.RefFileCheck.test_files


### PR DESCRIPTION
Enabled algo eval test to ensure that changes to the evaluate() script are done for both AutoTunerBase and PPAImprov.
