### PR TITLE
Add Nix flake to ORFS.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,171 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741851582,
+        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1724316499,
+        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "openroad": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1741801451,
+        "narHash": "sha256-fzWCeq0o6vx8/GoFcOtnaIENes3jXzNk9qfWnIaxtHI=",
+        "ref": "refs/heads/master",
+        "rev": "ec1bf1a13902813b722f8341c432cd09714d9e55",
+        "revCount": 27845,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
+      },
+      "original": {
+        "rev": "ec1bf1a13902813b722f8341c432cd09714d9e55",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "openroad": "openroad",
+        "yosys": "yosys"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "yosys": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1741764697,
+        "narHash": "sha256-5jQ9l0cyRhEI4UFInW3kqw5B+mdLFr66nfG716rO454=",
+        "ref": "refs/heads/master",
+        "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
+        "revCount": 14791,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/The-OpenROAD-Project/yosys"
+      },
+      "original": {
+        "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/The-OpenROAD-Project/yosys"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    openroad = {
+      type = "git";
+      url = "https://github.com/The-OpenROAD-Project/OpenROAD";
+      submodules = true;
+      rev = "ec1bf1a13902813b722f8341c432cd09714d9e55";
+    };
+    yosys = {
+      type = "git";
+      url = "https://github.com/The-OpenROAD-Project/yosys";
+      submodules = true;
+      rev = "c4b5190229616f7ebf8197f43990b4429de3e420";
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, openroad, yosys }: flake-utils.lib.eachDefaultSystem (
+    system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [
+          openroad.packages.${system}.default
+          yosys.packages.${system}.default
+          pkgs.klayout
+          pkgs.verilator
+	  pkgs.python3
+          pkgs.python3Packages.pandas
+          pkgs.python3Packages.numpy
+          pkgs.python3Packages.firebase-admin
+          pkgs.python3Packages.click
+          pkgs.python3Packages.pyyaml
+          pkgs.python3Packages.yamlfix
+        ];
+      };
+    }
+  );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,9 +24,11 @@
         buildInputs = [
           openroad.packages.${system}.default
           yosys.packages.${system}.default
+          pkgs.time
           pkgs.klayout
           pkgs.verilator
-	  pkgs.python3
+          pkgs.perl
+          pkgs.python3
           pkgs.python3Packages.pandas
           pkgs.python3Packages.numpy
           pkgs.python3Packages.firebase-admin

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -232,15 +232,27 @@ endif
 # Priority is given to
 #       1 user explicit set with variable in Makefile or command line, for instance setting OPENROAD_EXE
 #       2 ORFS compiled tools: openroad, yosys
-export OPENROAD_EXE      ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/openroad)
-export OPENSTA_EXE       ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/sta)
+ifneq (${IN_NIX_SHELL}, "")
+  export OPENROAD_EXE := $(shell which openroad)
+else
+  export OPENROAD_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/openroad)
+endif
+ifneq (${IN_NIX_SHELL}, "")
+  export OPENSTA_EXE := $(shell which opensta)
+else
+  export OPENSTA_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/opensta)
+endif
 
 OPENROAD_ARGS            = -no_init -threads $(NUM_CORES) $(OR_ARGS)
 OPENROAD_CMD             = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
 OPENROAD_NO_EXIT_CMD     = $(OPENROAD_EXE) $(OPENROAD_ARGS)
 OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
 
-YOSYS_EXE               ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
+ifneq (${IN_NIX_SHELL}, "")
+  YOSYS_EXE := $(shell which yosys)
+else
+  YOSYS_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
+endif
 
 # Use locally installed and built klayout if it exists, otherwise use klayout in path
 KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -232,15 +232,15 @@ endif
 # Priority is given to
 #       1 user explicit set with variable in Makefile or command line, for instance setting OPENROAD_EXE
 #       2 ORFS compiled tools: openroad, yosys
-ifneq (${IN_NIX_SHELL}, "")
-  export OPENROAD_EXE := $(shell which openroad)
+ifneq (${IN_NIX_SHELL},)
+  export OPENROAD_EXE := $(shell command -v openroad)
 else
   export OPENROAD_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/openroad)
 endif
-ifneq (${IN_NIX_SHELL}, "")
-  export OPENSTA_EXE := $(shell which opensta)
+ifneq (${IN_NIX_SHELL},)
+  export OPENSTA_EXE := $(shell command -v sta)
 else
-  export OPENSTA_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/opensta)
+  export OPENSTA_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/sta)
 endif
 
 OPENROAD_ARGS            = -no_init -threads $(NUM_CORES) $(OR_ARGS)
@@ -248,8 +248,8 @@ OPENROAD_CMD             = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
 OPENROAD_NO_EXIT_CMD     = $(OPENROAD_EXE) $(OPENROAD_ARGS)
 OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
 
-ifneq (${IN_NIX_SHELL}, "")
-  YOSYS_EXE := $(shell which yosys)
+ifneq (${IN_NIX_SHELL},)
+  YOSYS_EXE := $(shell command -v yosys)
 else
   YOSYS_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
 endif


### PR DESCRIPTION
Hopefully this should allow users to invoke `nix develop` (with the appropriate arguments) in order to drop into a shell with OpenROAD and Yosys. I'm uncertain whether the AutoTuner works with this since I don't have anything to test it with at the moment, but I'd be happy to get some feedback on that.