### PR TITLE
test secure-rsz-limit-area2

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -24,7 +24,7 @@
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1087,
+        "value": 1025,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 75547,
+        "value": 73816,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -104.94,
+        "value": -85.83,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,11 +60,11 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 399,
+        "value": 274,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -22.74,
+        "value": -21.12,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/aes-mbff/rules-base.json
+++ b/flow/designs/asap7/aes-mbff/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -83.87,
+        "value": -65.29,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -24.19,
+        "value": -20.72,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/aes_lvt/rules-base.json
+++ b/flow/designs/asap7/aes_lvt/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -31.87,
+        "value": -31.32,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -13.0,
+        "value": -12.88,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/ethmac_lvt/rules-base.json
+++ b/flow/designs/asap7/ethmac_lvt/rules-base.json
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 683727,
+        "value": 628443,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -152.08,
+        "value": -57.04,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -22.89,
+        "value": -22.88,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/gcd/rules-base.json
+++ b/flow/designs/asap7/gcd/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 54.33,
+        "value": 43.38,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 65,
+        "value": 53,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 639,
+        "value": 543,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,7 +20,7 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 155,
+        "value": 57,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1755,
+        "value": 1454,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -77.18,
+        "value": -74.47,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 80,
+        "value": 62,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 47,
+        "value": 27,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -33.9,
+        "value": -33.05,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/jpeg_lvt/rules-base.json
+++ b/flow/designs/asap7/jpeg_lvt/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 7151.38,
+        "value": 7116.74,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 7776,
+        "value": 7775,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 67398,
+        "value": 67280,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5861,
+        "value": 5850,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5861,
+        "value": 5850,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -36.96,
+        "value": -5.97,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 7866,
+        "value": 7857,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 2930,
+        "value": 2925,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/asap7/mock-alu/rules-base.json
+++ b/flow/designs/asap7/mock-alu/rules-base.json
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1908,
+        "value": 1899,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 14796,
+        "value": 14790,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1287,
+        "value": 1286,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1287,
+        "value": 1286,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -537.65,
+        "value": -514.21,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -98.82,
+        "value": -97.53,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/mock-array/rules-base.json
+++ b/flow/designs/asap7/mock-array/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 113607.14,
+        "value": 38128.06,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -32.57,
+        "value": 0.0,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/asap7/riscv32i/rules-base.json
+++ b/flow/designs/asap7/riscv32i/rules-base.json
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 13035,
+        "value": 12507,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1134,
+        "value": 1088,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1134,
+        "value": 1088,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 144993,
+        "value": 138823,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 585,
+        "value": 544,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/asap7/uart/rules-base.json
+++ b/flow/designs/asap7/uart/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 85.78,
+        "value": 83.24,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 96,
+        "value": 95,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 846,
+        "value": 835,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 74,
+        "value": 73,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 74,
+        "value": 73,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -48.37,
+        "value": -24.54,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 105,
+        "value": 103,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 37,
+        "value": 36,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -20.02,
+        "value": -13.14,
         "compare": ">="
     }
 }

--- a/flow/designs/gf180/aes-hybrid/rules-base.json
+++ b/flow/designs/gf180/aes-hybrid/rules-base.json
@@ -40,15 +40,15 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 22,
+        "value": 6,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.7,
+        "value": -1.44,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/gf180/aes/rules-base.json
+++ b/flow/designs/gf180/aes/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.3,
+        "value": -1.27,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/gf180/ibex/rules-base.json
+++ b/flow/designs/gf180/ibex/rules-base.json
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 799,
+        "value": 985,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/gf180/jpeg/rules-base.json
+++ b/flow/designs/gf180/jpeg/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 2177281.78,
+        "value": 2163344.49,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 2386940,
+        "value": 2383375,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 55001,
+        "value": 54888,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,15 +20,15 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 4783,
+        "value": 4773,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 4783,
+        "value": 4773,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 0,
+        "value": 3,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,19 +44,19 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 27,
+        "value": 16,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.5,
+        "value": -0.4,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 2443854,
+        "value": 2439311,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 2391,
+        "value": 2386,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/gf180/riscv32i/rules-base.json
+++ b/flow/designs/gf180/riscv32i/rules-base.json
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 15,
+        "value": 5,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/gf180/uart-blocks/rules-base.json
+++ b/flow/designs/gf180/uart-blocks/rules-base.json
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 742,
+        "value": 733,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 14,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 19722,
+        "value": 18510,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {

--- a/flow/designs/ihp-sg13g2/aes/rules-base.json
+++ b/flow/designs/ihp-sg13g2/aes/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 373,
+        "value": 288,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 49,
+        "value": 46,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 843,
+        "value": 842,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/ihp-sg13g2/gcd/rules-base.json
+++ b/flow/designs/ihp-sg13g2/gcd/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 6696.95,
+        "value": 5719.01,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 7624,
+        "value": 6508,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 646,
+        "value": 505,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 17667,
+        "value": 14242,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,11 +48,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.21,
+        "value": -0.17,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 31762,
+        "value": 27365,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 3,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {

--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1702,
+        "value": 1092,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 79,
+        "value": 56,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.03,
+        "value": -0.42,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
+++ b/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 779,
+        "value": 333,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 819634,
+        "value": 773278,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -40,7 +40,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 46,
+        "value": 13,
+        "compare": "<="
+    },
+    "detailedroute__antenna_diodes_count": {
+        "value": 5,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/ihp-sg13g2/spi/rules-base.json
+++ b/flow/designs/ihp-sg13g2/spi/rules-base.json
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 4994,
+        "value": 4812,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -52,11 +52,11 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 10447,
+        "value": 10408,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 20,
+        "value": 15,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/nangate45/aes/rules-base.json
+++ b/flow/designs/nangate45/aes/rules-base.json
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 114,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/nangate45/bp_be_top/rules-base.json
+++ b/flow/designs/nangate45/bp_be_top/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 271352.58,
+        "value": 268204.56,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 66169,
+        "value": 63881,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5754,
+        "value": 5555,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5754,
+        "value": 5555,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 3494576,
+        "value": 3320616,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.99,
+        "value": -0.62,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,15 +56,15 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 2877,
+        "value": 2777,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 775,
+        "value": 111,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -46.18,
+        "value": -33.73,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/bp_fe_top/rules-base.json
+++ b/flow/designs/nangate45/bp_fe_top/rules-base.json
@@ -8,7 +8,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 262272,
+        "value": 261984,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 2254141,
+        "value": 2113753,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -52,7 +52,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 264098,
+        "value": 263844,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 2076,
+        "value": 284,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/nangate45/bp_multi_top/rules-base.json
+++ b/flow/designs/nangate45/bp_multi_top/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -4.22,
+        "value": -3.76,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -61.44,
+        "value": -57.73,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/dynamic_node/rules-base.json
+++ b/flow/designs/nangate45/dynamic_node/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 25638.4,
+        "value": 25608.42,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 13609,
+        "value": 13598,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1183,
+        "value": 1182,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1183,
+        "value": 1182,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.57,
+        "value": -0.51,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 592,
+        "value": 591,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -37.9,
+        "value": -32.77,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/gcd/rules-base.json
+++ b/flow/designs/nangate45/gcd/rules-base.json
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 6770,
+        "value": 4782,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.09,
+        "value": -0.07,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1067,
+        "value": 909,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 46,
+        "value": 30,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/nangate45/ibex/rules-base.json
+++ b/flow/designs/nangate45/ibex/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.29,
+        "value": -0.27,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,11 +60,11 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 291,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -21.31,
+        "value": -17.65,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/jpeg/rules-base.json
+++ b/flow/designs/nangate45/jpeg/rules-base.json
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 71364,
+        "value": 71207,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 6206,
+        "value": 6192,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 6206,
+        "value": 6192,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.05,
+        "value": -0.02,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 3103,
+        "value": 3096,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/nangate45/swerv/rules-base.json
+++ b/flow/designs/nangate45/swerv/rules-base.json
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 808,
+        "value": 530,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.56,
+        "value": -0.49,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,11 +60,11 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 891,
+        "value": 592,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -28.24,
+        "value": -26.21,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/tinyRocket/rules-base.json
+++ b/flow/designs/nangate45/tinyRocket/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.4,
+        "value": -0.38,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/sky130hd/aes/rules-base.json
+++ b/flow/designs/sky130hd/aes/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 231,
+        "value": 198,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,11 +44,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 74,
+        "value": 24,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.23,
+        "value": -0.2,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -10.28,
+        "value": -10.0,
         "compare": ">="
     }
 }

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 350,
+        "value": 98,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 800673,
+        "value": 796825,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 332,
+        "value": 81,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -52,7 +52,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 6537497,
+        "value": 6536864,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {

--- a/flow/designs/sky130hd/ibex/rules-base.json
+++ b/flow/designs/sky130hd/ibex/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 54,
+        "value": 36,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,11 +44,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 38,
+        "value": 36,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.79,
+        "value": -1.57,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 937,
+        "value": 912,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/sky130hd/jpeg/rules-base.json
+++ b/flow/designs/sky130hd/jpeg/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 465087.75,
+        "value": 464771.19,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 55401,
+        "value": 55310,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,15 +20,15 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 4818,
+        "value": 4810,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 4818,
+        "value": 4810,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 406,
+        "value": 124,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,11 +44,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 196,
+        "value": 152,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.07,
+        "value": 0.0,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 2409,
+        "value": 2405,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 5485,
+        "value": 4388,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,11 +40,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 3,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 3434,
+        "value": 3138,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 122,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/sky130hs/aes/rules-base.json
+++ b/flow/designs/sky130hs/aes/rules-base.json
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 66,
+        "value": 64,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 713539,
+        "value": 700519,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 68,
+        "value": 33,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/sky130hs/gcd/rules-base.json
+++ b/flow/designs/sky130hs/gcd/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 4595.4,
+        "value": 4532.91,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 736,
+        "value": 631,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 64,
+        "value": 55,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 64,
+        "value": 55,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 12021,
+        "value": 10551,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 32,
+        "value": 27,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/sky130hs/ibex/rules-base.json
+++ b/flow/designs/sky130hs/ibex/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 24,
+        "value": 8,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 36,
+        "value": 30,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/sky130hs/jpeg/rules-base.json
+++ b/flow/designs/sky130hs/jpeg/rules-base.json
@@ -8,7 +8,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 770755,
+        "value": 770740,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 5,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {

--- a/flow/designs/sky130hs/riscv32i/rules-base.json
+++ b/flow/designs/sky130hs/riscv32i/rules-base.json
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 10,
+        "value": 20,
         "compare": "<="
     },
     "finish__timing__setup__ws": {


### PR DESCRIPTION
asap7/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__design__instance__count__hold_buffer     |     1087 |     1025 | Tighten  |
| detailedroute__route__wirelength              |    75547 |    73816 | Tighten  |
| finish__timing__setup__ws                     |  -104.94 |   -85.83 | Tighten  |
| finish__timing__drv__hold_violation_count     |      399 |      274 | Tighten  |
| finish__timing__wns_percent_delay             |   -22.74 |   -21.12 | Tighten  |

asap7/aes-block
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |   -83.87 |   -65.29 | Tighten  |
| finish__timing__wns_percent_delay             |   -24.19 |   -20.72 | Tighten  |

asap7/aes-mbff
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |   -31.87 |   -31.32 | Tighten  |
| finish__timing__wns_percent_delay             |    -13.0 |   -12.88 | Tighten  |

asap7/ethmac
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__route__wirelength              |   683727 |   628443 | Tighten  |
| finish__timing__setup__ws                     |  -152.08 |   -57.04 | Tighten  |
| finish__timing__wns_percent_delay             |   -22.89 |   -22.88 | Tighten  |

asap7/ethmac_lvt
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |    54.33 |    43.38 | Tighten  |
| placeopt__design__instance__area              |       65 |       53 | Tighten  |
| placeopt__design__instance__count__stdcell    |      639 |      543 | Tighten  |
| cts__design__instance__count__setup_buffer    |      155 |       57 | Tighten  |
| detailedroute__route__wirelength              |     1755 |     1454 | Tighten  |
| finish__timing__setup__ws                     |   -77.18 |   -74.47 | Tighten  |
| finish__design__instance__area                |       80 |       62 | Tighten  |
| finish__timing__drv__setup_violation_count    |       47 |       27 | Tighten  |
| finish__timing__wns_percent_delay             |    -33.9 |   -33.05 | Tighten  |

asap7/jpeg
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |  7151.38 |  7116.74 | Tighten  |
| placeopt__design__instance__area              |     7776 |     7775 | Tighten  |
| placeopt__design__instance__count__stdcell    |    67398 |    67280 | Tighten  |
| cts__design__instance__count__setup_buffer    |     5861 |     5850 | Tighten  |
| cts__design__instance__count__hold_buffer     |     5861 |     5850 | Tighten  |
| finish__timing__setup__ws                     |   -36.96 |    -5.97 | Tighten  |
| finish__design__instance__area                |     7866 |     7857 | Tighten  |
| finish__timing__drv__setup_violation_count    |     2930 |     2925 | Tighten  |

asap7/jpeg_lvt
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |     1908 |     1899 | Tighten  |
| placeopt__design__instance__count__stdcell    |    14796 |    14790 | Tighten  |
| cts__design__instance__count__setup_buffer    |     1287 |     1286 | Tighten  |
| cts__design__instance__count__hold_buffer     |     1287 |     1286 | Tighten  |
| finish__timing__setup__ws                     |  -537.65 |  -514.21 | Tighten  |
| finish__timing__wns_percent_delay             |   -98.82 |   -97.53 | Tighten  |

asap7/mock-alu
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 113607.14 | 38128.06 | Tighten  |
| finish__timing__setup__ws                     |   -32.57 |      0.0 | Tighten  |

asap7/mock-array
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__count__stdcell    |    13035 |    12507 | Tighten  |
| cts__design__instance__count__setup_buffer    |     1134 |     1088 | Tighten  |
| cts__design__instance__count__hold_buffer     |     1134 |     1088 | Tighten  |
| detailedroute__route__wirelength              |   144993 |   138823 | Tighten  |
| finish__timing__drv__setup_violation_count    |      585 |      544 | Tighten  |

asap7/riscv32i
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |    85.78 |    83.24 | Tighten  |
| placeopt__design__instance__area              |       96 |       95 | Tighten  |
| placeopt__design__instance__count__stdcell    |      846 |      835 | Tighten  |
| cts__design__instance__count__setup_buffer    |       74 |       73 | Tighten  |
| cts__design__instance__count__hold_buffer     |       74 |       73 | Tighten  |
| finish__timing__setup__ws                     |   -48.37 |   -24.54 | Tighten  |
| finish__design__instance__area                |      105 |      103 | Tighten  |
| finish__timing__drv__setup_violation_count    |       37 |       36 | Tighten  |
| finish__timing__wns_percent_delay             |   -20.02 |   -13.14 | Tighten  |

asap7/uart
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |        1 |        0 | Tighten  |
| finish__timing__setup__ws                     |     -1.3 |    -1.27 | Tighten  |

gf180/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna__violating__nets       |        1 |        0 | Tighten  |
| detailedroute__antenna_diodes_count           |       22 |        6 | Tighten  |
| finish__timing__setup__ws                     |     -1.7 |    -1.44 | Tighten  |

gf180/aes-hybrid
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__setup_violation_count    |      799 |      985 | Failing  |

gf180/ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 2177281.78 | 2163344.49 | Tighten  |
| placeopt__design__instance__area              |  2386940 |  2383375 | Tighten  |
| placeopt__design__instance__count__stdcell    |    55001 |    54888 | Tighten  |
| cts__design__instance__count__setup_buffer    |     4783 |     4773 | Tighten  |
| cts__design__instance__count__hold_buffer     |     4783 |     4773 | Tighten  |
| globalroute__antenna_diodes_count             |        0 |        3 | Failing  |
| detailedroute__antenna_diodes_count           |       27 |       16 | Tighten  |
| finish__timing__setup__ws                     |     -0.5 |     -0.4 | Tighten  |
| finish__design__instance__area                |  2443854 |  2439311 | Tighten  |
| finish__timing__drv__setup_violation_count    |     2391 |     2386 | Tighten  |

gf180/jpeg
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna_diodes_count           |       15 |        5 | Tighten  |

gf180/riscv32i
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__count__stdcell    |      742 |      733 | Tighten  |
| globalroute__antenna_diodes_count             |       14 |        0 | Tighten  |
| detailedroute__route__wirelength              |    19722 |    18510 | Tighten  |

gf180/uart-blocks
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      373 |      288 | Tighten  |
| detailedroute__antenna__violating__nets       |       49 |       46 | Tighten  |
| finish__timing__drv__setup_violation_count    |      843 |      842 | Tighten  |

ihp-sg13g2/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |  6696.95 |  5719.01 | Tighten  |
| placeopt__design__instance__area              |     7624 |     6508 | Tighten  |
| placeopt__design__instance__count__stdcell    |      646 |      505 | Tighten  |
| detailedroute__route__wirelength              |    17667 |    14242 | Tighten  |
| finish__timing__setup__ws                     |    -0.21 |    -0.17 | Tighten  |
| finish__design__instance__area                |    31762 |    27365 | Tighten  |

ihp-sg13g2/gcd
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna__violating__nets       |        3 |        1 | Tighten  |

ihp-sg13g2/i2c-gpio-expander
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |     1702 |     1092 | Tighten  |
| detailedroute__antenna__violating__nets       |       79 |       56 | Tighten  |
| finish__timing__setup__ws                     |    -1.03 |    -0.42 | Tighten  |

ihp-sg13g2/ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      779 |      333 | Tighten  |
| detailedroute__route__wirelength              |   819634 |   773278 | Tighten  |
| detailedroute__antenna__violating__nets       |       46 |       13 | Tighten  |

ihp-sg13g2/riscv32i
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__route__wirelength              |     4994 |     4812 | Tighten  |
| finish__design__instance__area                |    10447 |    10408 | Tighten  |
| finish__timing__drv__setup_violation_count    |       20 |       15 | Tighten  |

ihp-sg13g2/spi
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__hold_violation_count     |      114 |      100 | Tighten  |

nangate45/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 271352.58 | 268204.56 | Tighten  |
| placeopt__design__instance__count__stdcell    |    66169 |    63881 | Tighten  |
| cts__design__instance__count__setup_buffer    |     5754 |     5555 | Tighten  |
| cts__design__instance__count__hold_buffer     |     5754 |     5555 | Tighten  |
| detailedroute__route__wirelength              |  3494576 |  3320616 | Tighten  |
| finish__timing__setup__ws                     |    -0.99 |    -0.62 | Tighten  |
| finish__timing__drv__setup_violation_count    |     2877 |     2777 | Tighten  |
| finish__timing__drv__hold_violation_count     |      775 |      111 | Tighten  |
| finish__timing__wns_percent_delay             |   -46.18 |   -33.73 | Tighten  |

nangate45/bp_be_top
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |   262272 |   261984 | Tighten  |
| detailedroute__route__wirelength              |  2254141 |  2113753 | Tighten  |
| finish__design__instance__area                |   264098 |   263844 | Tighten  |
| finish__timing__drv__hold_violation_count     |     2076 |      284 | Tighten  |

nangate45/bp_fe_top
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |    -4.22 |    -3.76 | Tighten  |
| finish__timing__wns_percent_delay             |   -61.44 |   -57.73 | Tighten  |

nangate45/bp_multi_top
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |  25638.4 | 25608.42 | Tighten  |
| placeopt__design__instance__count__stdcell    |    13609 |    13598 | Tighten  |
| cts__design__instance__count__setup_buffer    |     1183 |     1182 | Tighten  |
| cts__design__instance__count__hold_buffer     |     1183 |     1182 | Tighten  |
| finish__timing__setup__ws                     |    -0.57 |    -0.51 | Tighten  |
| finish__timing__drv__setup_violation_count    |      592 |      591 | Tighten  |
| finish__timing__wns_percent_delay             |    -37.9 |   -32.77 | Tighten  |

nangate45/dynamic_node
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__route__wirelength              |     6770 |     4782 | Tighten  |
| finish__timing__setup__ws                     |    -0.09 |    -0.07 | Tighten  |
| finish__design__instance__area                |     1067 |      909 | Tighten  |
| finish__timing__drv__setup_violation_count    |       46 |       30 | Tighten  |

nangate45/gcd
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |    -0.29 |    -0.27 | Tighten  |
| finish__timing__drv__hold_violation_count     |      291 |      100 | Tighten  |
| finish__timing__wns_percent_delay             |   -21.31 |   -17.65 | Tighten  |

nangate45/ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__count__stdcell    |    71364 |    71207 | Tighten  |
| cts__design__instance__count__setup_buffer    |     6206 |     6192 | Tighten  |
| cts__design__instance__count__hold_buffer     |     6206 |     6192 | Tighten  |
| finish__timing__setup__ws                     |    -0.05 |    -0.02 | Tighten  |
| finish__timing__drv__setup_violation_count    |     3103 |     3096 | Tighten  |

nangate45/jpeg
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__hold_violation_count     |      808 |      530 | Tighten  |

nangate45/swerv
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |    -0.56 |    -0.49 | Tighten  |
| finish__timing__drv__hold_violation_count     |      891 |      592 | Tighten  |
| finish__timing__wns_percent_delay             |   -28.24 |   -26.21 | Tighten  |

nangate45/swerv_wrapper
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |     -0.4 |    -0.38 | Tighten  |

nangate45/tinyRocket
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      231 |      198 | Tighten  |
| detailedroute__antenna_diodes_count           |       74 |       24 | Tighten  |
| finish__timing__setup__ws                     |    -0.23 |     -0.2 | Tighten  |
| finish__timing__wns_percent_delay             |   -10.28 |    -10.0 | Tighten  |

sky130hd/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      350 |       98 | Tighten  |
| detailedroute__route__wirelength              |   800673 |   796825 | Tighten  |
| detailedroute__antenna_diodes_count           |      332 |       81 | Tighten  |
| finish__design__instance__area                |  6537497 |  6536864 | Tighten  |

sky130hd/gcd
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       54 |       36 | Tighten  |
| detailedroute__antenna_diodes_count           |       38 |       36 | Tighten  |
| finish__timing__setup__ws                     |    -1.79 |    -1.57 | Tighten  |
| finish__timing__drv__setup_violation_count    |      937 |      912 | Tighten  |

sky130hd/ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 465087.75 | 464771.19 | Tighten  |
| placeopt__design__instance__count__stdcell    |    55401 |    55310 | Tighten  |
| cts__design__instance__count__setup_buffer    |     4818 |     4810 | Tighten  |
| cts__design__instance__count__hold_buffer     |     4818 |     4810 | Tighten  |
| globalroute__antenna_diodes_count             |      406 |      124 | Tighten  |
| detailedroute__antenna_diodes_count           |      196 |      152 | Tighten  |
| finish__timing__setup__ws                     |    -0.07 |      0.0 | Tighten  |
| finish__timing__drv__setup_violation_count    |     2409 |     2405 | Tighten  |

sky130hd/jpeg
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |     5485 |     4388 | Tighten  |
| detailedroute__antenna__violating__nets       |        3 |        1 | Tighten  |
| detailedroute__antenna_diodes_count           |     3434 |     3138 | Tighten  |
| finish__timing__drv__hold_violation_count     |      122 |      100 | Tighten  |

sky130hd/riscv32i
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       66 |       64 | Tighten  |
| detailedroute__route__wirelength              |   713539 |   700519 | Tighten  |
| detailedroute__antenna_diodes_count           |       68 |       33 | Tighten  |

sky130hs/aes
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |   4595.4 |  4532.91 | Tighten  |
| placeopt__design__instance__count__stdcell    |      736 |      631 | Tighten  |
| cts__design__instance__count__setup_buffer    |       64 |       55 | Tighten  |
| cts__design__instance__count__hold_buffer     |       64 |       55 | Tighten  |
| detailedroute__route__wirelength              |    12021 |    10551 | Tighten  |
| finish__timing__drv__setup_violation_count    |       32 |       27 | Tighten  |

sky130hs/gcd
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       24 |        8 | Tighten  |
| detailedroute__antenna_diodes_count           |       36 |       30 | Tighten  |

sky130hs/ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |   770755 |   770740 | Tighten  |
| detailedroute__antenna__violating__nets       |        5 |        0 | Tighten  |

sky130hs/jpeg
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna_diodes_count           |       10 |       20 | Failing  |