### PR TITLE
synthesis: add a do-yosys-coarse stage

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -445,8 +445,14 @@ yosys-dependencies: $(YOSYS_DEPENDENCIES)
 .PHONY: do-yosys
 do-yosys: $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
+	(export VERILOG_FILES=$(RESULTS_DIR)/1_yosys_coarse.rtlil; \
 	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys.log)
+
+.PHONY: do-yosys-coarse
+do-yosys-coarse: $(DONT_USE_SC_LIB)
+	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
+	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
+	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SCRIPTS_DIR)/synth_coarse.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_coarse.log)
 
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)
@@ -456,8 +462,11 @@ do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)
 $(RESULTS_DIR)/1_synth.rtlil: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
-$(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_synth.rtlil
+$(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_yosys_coarse.rtlil
 	$(UNSET_AND_MAKE) do-yosys
+
+$(RESULTS_DIR)/1_yosys_coarse.rtlil: $(RESULTS_DIR)/1_synth.rtlil
+	$(UNSET_AND_MAKE) do-yosys-coarse
 
 .PHONY: do-synth
 do-synth:

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -1,39 +1,14 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
-hierarchy -check -top $::env(DESIGN_NAME)
-
-if { [env_var_equals SYNTH_GUT 1] } {
-  # /deletes all cells at the top level, which will quickly optimize away
-  # everything else, including macros.
-  delete $::env(DESIGN_NAME)/c:*
-}
-
-if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
-  # Perform standard coarse-level synthesis script, flatten right away
-  # (-flatten part of $synth_args per default)
-  synth -run :fine {*}$::env(SYNTH_FULL_ARGS)
-} else {
-  # Perform standard coarse-level synthesis script,
-  # defer flattening until we have decided what hierarchy to keep
-  synth -run :fine
-
-  if {[env_var_exists_and_non_empty MAX_UNGROUP_SIZE]} {
-    set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
-    puts "Ungroup modules below estimated size of $ungroup_threshold instances"
-
-    convert_liberty_areas
-    keep_hierarchy -min_cost $ungroup_threshold
-  } else {
-    keep_hierarchy
-  }
-
+if {[env_var_equals SYNTH_HIERARCHICAL 1]} {
   # Re-run coarse-level script, this time do pass -flatten
+  #
+  # This is done here instead of in synth_coarse.tcl, because this part of
+  # the flow can be done in parallel for all the kept modules as
+  # well as being faster here, when taking SYNTH_BLACKBOXES into
+  # account for parallel builds.
   synth -run coarse:fine {*}$::env(SYNTH_FULL_ARGS)
 }
-
-json -o $::env(RESULTS_DIR)/mem.json
-# Run report and check here so as to fail early if this synthesis run is doomed
-exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
 
 if {![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS]} {
   synth -top $::env(DESIGN_NAME) -run fine: {*}$::env(SYNTH_FULL_ARGS)

--- a/flow/scripts/synth_coarse.tcl
+++ b/flow/scripts/synth_coarse.tcl
@@ -1,0 +1,35 @@
+source $::env(SCRIPTS_DIR)/synth_preamble.tcl
+
+hierarchy -check -top $::env(DESIGN_NAME)
+
+if { [env_var_equals SYNTH_GUT 1] } {
+  # /deletes all cells at the top level, which will quickly optimize away
+  # everything else, including macros.
+  delete $::env(DESIGN_NAME)/c:*
+}
+
+if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
+  # Perform standard coarse-level synthesis script, flatten right away
+  # (-flatten part of $synth_args per default)
+  synth -run :fine {*}$::env(SYNTH_FULL_ARGS)
+} else {
+  # Perform standard coarse-level synthesis script,
+  # defer flattening until we have decided what hierarchy to keep
+  synth -run :fine
+
+  if {[env_var_exists_and_non_empty MAX_UNGROUP_SIZE]} {
+    set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
+    puts "Ungroup modules below estimated size of $ungroup_threshold instances"
+
+    convert_liberty_areas
+    keep_hierarchy -min_cost $ungroup_threshold
+  } else {
+    keep_hierarchy
+  }
+}
+
+json -o $::env(RESULTS_DIR)/mem.json
+# Run report and check here so as to fail early if this synthesis run is doomed
+exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
+
+write_rtlil $::env(RESULTS_DIR)/1_yosys_coarse.rtlil


### PR DESCRIPTION
@povik Tinkering with faster/earlier synthesis reporting and parallel synthesis.

This is the minimum time to run synthesis before interesting things can be known about the design. Reports can be made about which modules will be kept, sram sizes to be realized as flip flops.

After this stage, it is possible to run the rest of synthesis in parallel for kept modules and combine the netlists.

Example of running times:

```
$ make DESIGN_CONFIG=designs/asap7/swerv_wrapper/config.mk clean_synth do-yosys-canonicalize
[deleted]
Elapsed time: 0:12.44[h:]min:sec. CPU time: user 12.02 sys 0.41 (99%). Peak memory: 1179692KB.
$ make DESIGN_CONFIG=designs/asap7/swerv_wrapper/config.mk do-yosys-coarse
[deleted]
Elapsed time: 0:31.94[h:]min:sec. CPU time: user 31.37 sys 0.55 (99%). Peak memory: 745904KB.
$ make DESIGN_CONFIG=designs/asap7/swerv_wrapper/config.mk do-yosys
[deleted]
Elapsed time: 4:04.65[h:]min:sec. CPU time: user 238.70 sys 5.90 (99%). Peak memory: 1148760KB.
```

For a larger design, like MegaBoom, this would of course be much longer and I'm not sure the relative running times are representative.

The Bazel dependency graph is static, so either a report of kept modules must be generated and stored in the bazel BUILD files, or bazel-orfs could set aside a configurable number of jobs, these jobs are hidden inside a rule to as not to pollute bazel query namespace, then each of these parallel jobs picks up its part of the synthesis work. This allows remote execution and parallel execution of the rest of the build.

The advantage of having a list of kept modules in bazel BUILD file is that the entire synthesis flow could be run in parallel. The coarse stage should run faster when run on individual modules. However, this requires maintaining that list(some automation is possible to update the list, but it is a slight cognitive load), whereas re-running the coarse synthesis would without further mindshare from the user always give the desired result.

In the case of MegaBoom, hierarchical synthesis is used to generate a macro placement, macro placement works better with hierarchical synthesis. The macro placement could be stored statically and updated semi-regularly with some automation, which would skip synthesis entirely for the purposes of creating a macro placement. There is something to be said for keeping macro placement stable during development to avoid strange effects with small seemingly unrelated RTL changes resulting a significantly different macro placement. Macro placement can be sensitive to initial conditions, a small change in input can yield a very different macro placement.

However, the actual MegaBoom build uses flattened synthesis for best results, though for everyday development hierarchical parallel synthesis would probably be a better choice sacrifizing some quality of results while iterating on RTL.

