### PR TITLE
makefile: make yosys-run target to explore and report on synthesis results

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1026,6 +1026,11 @@ run:
 	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
 	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/$(RUN_LOG_NAME_STEM).log))
 
+export RUN_YOSYS_ARGS ?= -c $(SCRIPTS_DIR)/yosys_keep.tcl
+.phony: run-yosys
+run-yosys:
+	$(YOSYS_EXE) $(RUN_YOSYS_ARGS)
+
 # Utilities
 #-------------------------------------------------------------------------------
 include $(UTILS_DIR)/utils.mk

--- a/flow/scripts/README.md
+++ b/flow/scripts/README.md
@@ -1,0 +1,37 @@
+# Scripts
+
+Various scripts to support flow as well as utilities.
+
+## make run-yosys
+
+Sets up all the ORFS environment variables and launches Yosys.
+
+Useful to run a Yosys script or interactive mode on the synthesis result to  extract information or debug synthesis results using Yosys commands.
+
+Used with the `YOSYS_RUN_ARGS` variable to pass arguments to Yosys. The default arguments is a "Hello world" script that lists all modules with the keep_hierarchy attribute set and writes a report of those modules.
+
+    $ make DESIGN_CONFIG=designs/asap7/aes-block/config.mk synth run-yosys
+    $ cat reports/asap7/aes-block/base/keep.txt
+
+    2 modules:
+      aes_cipher_top    aes_key_expand_128
+
+## yosys_load.tcl
+
+Loads in 1_synth.v synthesis result from Yosys. This is useful in automation, such as generating reports from synthesis, but can also be used in interactive inspection.
+
+Example usage to examine results interactively:
+
+    make DESIGN_CONFIG=designs/asap7/aes-block/config.mk synth run-yosys RUN_YOSYS_ARGS=-C
+
+Load synthesis result and list modules that were kept in hierarchical synthesis:
+
+    [banner deleted]
+    % source $::env(SCRIPTS_DIR)/yosys_load.tcl
+    [yosys verbose output deleted]
+    % ls A:keep_hierarchy=1
+
+    2 modules:
+    aes_cipher_top
+    aes_key_expand_128
+    %

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -42,11 +42,7 @@ foreach file $::env(VERILOG_FILES) {
   }
 }
 
-# Read standard cells and macros as blackbox inputs
-# These libs have their dont_use properties set accordingly
-read_liberty -overwrite -setattr liberty_cell -lib {*}$::env(DONT_USE_LIBS)
-read_liberty -overwrite -setattr liberty_cell \
-  -unit_delay -wb -ignore_miss_func -ignore_buses {*}$::env(DONT_USE_LIBS)
+source $::env(SCRIPTS_DIR)/synth_stdcells.tcl
 
 # Apply toplevel parameters (if exist)
 if {[env_var_exists_and_non_empty VERILOG_TOP_PARAMS]} {

--- a/flow/scripts/synth_stdcells.tcl
+++ b/flow/scripts/synth_stdcells.tcl
@@ -1,0 +1,5 @@
+# Read standard cells and macros as blackbox inputs
+# These libs have their dont_use properties set accordingly
+read_liberty -overwrite -setattr liberty_cell -lib {*}$::env(DONT_USE_LIBS)
+read_liberty -overwrite -setattr liberty_cell \
+  -unit_delay -wb -ignore_miss_func -ignore_buses {*}$::env(DONT_USE_LIBS)

--- a/flow/scripts/yosys_keep.tcl
+++ b/flow/scripts/yosys_keep.tcl
@@ -1,0 +1,5 @@
+# Example script, tee list of modules with keep attribute to a
+# report file
+source $::env(SCRIPTS_DIR)/yosys_load.tcl
+
+tee -o $::env(REPORTS_DIR)/keep.txt ls A:keep_hierarchy=1

--- a/flow/scripts/yosys_load.tcl
+++ b/flow/scripts/yosys_load.tcl
@@ -1,0 +1,6 @@
+# Load synthesis result
+yosys -import
+
+source $::env(SCRIPTS_DIR)/synth_stdcells.tcl
+
+read_verilog $::env(RESULTS_DIR)/1_synth.v


### PR DESCRIPTION
@povik FYI.

Motivated by my tinkering with parallel yosys synthesis in Bazel. To do parallel synthesis, the modules to be flattened need to be part of the source code like other build parameters and information (placement density, die area, etc, etc.)

There's precedent for extracting information from the flow and locking choices, keeping it in git and using it as a parameter for future builds:

- From a different domain, Python: requirements.txt and requirements_lock.txt. Requirements.txt is an ambigious definition of lists of modules to use(use a module equal to or newer than such and such). requirements_lock.txt contains a list of modules actually chosen at some point in time, kept in git. 
- lock automatic io pin placement
- write_macro_placement
- list of modules to keep, useful for running synthesis in parallel. I don't have a way to extract dependencies automatically kinda like .d files for .cpp files, but that could speed up synthesis even more in bazel.
- AutoTuner is in a sense a broader example of extracting information during automation/flow and use those as parameters to the design