### PR TITLE
synthesis: rename MAX_UNGROUP_SIZE to SYNTH_MINIMUM_KEEP_SIZE

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -122,7 +122,6 @@ configuration file.
 | <a name="MAKE_TRACKS"></a>MAKE_TRACKS| Tcl file that defines add routing tracks to a floorplan.| | |
 | <a name="MATCH_CELL_FOOTPRINT"></a>MATCH_CELL_FOOTPRINT| Enforce sizing operations to only swap cells that have the same layout boundary.| 0| |
 | <a name="MAX_ROUTING_LAYER"></a>MAX_ROUTING_LAYER| The highest metal layer name to be used in routing.| | |
-| <a name="MAX_UNGROUP_SIZE"></a>MAX_UNGROUP_SIZE| For hierarchical synthesis, we ungroup modules of larger area than given by this variable. The area unit used is the size of a basic nand2 gate from the platform's standard cell library. The default value is platform specific.| | |
 | <a name="MIN_BUF_CELL_AND_PORTS"></a>MIN_BUF_CELL_AND_PORTS| Used to insert a buffer cell to pass through wires. Used in synthesis.| | |
 | <a name="MIN_ROUTING_LAYER"></a>MIN_ROUTING_LAYER| The lowest metal layer name to be used in routing.| | |
 | <a name="PDN_TCL"></a>PDN_TCL| File path which has a set of power grid policies used by pdn to be applied to the design, such as layers to use, stripe width and spacing to generate the actual metal straps.| | |
@@ -183,6 +182,7 @@ configuration file.
 | <a name="SYNTH_GUT"></a>SYNTH_GUT| Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.| | |
 | <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| 0| |
 | <a name="SYNTH_MEMORY_MAX_BITS"></a>SYNTH_MEMORY_MAX_BITS| Maximum number of bits for memory synthesis.| 4096| |
+| <a name="SYNTH_MINIMUM_KEEP_SIZE"></a>SYNTH_MINIMUM_KEEP_SIZE| For hierarchical synthesis, we keep modules of larger area than given by this variable and flatten smaller modules. The area unit used is the size of a basic nand2 gate from the platform's standard cell library. The default value is platform specific.| | |
 | <a name="SYNTH_NETLIST_FILES"></a>SYNTH_NETLIST_FILES| Skips synthesis and uses the supplied netlist files. If the netlist files contains duplicate modules, which can happen when using hierarchical synthesis on indvidual netlist files and combining here, subsequent modules are silently ignored and only the first module is used.| | |
 | <a name="SYNTH_WRAPPED_OPERATORS"></a>SYNTH_WRAPPED_OPERATORS| Synthesize multiple architectural options for each arithmetic operator in the design. These options are available for switching among in later stages of the flow.| | |
 | <a name="TAPCELL_TCL"></a>TAPCELL_TCL| Path to Endcap and Welltie cells file.| | |
@@ -205,7 +205,6 @@ configuration file.
 - [ADDER_MAP_FILE](#ADDER_MAP_FILE)
 - [CLKGATE_MAP_FILE](#CLKGATE_MAP_FILE)
 - [LATCH_MAP_FILE](#LATCH_MAP_FILE)
-- [MAX_UNGROUP_SIZE](#MAX_UNGROUP_SIZE)
 - [MIN_BUF_CELL_AND_PORTS](#MIN_BUF_CELL_AND_PORTS)
 - [SDC_FILE](#SDC_FILE)
 - [SDC_GUT](#SDC_GUT)
@@ -213,6 +212,7 @@ configuration file.
 - [SYNTH_GUT](#SYNTH_GUT)
 - [SYNTH_HIERARCHICAL](#SYNTH_HIERARCHICAL)
 - [SYNTH_MEMORY_MAX_BITS](#SYNTH_MEMORY_MAX_BITS)
+- [SYNTH_MINIMUM_KEEP_SIZE](#SYNTH_MINIMUM_KEEP_SIZE)
 - [SYNTH_NETLIST_FILES](#SYNTH_NETLIST_FILES)
 - [SYNTH_WRAPPED_OPERATORS](#SYNTH_WRAPPED_OPERATORS)
 - [TIEHI_CELL_AND_PORT](#TIEHI_CELL_AND_PORT)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -160,7 +160,7 @@ include $(PLATFORM_DIR)/config.mk
 $(foreach line,$(shell $(SCRIPTS_DIR)/defaults.py),$(eval export $(subst __SPACE__, ,$(line))))
 
 # If the design, nor $(PLATFORM_DIR)/config.mk provided a default, provide one here
-export MAX_UNGROUP_SIZE ?= 0
+export SYNTH_MINIMUM_KEEP_SIZE ?= 0
 
 # Not normally adjusted by user
 export SYNTH_OPERATIONS_ARGS ?= -extra-map $(FLOW_HOME)/platforms/common/lcu_kogge_stone.v

--- a/flow/designs/asap7/aes/README.md
+++ b/flow/designs/asap7/aes/README.md
@@ -3,7 +3,7 @@
 For large designs, it can be useful to split synthesis for the
 major blocks and combine the synthesized result.
 
-SYNTH_HIERARCHICAL=1 and MAX_UNGROUP_SIZE can be used to adjust which
+SYNTH_HIERARCHICAL=1 and SYNTH_MINIMUM_KEEP_SIZE can be used to adjust which
 modules are flattened and which are kept.
 
 A module that is not flattened, can be built separately without any

--- a/flow/designs/asap7/minimal/config.mk
+++ b/flow/designs/asap7/minimal/config.mk
@@ -4,7 +4,7 @@ export PLATFORM = asap7
 # Faster build and more information in GUI with hierarchical synthesis
 export SYNTH_HIERARCHICAL ?= 1
 # Keep all modules so we can examine the full hierarchy
-export MAX_UNGROUP_SIZE ?= 0
+export SYNTH_MINIMUM_KEEP_SIZE ?= 0
 
 # Set the core utilization to 10% for the minimal design to
 # maximize chances of getting an initial floorplan. This

--- a/flow/designs/asap7/riscv32i/config.mk
+++ b/flow/designs/asap7/riscv32i/config.mk
@@ -9,7 +9,7 @@ export RTLMP_MAX_INST = 3500
 export RTLMP_MIN_MACRO = 1
 export RTLMP_MAX_MACRO = 5
 
-export MAX_UNGROUP_SIZE ?= 10000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 10000
 
 export VERILOG_FILES = $(sort $(wildcard $(DESIGN_HOME)/src/riscv32i/*.v))
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/riscv32i/constraint.sdc

--- a/flow/designs/gf12/ariane/config.mk
+++ b/flow/designs/gf12/ariane/config.mk
@@ -2,7 +2,7 @@ export DESIGN_NAME = ariane
 export PLATFORM    = gf12
 
 export SYNTH_HIERARCHICAL = 1
-export MAX_UNGROUP_SIZE ?= 10000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 10000
 #
 
 export VERILOG_FILES = $(DESIGN_HOME)/src/$(DESIGN_NAME)/ariane.sv2v.v \

--- a/flow/designs/gf12/ariane133/config.mk
+++ b/flow/designs/gf12/ariane133/config.mk
@@ -3,7 +3,7 @@ export DESIGN_NAME = ariane
 export PLATFORM    = gf12
 
 export SYNTH_HIERARCHICAL = 1
-export MAX_UNGROUP_SIZE ?= 10000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 10000
 
 export VERILOG_FILES = $(PLATFORM_DIR)/ariane133/ariane.v
 

--- a/flow/designs/gf12/bp_quad/config.mk
+++ b/flow/designs/gf12/bp_quad/config.mk
@@ -3,7 +3,7 @@ export DESIGN_NAME = bsg_chip
 export PLATFORM    = gf12
 
 export SYNTH_HIERARCHICAL = 1
-export MAX_UNGROUP_SIZE ?= 1000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 1000
 
 export SYNTH_NETLIST_FILES = $(PLATFORM_DIR)/bp/bsg_ac_black_parrot_quad_core_v0/bp_quad_block/yosys/bp_quad_yosys_netlist.v
 export VERILOG_FILES = $(PLATFORM_DIR)/bp/bsg_ac_black_parrot_quad_core_v0/bp_quad_block/rtl/bsg_chip_block.sv2v.v

--- a/flow/designs/gf12/swerv_wrapper/config.mk
+++ b/flow/designs/gf12/swerv_wrapper/config.mk
@@ -1,7 +1,7 @@
 export DESIGN_NAME = swerv_wrapper
 export PLATFORM    = gf12
 #
-export MAX_UNGROUP_SIZE ?= 10000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 10000
 export SYNTH_HIERARCHICAL = 1
 
 # RTL_MP Settings

--- a/flow/designs/gf12/tinyRocket/config.mk
+++ b/flow/designs/gf12/tinyRocket/config.mk
@@ -3,7 +3,7 @@ export DESIGN_NAME = RocketTile
 export PLATFORM    = gf12
 
 export SYNTH_HIERARCHICAL = 1
-export MAX_UNGROUP_SIZE ?= 1000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 1000
 
 export VERILOG_FILES  = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/AsyncResetReg.v \
                         $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/ClockDivider2.v \

--- a/flow/designs/nangate45/tinyRocket/config.mk
+++ b/flow/designs/nangate45/tinyRocket/config.mk
@@ -3,7 +3,7 @@ export DESIGN_NAME = RocketTile
 export PLATFORM    = nangate45
 
 export SYNTH_HIERARCHICAL = 1
-export MAX_UNGROUP_SIZE ?= 5000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 5000
 
 export VERILOG_FILES = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/AsyncResetReg.v \
                        $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/ClockDivider2.v \

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -81,7 +81,7 @@ export DONT_USE_CELLS          += SDF* ICG*
 export LATCH_MAP_FILE          = $(PLATFORM_DIR)/yoSys/cells_latch_R.v
 export CLKGATE_MAP_FILE        = $(PLATFORM_DIR)/yoSys/cells_clkgate_R.v
 export ADDER_MAP_FILE         ?= $(PLATFORM_DIR)/yoSys/cells_adders_R.v
-export MAX_UNGROUP_SIZE       ?= 1000
+export SYNTH_MINIMUM_KEEP_SIZE       ?= 1000
 
 export ABC_DRIVER_CELL         = BUFx2_ASAP7_75t_R
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -22,7 +22,7 @@ export FILL_CELLS ?= FILLCELL_X1 FILLCELL_X2 FILLCELL_X4 FILLCELL_X8 FILLCELL_X1
 #  Yosys
 #  ----------------------------------------------------
 # Ungroup size for hierarchical synthesis
-export MAX_UNGROUP_SIZE ?= 10000
+export SYNTH_MINIMUM_KEEP_SIZE ?= 10000
 # Set the TIEHI/TIELO cells
 # These are used in yosys synthesis to avoid logical 1/0's in the netlist
 export TIEHI_CELL_AND_PORT = LOGIC1_X1 Z

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -17,9 +17,9 @@ if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
   # defer flattening until we have decided what hierarchy to keep
   synth -run :fine
 
-  if {[env_var_exists_and_non_empty MAX_UNGROUP_SIZE]} {
-    set ungroup_threshold $::env(MAX_UNGROUP_SIZE)
-    puts "Ungroup modules below estimated size of $ungroup_threshold instances"
+  if {[env_var_exists_and_non_empty SYNTH_MINIMUM_KEEP_SIZE]} {
+    set ungroup_threshold $::env(SYNTH_MINIMUM_KEEP_SIZE)
+    puts "Keep modules above estimated size of $ungroup_threshold gate equivalents"
 
     convert_liberty_areas
     keep_hierarchy -min_cost $ungroup_threshold

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -232,10 +232,11 @@ ABC_LOAD_IN_FF:
     During synthesis set_load value used.
   stages:
     - synth
-MAX_UNGROUP_SIZE:
+SYNTH_MINIMUM_KEEP_SIZE:
   description: >
-    For hierarchical synthesis, we ungroup modules of larger area than given by
-    this variable. The area unit used is the size of a basic nand2 gate from the
+    For hierarchical synthesis, we keep modules of larger area than given by
+    this variable and flatten smaller modules.
+    The area unit used is the size of a basic nand2 gate from the
     platform's standard cell library. The default value is platform specific.
   stages:
     - synth


### PR DESCRIPTION
SYNTH_ prefix minimizes surprises.

Use keep terminology consistently.