### PR TITLE
util: make prints simpler for genRuleFile

### DIFF
--- a/flow/util/genRuleFile.py
+++ b/flow/util/genRuleFile.py
@@ -96,7 +96,7 @@ def gen_rule_file(
             with open(metrics_file, "r") as f:
                 metrics = json.load(f)
         else:
-            print(f"[ERROR] File not found {abspath(metrics_file)}")
+            print(f"[ERROR] Golden metrics file not found {design_dir}")
             sys.exit(1)
     else:
         metrics = golden_metrics
@@ -105,7 +105,7 @@ def gen_rule_file(
         with open(rules_file, "r") as f:
             OLD_RULES = json.load(f)
     else:
-        print(f"[WARNING] File not found {abspath(rules_file)}")
+        print(f"[WARNING] Rules file not found {design_dir}")
         OLD_RULES = None
 
     # dict format
@@ -370,12 +370,12 @@ def gen_rule_file(
         rules[field] = dict(value=rule_value, compare=option["compare"])
 
     if len(change_str) > 0:
+        print(design_dir)
         print(format_str.format("Metric", "Old", "New", "Type"), end="")
         print(format_str.format("------", "---", "---", "----"), end="")
         print(change_str)
 
     with open(rules_file, "w") as f:
-        print("[INFO] writing", abspath(rules_file))
         json.dump(rules, f, indent=4)
 
     chdir(original_directory)


### PR DESCRIPTION
* `abspath` for the files is just noisy; printing the `design_dir` is enough to know which design we are talking about.
* adding the print to the table makes it easier to include in PR descriptions and ID which designs the changes refer to.


Sample of how this will show up, the text was added directly form the output of the script: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2874#issue-2879123708