### PR TITLE
synthesis: use fast coarse module size estimate to drive flattening policy

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -13,9 +13,15 @@ if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
   # (-flatten part of $synth_args per default)
   synth -run :fine {*}$::env(SYNTH_FULL_ARGS)
 } else {
-  # Perform standard coarse-level synthesis script,
-  # defer flattening until we have decided what hierarchy to keep
-  synth -run :fine
+  # Get a quick estimate of module sizes. Since we're only using
+  # this to decide which modules to flatten and which to keep,
+  # actual quality of results doesn't matter, so no point in running
+  # any optimizations of a coarse synthesis. the user has the
+  # option to tweak MAX_UNGROUP_SIZE or use an explicit list of
+  # modules to flatten if they have a better policy than this
+  # default policy on what to keep and what to flatten.
+  procs
+  memory -nomap
 
   if {[env_var_exists_and_non_empty MAX_UNGROUP_SIZE]} {
     set ungroup_threshold $::env(MAX_UNGROUP_SIZE)

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -21,6 +21,9 @@ if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
   # modules to flatten if they have a better policy than this
   # default policy on what to keep and what to flatten.
   procs
+  # reducing width significantly improves estimates without
+  # impacting running time much.
+  wreduce
   memory -nomap
 
   if {[env_var_exists_and_non_empty MAX_UNGROUP_SIZE]} {


### PR DESCRIPTION
Turns out that the improvement in quality of results is roughly linear or the user can make explicit choices about which modules to flatten, so no point in anything but a very rough fast module size estimate.

![image](https://github.com/user-attachments/assets/2cc86a87-bde9-49a7-8c81-abdd308e8ace)

This is the difference in sizes for modules in the 500 to 2000 size range for MAX_UNGROUP_SIZE=1000 default:

![image](https://github.com/user-attachments/assets/4690edbd-6f1d-40e4-9a07-a504bba11e5f)

Doctoring the data to use only 500 to 1500 range :-)

![image](https://github.com/user-attachments/assets/68870e74-cbab-4d5f-83c5-59565cee5096)



Some modules are in the changed set to keep, but not in original set. MAX_UNGROUP_SIZE=1000: exu_mul_ctl, 111005 and swerv, 1140.

So this would have me believe that exu_mul_ctl dropped from 111005 to less than 1000. The only effect from this is to flip flatten or not, but the effect on quality of results could be better or worse...



```
make DESIGN_CONFIG=designs/asap7/swerv_wrapper/config.mk do-yosys-coarse YOSYS_FLAGS=
```


ca. 11 seconds:

```
Keeping ram_2048x39 (estimated size above threshold: 57507 > 1000).
Keeping lsu_dccm_mem (estimated size above threshold: 1155 > 1000).
Keeping ram_256x34 (estimated size above threshold: 6266 > 1000).
Keeping IC_DATA_ICACHE_TAG_HIGH12_ICACHE_TAG_LOW6_ICACHE_IC_DEPTH8 (estimated size above threshold: 2997 > 1000).
Keeping IC_TAG_ICACHE_TAG_HIGH12_ICACHE_TAG_LOW6_ICACHE_TAG_DEPTH64 (estimated size above threshold: 4411 > 1000).
Keeping dbg (estimated size above threshold: 4919 > 1000).
Keeping dec_gpr_ctl_GPR_BANKS1_GPR_BANKS_LOG21 (estimated size above threshold: 22782 > 1000).
Keeping dec_trigger (estimated size above threshold: 6028 > 1000).
Keeping dec_decode_ctl (estimated size above threshold: 15816 > 1000).
Keeping dec_ib_ctl (estimated size above threshold: 3955 > 1000).
Keeping dec_tlu_ctl (estimated size above threshold: 20329 > 1000).
Keeping dma_ctrl (estimated size above threshold: 4727 > 1000).
Keeping exu_div_ctl (estimated size above threshold: 5061 > 1000).
Keeping exu_alu_ctl (estimated size above threshold: 3422 > 1000).
Keeping exu_mul_ctl (estimated size above threshold: 111005 > 1000).
Keeping exu (estimated size above threshold: 6615 > 1000).
Keeping ifu_aln_ctl (estimated size above threshold: 14726 > 1000).
Keeping ifu_bp_ctl (estimated size above threshold: 12990 > 1000).
Keeping ifu_ifc_ctl (estimated size above threshold: 1154 > 1000).
Keeping ifu_mem_ctl (estimated size above threshold: 9403 > 1000).
Keeping lsu_bus_buffer (estimated size above threshold: 26745 > 1000).
Keeping lsu_bus_intf (estimated size above threshold: 4680 > 1000).
Keeping lsu_dccm_ctl (estimated size above threshold: 1640 > 1000).
Keeping lsu_ecc (estimated size above threshold: 2107 > 1000).
Keeping lsu_lsc_ctl (estimated size above threshold: 4095 > 1000).
Keeping lsu_stbuf (estimated size above threshold: 15068 > 1000).
Keeping lsu_trigger (estimated size above threshold: 3325 > 1000).
Keeping pic_ctrl (estimated size above threshold: 2114 > 1000).
Keeping swerv (estimated size above threshold: 1140 > 1000).
```


original ca. 30 seconds to compile:

```
Keeping ram_2048x39 (estimated size above threshold: 57507 > 1000).
Keeping lsu_dccm_mem (estimated size above threshold: 1094 > 1000).
Keeping ram_256x34 (estimated size above threshold: 6266 > 1000).
Keeping IC_DATA_ICACHE_TAG_HIGH12_ICACHE_TAG_LOW6_ICACHE_IC_DEPTH8 (estimated size above threshold: 1741 > 1000).
Keeping IC_TAG_ICACHE_TAG_HIGH12_ICACHE_TAG_LOW6_ICACHE_TAG_DEPTH64 (estimated size above threshold: 4374 > 1000).
Keeping dbg (estimated size above threshold: 3796 > 1000).
Keeping dec_gpr_ctl_GPR_BANKS1_GPR_BANKS_LOG21 (estimated size above threshold: 14907 > 1000).
Keeping dec_trigger (estimated size above threshold: 5520 > 1000).
Keeping dec_decode_ctl (estimated size above threshold: 13835 > 1000).
Keeping dec_ib_ctl (estimated size above threshold: 3897 > 1000).
Keeping dec_tlu_ctl (estimated size above threshold: 14470 > 1000).
Warning: Can't determine cost of $macc cell (5 parameters).
Keeping dma_ctrl (estimated size above threshold: 3599 > 1000).
Keeping exu_div_ctl (estimated size above threshold: 4127 > 1000).
Keeping exu_alu_ctl (estimated size above threshold: 2889 > 1000).
Warning: Can't determine cost of $macc cell (5 parameters).
Keeping exu (estimated size above threshold: 5031 > 1000).
Keeping ifu_aln_ctl (estimated size above threshold: 12941 > 1000).
Warning: Can't determine cost of $macc cell (5 parameters).
Keeping ifu_bp_ctl (estimated size above threshold: 8285 > 1000).
Keeping ifu_ifc_ctl (estimated size above threshold: 1095 > 1000).
Keeping ifu_mem_ctl (estimated size above threshold: 3937 > 1000).
Warning: Can't determine cost of $macc cell (5 parameters).
Warning: Can't determine cost of $macc cell (5 parameters).
Warning: Can't determine cost of $macc cell (5 parameters).
Warning: Can't determine cost of $macc cell (5 parameters).
Keeping lsu_bus_buffer (estimated size above threshold: 17359 > 1000).
Keeping lsu_bus_intf (estimated size above threshold: 4301 > 1000).
Keeping lsu_dccm_ctl (estimated size above threshold: 1376 > 1000).
Keeping lsu_ecc (estimated size above threshold: 1774 > 1000).
Keeping lsu_lsc_ctl (estimated size above threshold: 3457 > 1000).
Warning: Can't determine cost of $macc cell (5 parameters).
Warning: Can't determine cost of $macc cell (5 parameters).
Keeping lsu_stbuf (estimated size above threshold: 9223 > 1000).
Keeping lsu_trigger (estimated size above threshold: 3067 > 1000).
Keeping pic_ctrl (estimated size above threshold: 1418 > 1000).
```
