### PR TITLE
flow: avoid DONT_USE_SC_LIB as an artifact between steps

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -337,7 +337,7 @@ $(DONT_USE_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
 	@mkdir -p $(OBJECTS_DIR)/lib
 	$(UTILS_DIR)/preprocessLib.py -i $^ -o $@
 
-$(OBJECTS_DIR)/lib/merged.lib:
+$(OBJECTS_DIR)/lib/merged.lib: $(DONT_USE_LIBS)
 	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $(DONT_USE_LIBS) > $@
 
 # Pre-process KLayout tech

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -437,19 +437,19 @@ $(SDC_FILE_CLOCK_PERIOD): $(SDC_FILE)
 	mkdir -p $(dir $@)
 	echo $(ABC_CLOCK_PERIOD_IN_PS) > $@
 
-YOSYS_DEPENDENCIES=$(DONT_USE_LIBS) $(WRAPPED_LIBS) $(DONT_USE_SC_LIB) $(DFF_LIB_FILE) $(VERILOG_FILES) $(SYNTH_NETLIST_FILES) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE) $(SDC_FILE_CLOCK_PERIOD)
+YOSYS_DEPENDENCIES=$(DONT_USE_LIBS) $(WRAPPED_LIBS) $(DFF_LIB_FILE) $(VERILOG_FILES) $(SYNTH_NETLIST_FILES) $(LATCH_MAP_FILE) $(ADDER_MAP_FILE) $(SDC_FILE_CLOCK_PERIOD)
 
 .PHONY: yosys-dependencies
 yosys-dependencies: $(YOSYS_DEPENDENCIES)
 
 .PHONY: do-yosys
-do-yosys:
+do-yosys: $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
 	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
 	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys.log)
 
 .PHONY: do-yosys-canonicalize
-do-yosys-canonicalize: yosys-dependencies
+do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
 	($(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SCRIPTS_DIR)/synth_canonicalize.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_canonicalize.log)
 
@@ -594,7 +594,7 @@ endef
 
 # STEP 1: Translate verilog to odb
 #-------------------------------------------------------------------------------
-$(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL),floorplan))
+$(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL) $(DONT_USE_SC_LIB),floorplan))
 
 # STEP 2: Random IO placement
 #-------------------------------------------------------------------------------
@@ -619,7 +619,7 @@ $(eval $(call do-copy,2_floorplan,2_5_floorplan_pdn.odb,))
 $(RESULTS_DIR)/2_floorplan.sdc: $(RESULTS_DIR)/2_1_floorplan.odb
 
 .PHONY: do-floorplan
-do-floorplan:
+do-floorplan: $(DONT_USE_SC_LIB)
 	$(UNSET_AND_MAKE) do-2_1_floorplan do-2_2_floorplan_io do-2_3_floorplan_macro do-2_4_floorplan_tapcell do-2_5_floorplan_pdn do-2_floorplan do-2_floorplan.sdc
 
 .PHONY: clean_floorplan

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -263,6 +263,10 @@ export LIB_FILES             += $(ADDITIONAL_LIBS)
 export DB_FILES              += $(realpath $($(CORNER)_DB_FILES))
 export TEMPERATURE            = $($(CORNER)_TEMPERATURE)
 export VOLTAGE                = $($(CORNER)_VOLTAGE)
+
+# FIXME Need merged.lib for now, but ideally it shouldn't be necessary:
+#
+# https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2139
 export DONT_USE_SC_LIB        = $(OBJECTS_DIR)/lib/merged.lib
 
 # ---------------------------------------------------------


### PR DESCRIPTION
in Bazel, DONT_USE_SC_LIB needs to be an artifact that has to stored between synthesis and floorplan, better to create this on the fly and leave it as an implementation detail of ORFS.

This avoids the merged.lib (large) artifact between synthesis and floorplan.

Tested locally as follows:


```
$ make DESIGN_CONFIG=designs/asap7/gcd/config.mk print-DONT_USE_SC_LIB
DONT_USE_SC_LIB = ./objects/asap7/gcd/base/lib/merged.lib
$ make DESIGN_CONFIG=designs/asap7/gcd/config.mk floorplan
$ rm objects/asap7/gcd/base/lib/merged.lib
$ make DESIGN_CONFIG=designs/asap7/gcd/config.mk RESYNTH_TIMING_RECOVER=1 do-2_1_floorplan
=> fails as expected
$ make DESIGN_CONFIG=designs/asap7/gcd/config.mk RESYNTH_TIMING_RECOVER=1 do-floorplan
=> works as expected
$ ls -l objects/asap7/gcd/base/lib/merged.lib
```
