### PR TITLE
Enabled cva6 on asap7 using yosys-slang

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -1,0 +1,196 @@
+#
+# TODO before enablement: pipe VERILOG_DEFINES through to yosys
+#
+
+export PLATFORM               = asap7
+
+export DESIGN_NAME            = cva6
+
+export VERILOG_FILES          = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/config_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/cv32a65x_config_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/riscv_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/ariane_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/axi/src/axi_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/wt_cache_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/std_cache_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include/build_config_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_example/include/cvxif_instr_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/cf_math_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_pkg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_cast_multi.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_classifier.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_divsqrt_multi.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_fma_multi.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_fma.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_noncomp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_opgroup_block.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_opgroup_fmt_slice.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_opgroup_multifmt_slice.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_rounding.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpnew_top.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_compressed_if_driver.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_issue_register_commit_if_driver.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_fu.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_example/instr_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_example/compressed_instr_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvxif_example/copro_alu.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/fifo_v3.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/lfsr.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/lfsr_8bit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/stream_arbiter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/stream_arbiter_flushable.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/stream_mux.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/stream_demux.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/lzc.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/shift_reg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/unread.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/popcount.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/exp_backoff.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/counter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/common_cells/src/delta_counter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_rvfi_probes.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/alu.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/fpu_wrap.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/branch_unit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/compressed_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/macro_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/controller.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/zcmt_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/csr_buffer.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/csr_regfile.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/ex_stage.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/instr_realign.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/id_stage.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/issue_read_operands.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/issue_stage.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/load_unit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/load_store_unit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/lsu_bypass.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/mult.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/multiplier.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/serdiv.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/perf_counters.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/ariane_regfile_ff.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/scoreboard.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/store_buffer.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/amo_buffer.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/store_unit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/commit_stage.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/axi_shim.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_accel_first_pass_decoder_stub.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/acc_dispatcher.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_fifo_v3.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/btb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/bht.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/bht2lvl.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/ras.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/instr_scan.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/instr_queue.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/frontend/frontend.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_dcache_ctrl.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_dcache_mem.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_dcache_missunit.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_dcache_wbuffer.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_dcache.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_icache.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_cache_subsystem.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/wt_axi_adapter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/tag_cmp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/axi_adapter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cache_ctrl.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_icache_axi_wrapper.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/std_cache_subsystem.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/std_nbdcache.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/utils/hpdcache_mem_resp_demux.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/utils/hpdcache_mem_to_axi_read.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/utils/hpdcache_mem_to_axi_write.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_hpdcache_subsystem.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_hpdcache_subsystem_axi_arbiter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_hpdcache_if_adapter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/cva6_hpdcache_wrapper.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/macros/blackbox/hpdcache_sram_1rw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/macros/blackbox/hpdcache_sram_wbyteenable_1rw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/macros/blackbox/hpdcache_sram_wmask_1rw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp_entry.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp_data_if.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/tc_sram_wrapper.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/tc_sram_wrapper_cache_techno.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/sram.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/sram_cache.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_mmu/cva6_mmu.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_mmu/cva6_ptw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_mmu/cva6_tlb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cva6_mmu/cva6_shared_tlb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/utils/hpdcache_mem_req_read_arbiter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/utils/hpdcache_mem_req_write_arbiter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_demux.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_lfsr.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sync_buffer.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_fifo_reg.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_fxarb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_rrarb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_mux.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_decoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_1hot_to_binary.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_prio_1hot_encoder.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram_wbyteenable.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram_wmask.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_regbank_wbyteenable_1rw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_regbank_wmask_1rw.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_data_downsize.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_data_upsize.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_data_resize.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_arb.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_wrapper.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_amo.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_cmo.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_core_arbiter.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_ctrl.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_ctrl_pe.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_memctrl.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_miss_handler.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_mshr.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_rtab.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_uncached.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_plru.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_random.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_sel.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_wbuf.sv \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_flush.sv
+
+export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/common_cells/include \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/include
+
+VERILOG_DEFINES += -D HPDCACHE_ASSERT_OFF
+
+export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
+
+export DIE_AREA               = 0 0 200 200
+export CORE_AREA              = 1.08 1.08 190 190
+
+export PLACE_DENSITY          = 0.40
+
+# a smoketest for this option, there are a
+# few last gasp iterations
+export SKIP_LAST_GASP ?= 1
+
+
+export SYNTH_USE_SLANG = 1

--- a/flow/designs/asap7/cva6/constraint.sdc
+++ b/flow/designs/asap7/cva6/constraint.sdc
@@ -1,0 +1,28 @@
+# Derived from cva6_synth.tcl and Makefiles
+
+set clk_name main_clk
+set clk_port clk_i
+set clk_ports_list [list $clk_port]
+set clk_period 1300
+set input_delay 0.46
+set output_delay 0.11
+create_clock [get_ports $clk_port] -name $clk_name -period $clk_period
+
+# #set_dont_touch to keep sram as black boxes
+# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams[*].i_tag_sram
+# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks[*].i_data_sram
+# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].data_sram
+# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].tag_sram
+# #constraint the timing to and from the sram black boxes
+# set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+
+# set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+
+
+set_false_path -to [get_ports {rvfi_probes_o}]

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,0 +1,70 @@
+{
+    "synth__design__instance__area__stdcell": {
+        "value": 13337.62,
+        "compare": "<="
+    },
+    "constraints__clocks__count": {
+        "value": 1,
+        "compare": "=="
+    },
+    "placeopt__design__instance__area": {
+        "value": 15798,
+        "compare": "<="
+    },
+    "placeopt__design__instance__count__stdcell": {
+        "value": 130789,
+        "compare": "<="
+    },
+    "detailedplace__design__violations": {
+        "value": 0,
+        "compare": "=="
+    },
+    "cts__design__instance__count__setup_buffer": {
+        "value": 11373,
+        "compare": "<="
+    },
+    "cts__design__instance__count__hold_buffer": {
+        "value": 11373,
+        "compare": "<="
+    },
+    "globalroute__antenna_diodes_count": {
+        "value": 0,
+        "compare": "<="
+    },
+    "detailedroute__route__wirelength": {
+        "value": 1241141,
+        "compare": "<="
+    },
+    "detailedroute__route__drc_errors": {
+        "value": 0,
+        "compare": "<="
+    },
+    "detailedroute__antenna__violating__nets": {
+        "value": 0,
+        "compare": "<="
+    },
+    "detailedroute__antenna_diodes_count": {
+        "value": 5,
+        "compare": "<="
+    },
+    "finish__timing__setup__ws": {
+        "value": -181.59,
+        "compare": ">="
+    },
+    "finish__design__instance__area": {
+        "value": 16112,
+        "compare": "<="
+    },
+    "finish__timing__drv__setup_violation_count": {
+        "value": 5686,
+        "compare": "<="
+    },
+    "finish__timing__drv__hold_violation_count": {
+        "value": 100,
+        "compare": "<="
+    },
+    "finish__timing__wns_percent_delay": {
+        "value": -18.66,
+        "compare": ">="
+    }
+}

--- a/flow/designs/src/cva6/README.md
+++ b/flow/designs/src/cva6/README.md
@@ -1,0 +1,1 @@
+Extracted from https://github.com/openhwgroup/cva6

--- a/flow/designs/src/cva6/common/local/util/sram.sv
+++ b/flow/designs/src/cva6/common/local/util/sram.sv
@@ -1,0 +1,117 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
+// Description: SRAM wrapper for FPGA (requires the fpga-support submodule)
+//
+// Note: the wrapped module contains two different implementations for
+// ALTERA and XILINX tools, since these follow different coding styles for
+// inferrable RAMS with byte enable. define `FPGA_TARGET_XILINX or
+// `FPGA_TARGET_ALTERA in your build environment (default is ALTERA)
+
+module sram #(
+    parameter DATA_WIDTH = 64,
+    parameter USER_WIDTH = 1,
+    parameter USER_EN    = 0,
+    parameter NUM_WORDS  = 1024,
+    parameter SIM_INIT   = "none",
+    parameter OUT_REGS   = 0     // enables output registers in FPGA macro (read lat = 2)
+)(
+   input  logic                          clk_i,
+   input  logic                          rst_ni,
+   input  logic                          req_i,
+   input  logic                          we_i,
+   input  logic [$clog2(NUM_WORDS)-1:0]  addr_i,
+   input  logic [USER_WIDTH-1:0]         wuser_i,
+   input  logic [DATA_WIDTH-1:0]         wdata_i,
+   input  logic [(DATA_WIDTH+7)/8-1:0]   be_i,
+   output logic [USER_WIDTH-1:0]         ruser_o,
+   output logic [DATA_WIDTH-1:0]         rdata_o
+);
+
+localparam DATA_WIDTH_ALIGNED = ((DATA_WIDTH+63)/64)*64;
+localparam USER_WIDTH_ALIGNED = DATA_WIDTH_ALIGNED; // To be fine tuned to reduce memory size
+localparam BE_WIDTH_ALIGNED   = (((DATA_WIDTH+7)/8+7)/8)*8;
+
+logic [DATA_WIDTH_ALIGNED-1:0]  wdata_aligned;
+logic [USER_WIDTH_ALIGNED-1:0]  wuser_aligned;
+logic [BE_WIDTH_ALIGNED-1:0]    be_aligned;
+logic [DATA_WIDTH_ALIGNED-1:0]  rdata_aligned;
+logic [USER_WIDTH_ALIGNED-1:0]  ruser_aligned;
+
+
+// align to 64 bits for inferrable macro below
+always_comb begin : p_align
+    wdata_aligned                    ='0;
+    wuser_aligned                    ='0;
+    be_aligned                       ='0;
+    wdata_aligned[DATA_WIDTH-1:0]    = wdata_i;
+    wuser_aligned[USER_WIDTH-1:0]    = wuser_i;
+    be_aligned[BE_WIDTH_ALIGNED-1:0] = be_i;
+
+    rdata_o = rdata_aligned[DATA_WIDTH-1:0];
+    ruser_o = ruser_aligned[USER_WIDTH-1:0];
+end
+
+  for (genvar k = 0; k<(DATA_WIDTH+63)/64; k++) begin : gen_cut
+      // unused byte-enable segments (8bits) are culled by the tool
+      tc_sram_wrapper #(
+        .NumWords(NUM_WORDS),           // Number of Words in data array
+        .DataWidth(64),                 // Data signal width
+        .ByteWidth(32'd8),              // Width of a data byte
+        .NumPorts(32'd1),               // Number of read and write ports
+        .Latency(32'd1),                // Latency when the read data is available
+        .SimInit(SIM_INIT),             // Simulation initialization
+        .PrintSimCfg(1'b0)              // Print configuration
+      ) i_tc_sram_wrapper (
+          .clk_i    ( clk_i                     ),
+          .rst_ni   ( rst_ni                    ),
+          .req_i    ( req_i                     ),
+          .we_i     ( we_i                      ),
+          .be_i     ( be_aligned[k*8 +: 8]      ),
+          .wdata_i  ( wdata_aligned[k*64 +: 64] ),
+          .addr_i   ( addr_i                    ),
+          .rdata_o  ( rdata_aligned[k*64 +: 64] )
+      );
+      if (USER_EN > 0) begin : gen_mem_user
+        tc_sram_wrapper #(
+          .NumWords(NUM_WORDS),           // Number of Words in data array
+          .DataWidth(64),                 // Data signal width
+          .ByteWidth(32'd8),              // Width of a data byte
+          .NumPorts(32'd1),               // Number of read and write ports
+          .Latency(32'd1),                // Latency when the read data is available
+          .SimInit(SIM_INIT),             // Simulation initialization
+          .PrintSimCfg(1'b0)              // Print configuration
+        ) i_tc_sram_wrapper_user (
+            .clk_i    ( clk_i                     ),
+            .rst_ni   ( rst_ni                    ),
+            .req_i    ( req_i                     ),
+            .we_i     ( we_i                      ),
+            .be_i     ( be_aligned[k*8 +: 8]      ),
+            .wdata_i  ( wuser_aligned[k*64 +: 64] ),
+            .addr_i   ( addr_i                    ),
+            .rdata_o  ( ruser_aligned[k*64 +: 64] )
+        );
+      end else begin : gen_mem_user
+          assign ruser_aligned[k*64 +: 64] = '0;
+          // synthesis translate_off
+          begin: i_tc_sram_wrapper_user
+            begin: i_tc_sram
+              localparam type data_t = logic [63:0];
+              data_t init_val [0:0];
+              data_t sram [NUM_WORDS-1:0] /* verilator public_flat */;
+            end
+          end
+          // synthesis translate_on
+      end
+  end
+endmodule : sram

--- a/flow/designs/src/cva6/common/local/util/sram_cache.sv
+++ b/flow/designs/src/cva6/common/local/util/sram_cache.sv
@@ -1,0 +1,126 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Florian Zaruba    <zarubaf@iis.ee.ethz.ch>, ETH Zurich
+//         Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 15.08.2018
+// Description: SRAM wrapper for FPGA (requires the fpga-support submodule)
+//
+// Note: the wrapped module contains two different implementations for
+// ALTERA and XILINX tools, since these follow different coding styles for
+// inferrable RAMS with byte enable. define `FPGA_TARGET_XILINX or
+// `FPGA_TARGET_ALTERA in your build environment (default is ALTERA)
+
+module sram_cache #(
+    parameter DATA_WIDTH = 64,
+    parameter USER_WIDTH = 1,
+    parameter USER_EN    = 0,
+    parameter NUM_WORDS  = 1024,
+    parameter SIM_INIT   = "none",
+    parameter BYTE_ACCESS = 1,
+    parameter TECHNO_CUT = 0,
+    parameter OUT_REGS   = 0     // enables output registers in FPGA macro (read lat = 2)
+)(
+   input  logic                          clk_i,
+   input  logic                          rst_ni,
+   input  logic                          req_i,
+   input  logic                          we_i,
+   input  logic [$clog2(NUM_WORDS)-1:0]  addr_i,
+   input  logic [USER_WIDTH-1:0]         wuser_i,
+   input  logic [DATA_WIDTH-1:0]         wdata_i,
+   input  logic [(DATA_WIDTH+7)/8-1:0]   be_i,
+   output logic [USER_WIDTH-1:0]         ruser_o,
+   output logic [DATA_WIDTH-1:0]         rdata_o
+);
+  localparam DATA_AND_USER_WIDTH = USER_EN ? DATA_WIDTH + USER_WIDTH : DATA_WIDTH;
+  if (TECHNO_CUT) begin : gen_techno_cut
+    if (USER_EN > 0) begin
+      logic [DATA_WIDTH + USER_WIDTH-1:0] wdata_user;
+      logic [DATA_WIDTH + USER_WIDTH-1:0] rdata_user;
+      logic [(DATA_WIDTH+7)/8+(DATA_WIDTH+7)/8-1:0] be;
+
+      always_comb begin
+        wdata_user = {wdata_i, wuser_i};
+        be         = {be_i, be_i};
+        rdata_o    = rdata_user[DATA_AND_USER_WIDTH-1:DATA_WIDTH];
+        ruser_o    = rdata_user[USER_WIDTH-1:0];
+      end
+      tc_sram_wrapper_cache_techno #(
+        .NumWords(NUM_WORDS),           // Number of Words in data array
+        .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
+        .ByteWidth(32'd8),              // Width of a data byte
+        .NumPorts(32'd1),               // Number of read and write ports
+        .Latency(32'd1),                // Latency when the read data is available
+        .SimInit(SIM_INIT),             // Simulation initialization
+        .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
+        .PrintSimCfg(1'b0)              // Print configuration
+      ) i_tc_sram_wrapper (
+        .clk_i    ( clk_i                     ),
+        .rst_ni   ( rst_ni                    ),
+        .req_i    ( req_i                     ),
+        .we_i     ( we_i                      ),
+        .be_i     ( be                        ),
+        .wdata_i  ( wdata_user                ),
+        .addr_i   ( addr_i                    ),
+        .rdata_o  ( rdata_user                )
+      );
+    end else begin
+      logic [DATA_WIDTH-1:0] wdata_user;
+      logic [DATA_WIDTH-1:0] rdata_user;
+      logic [(DATA_WIDTH+7)/8-1:0] be;
+
+      always_comb begin
+        wdata_user = wdata_i;
+        be         = be_i;
+        rdata_o    = rdata_user;
+        ruser_o    = '0;
+      end
+      tc_sram_wrapper_cache_techno #(
+        .NumWords(NUM_WORDS),           // Number of Words in data array
+        .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
+        .ByteWidth(32'd8),              // Width of a data byte
+        .NumPorts(32'd1),               // Number of read and write ports
+        .Latency(32'd1),                // Latency when the read data is available
+        .SimInit(SIM_INIT),             // Simulation initialization
+        .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
+        .PrintSimCfg(1'b0)              // Print configuration
+      ) i_tc_sram_wrapper (
+        .clk_i    ( clk_i                     ),
+        .rst_ni   ( rst_ni                    ),
+        .req_i    ( req_i                     ),
+        .we_i     ( we_i                      ),
+        .be_i     ( be                        ),
+        .wdata_i  ( wdata_user                ),
+        .addr_i   ( addr_i                    ),
+        .rdata_o  ( rdata_user                )
+      );
+    end
+  end else begin
+    sram #(
+          .USER_WIDTH (USER_WIDTH),
+          .DATA_WIDTH (DATA_WIDTH),
+          .USER_EN    (USER_EN),
+          .NUM_WORDS  (NUM_WORDS)
+      ) data_sram (
+          .clk_i  (clk_i),
+          .rst_ni (rst_ni),
+          .req_i  (req_i),
+          .we_i   (we_i),
+          .addr_i (addr_i),
+          .wuser_i(wuser_i),
+          .wdata_i(wdata_i),
+          .be_i   (be_i),
+          .ruser_o(ruser_o),
+          .rdata_o(rdata_o)
+      );
+  end
+
+
+endmodule : sram_cache

--- a/flow/designs/src/cva6/common/local/util/tc_sram_wrapper.sv
+++ b/flow/designs/src/cva6/common/local/util/tc_sram_wrapper.sv
@@ -1,0 +1,60 @@
+// Copyright 2022 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+module tc_sram_wrapper #(
+  parameter int unsigned NumWords     = 32'd1024, // Number of Words in data array
+  parameter int unsigned DataWidth    = 32'd128,  // Data signal width
+  parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
+  parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
+  parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
+  parameter              SimInit      = "none",   // Simulation initialization
+  parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
+  parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
+  parameter type         addr_t    = logic [AddrWidth-1:0],
+  parameter type         data_t    = logic [DataWidth-1:0],
+  parameter type         be_t      = logic [BeWidth-1:0]
+) (
+  input  logic                 clk_i,      // Clock
+  input  logic                 rst_ni,     // Asynchronous reset active low
+  // input ports
+  input  logic  [NumPorts-1:0] req_i,      // request
+  input  logic  [NumPorts-1:0] we_i,       // write enable
+  input  addr_t [NumPorts-1:0] addr_i,     // request address
+  input  data_t [NumPorts-1:0] wdata_i,    // write data
+  input  be_t   [NumPorts-1:0] be_i,       // write byte enable
+  // output ports
+  output data_t [NumPorts-1:0] rdata_o     // read data
+);
+
+// synthesis translate_off
+
+  tc_sram #(
+    .NumWords(NumWords),
+    .DataWidth(DataWidth),
+    .ByteWidth(ByteWidth),
+    .NumPorts(NumPorts),
+    .Latency(Latency),
+    .SimInit(SimInit),
+    .PrintSimCfg(PrintSimCfg)
+  ) i_tc_sram (
+      .clk_i    ( clk_i   ),
+      .rst_ni   ( rst_ni  ),
+      .req_i    ( req_i   ),
+      .we_i     ( we_i    ),
+      .be_i     ( be_i    ),
+      .wdata_i  ( wdata_i ),
+      .addr_i   ( addr_i  ),
+      .rdata_o  ( rdata_o )
+    );
+
+// synthesis translate_on
+
+endmodule

--- a/flow/designs/src/cva6/common/local/util/tc_sram_wrapper_cache_techno.sv
+++ b/flow/designs/src/cva6/common/local/util/tc_sram_wrapper_cache_techno.sv
@@ -1,0 +1,64 @@
+// Copyright 2022 Thales DIS design services SAS
+//
+// Licensed under the Solderpad Hardware Licence, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.0
+// You may obtain a copy of the License at https://solderpad.org/licenses/
+//
+// Original Author: Jean-Roch COULON - Thales
+
+// Copy of tc_sram_wrapper_cache
+// To be replaced by the wrapper of the technology used to avoid having black box at synthesis
+
+module tc_sram_wrapper_cache_techno #(
+  parameter int unsigned NumWords     = 32'd1024, // Number of Words in data array
+  parameter int unsigned DataWidth    = 32'd128,  // Data signal width
+  parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
+  parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
+  parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
+  parameter              SimInit      = "none",   // Simulation initialization
+  parameter              BYTE_ACCESS  = 1,
+  parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
+  parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
+  parameter type         addr_t    = logic [AddrWidth-1:0],
+  parameter type         data_t    = logic [DataWidth-1:0],
+  parameter type         be_t      = logic [BeWidth-1:0]
+) (
+  input  logic                 clk_i,      // Clock
+  input  logic                 rst_ni,     // Asynchronous reset active low
+  // input ports
+  input  logic  [NumPorts-1:0] req_i,      // request
+  input  logic  [NumPorts-1:0] we_i,       // write enable
+  input  addr_t [NumPorts-1:0] addr_i,     // request address
+  input  data_t [NumPorts-1:0] wdata_i,    // write data
+  input  be_t   [NumPorts-1:0] be_i,       // write byte enable
+  // output ports
+  output data_t [NumPorts-1:0] rdata_o     // read data
+);
+
+// synthesis translate_off
+
+  tc_sram #(
+    .NumWords(NumWords),
+    .DataWidth(DataWidth),
+    .ByteWidth(ByteWidth),
+    .NumPorts(NumPorts),
+    .Latency(Latency),
+    .SimInit(SimInit),
+    .PrintSimCfg(PrintSimCfg)
+  ) i_tc_sram (
+      .clk_i    ( clk_i   ),
+      .rst_ni   ( rst_ni  ),
+      .req_i    ( req_i   ),
+      .we_i     ( we_i    ),
+      .be_i     ( be_i    ),
+      .wdata_i  ( wdata_i ),
+      .addr_i   ( addr_i  ),
+      .rdata_o  ( rdata_o )
+    );
+
+// synthesis translate_on
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/axi/src/axi_pkg.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/axi/src/axi_pkg.sv
@@ -1,0 +1,423 @@
+// Copyright (c) 2014-2020 ETH Zurich, University of Bologna
+//
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Authors:
+// - Andreas Kurth <akurth@iis.ee.ethz.ch>
+// - Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+// - Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>
+// - Fabian Schuiki <fschuiki@iis.ee.ethz.ch>
+// - Matheus Cavalcante <matheusd@iis.ee.ethz.ch>
+
+//! AXI Package
+/// Contains all necessary type definitions, constants, and generally useful functions.
+package axi_pkg;
+  /// AXI Transaction Burst Type.
+  typedef logic [1:0] burst_t;
+  /// AXI Transaction Response Type.
+  typedef logic [1:0] resp_t;
+  /// AXI Transaction Cacheability Type.
+  typedef logic [3:0] cache_t;
+  /// AXI Transaction Protection Type.
+  typedef logic [2:0] prot_t;
+  /// AXI Transaction Quality of Service Type.
+  typedef logic [3:0] qos_t;
+  /// AXI Transaction Region Type.
+  typedef logic [3:0] region_t;
+  /// AXI Transaction Length Type.
+  typedef logic [7:0] len_t;
+  /// AXI Transaction Size Type.
+  typedef logic [2:0] size_t;
+  /// AXI5 Atomic Operation Type.
+  typedef logic [5:0] atop_t; // atomic operations
+  /// AXI5 Non-Secure Address Identifier.
+  typedef logic [3:0] nsaid_t;
+
+  /// In a fixed burst:
+  /// - The address is the same for every transfer in the burst.
+  /// - The byte lanes that are valid are constant for all beats in the burst.  However, within
+  ///   those byte lanes, the actual bytes that have `wstrb` asserted can differ for each beat in
+  ///   the burst.
+  /// This burst type is used for repeated accesses to the same location such as when loading or
+  /// emptying a FIFO.
+  localparam BURST_FIXED = 2'b00;
+  /// In an incrementing burst, the address for each transfer in the burst is an increment of the
+  /// address for the previous transfer.  The increment value depends on the size of the transfer.
+  /// For example, the address for each transfer in a burst with a size of 4 bytes is the previous
+  /// address plus four.
+  /// This burst type is used for accesses to normal sequential memory.
+  localparam BURST_INCR  = 2'b01;
+  /// A wrapping burst is similar to an incrementing burst, except that the address wraps around to
+  /// a lower address if an upper address limit is reached.
+  /// The following restrictions apply to wrapping bursts:
+  /// - The start address must be aligned to the size of each transfer.
+  /// - The length of the burst must be 2, 4, 8, or 16 transfers.
+  localparam BURST_WRAP  = 2'b10;
+
+  /// Normal access success.  Indicates that a normal access has been successful. Can also indicate
+  /// that an exclusive access has failed.
+  localparam RESP_OKAY   = 2'b00;
+  /// Exclusive access okay.  Indicates that either the read or write portion of an exclusive access
+  /// has been successful.
+  localparam RESP_EXOKAY = 2'b01;
+  /// Slave error.  Used when the access has reached the slave successfully, but the slave wishes to
+  /// return an error condition to the originating master.
+  localparam RESP_SLVERR = 2'b10;
+  /// Decode error.  Generated, typically by an interconnect component, to indicate that there is no
+  /// slave at the transaction address.
+  localparam RESP_DECERR = 2'b11;
+
+  /// When this bit is asserted, the interconnect, or any component, can delay the transaction
+  /// reaching its final destination for any number of cycles.
+  localparam CACHE_BUFFERABLE = 4'b0001;
+  /// When HIGH, Modifiable indicates that the characteristics of the transaction can be modified.
+  /// When Modifiable is LOW, the transaction is Non-modifiable.
+  localparam CACHE_MODIFIABLE = 4'b0010;
+  /// When this bit is asserted, read allocation of the transaction is recommended but is not
+  /// mandatory.
+  localparam CACHE_RD_ALLOC   = 4'b0100;
+  /// When this bit is asserted, write allocation of the transaction is recommended but is not
+  /// mandatory.
+  localparam CACHE_WR_ALLOC   = 4'b1000;
+
+  /// Maximum number of bytes per burst, as specified by `size` (see Table A3-2).
+  function automatic shortint unsigned num_bytes(size_t size);
+    return 1 << size;
+  endfunction
+
+  /// An overly long address type.
+  /// It lets us define functions that work generically for shorter addresses.  We rely on the
+  /// synthesizer to optimize the unused bits away.
+  typedef logic [127:0] largest_addr_t;
+
+  /// Aligned address of burst (see A3-51).
+  function automatic largest_addr_t aligned_addr(largest_addr_t addr, size_t size);
+    return (addr >> size) << size;
+  endfunction
+
+  /// Warp boundary of a `BURST_WRAP` transfer (see A3-51).
+  /// This is the lowest address accessed within a wrapping burst.
+  /// This address is aligned to the size and length of the burst.
+  /// The length of a `BURST_WRAP` has to be 2, 4, 8, or 16 transfers.
+  function automatic largest_addr_t wrap_boundary (largest_addr_t addr, size_t size, len_t len);
+    largest_addr_t wrap_addr;
+
+    // pragma translate_off
+    `ifndef VERILATOR
+      assume (len == len_t'(4'b1) || len == len_t'(4'b11) || len == len_t'(4'b111) ||
+          len == len_t'(4'b1111)) else
+        $error("AXI BURST_WRAP with not allowed len of: %0h", len);
+    `endif
+    // pragma translate_on
+
+    // In A3-51 the wrap boundary is defined as:
+    // `Wrap_Boundary = (INT(Start_Address / (Number_Bytes × Burst_Length))) ×
+    //    (Number_Bytes × Burst_Length)`
+    // Whereas the aligned address is defined as:
+    // `Aligned_Address = (INT(Start_Address / Number_Bytes)) × Number_Bytes`
+    // This leads to the wrap boundary using the same calculation as the aligned address, difference
+    // being the additional dependency on the burst length. The addition in the case statement
+    // is equal to the multiplication with `Burst_Length` as a shift (used by `aligned_addr`) is
+    // equivalent with multiplication and division by a power of two, which conveniently are the
+    // only allowed values for `len` of a `BURST_WRAP`.
+    unique case (len)
+      4'b1    : wrap_addr = (addr >> (unsigned'(size) + 1)) << (unsigned'(size) + 1); // multiply `Number_Bytes` by `2`
+      4'b11   : wrap_addr = (addr >> (unsigned'(size) + 2)) << (unsigned'(size) + 2); // multiply `Number_Bytes` by `4`
+      4'b111  : wrap_addr = (addr >> (unsigned'(size) + 3)) << (unsigned'(size) + 3); // multiply `Number_Bytes` by `8`
+      4'b1111 : wrap_addr = (addr >> (unsigned'(size) + 4)) << (unsigned'(size) + 4); // multiply `Number_Bytes` by `16`
+      default : wrap_addr = '0;
+    endcase
+    return wrap_addr;
+  endfunction
+
+  /// Address of beat (see A3-51).
+  function automatic largest_addr_t
+  beat_addr(largest_addr_t addr, size_t size, len_t len, burst_t burst, shortint unsigned i_beat);
+    largest_addr_t ret_addr = addr;
+    largest_addr_t wrp_bond = '0;
+    if (burst == BURST_WRAP) begin
+      // do not trigger the function if there is no wrapping burst, to prevent assumptions firing
+      wrp_bond = wrap_boundary(addr, size, len);
+    end
+    if (i_beat != 0 && burst != BURST_FIXED) begin
+      // From A3-51:
+      // For an INCR burst, and for a WRAP burst for which the address has not wrapped, this
+      // equation determines the address of any transfer after the first transfer in a burst:
+      // `Address_N = Aligned_Address + (N – 1) × Number_Bytes` (N counts from 1 to len!)
+      ret_addr = aligned_addr(addr, size) + i_beat * num_bytes(size);
+      // From A3-51:
+      // For a WRAP burst, if Address_N = Wrap_Boundary + (Number_Bytes × Burst_Length), then:
+      // * Use this equation for the current transfer:
+      //     `Address_N = Wrap_Boundary`
+      // * Use this equation for any subsequent transfers:
+      //     `Address_N = Start_Address + ((N – 1) × Number_Bytes) – (Number_Bytes × Burst_Length)`
+      // This means that the address calculation of a `BURST_WRAP` fundamentally works the same
+      // as for a `BURST_INC`, the difference is when the calculated address increments
+      // over the wrap threshold, the address wraps around by subtracting the accessed address
+      // space from the normal `BURST_INCR` address. The lower wrap boundary is equivalent to
+      // The wrap trigger condition minus the container size (`num_bytes(size) * (len + 1)`).
+      if (burst == BURST_WRAP && ret_addr >= wrp_bond + (num_bytes(size) * (len + 1))) begin
+        ret_addr = ret_addr - (num_bytes(size) * (len + 1));
+      end
+    end
+    return ret_addr;
+  endfunction
+
+  /// Index of lowest byte in beat (see A3-51).
+  function automatic shortint unsigned
+  beat_lower_byte(largest_addr_t addr, size_t size, len_t len, burst_t burst,
+      shortint unsigned strobe_width, shortint unsigned i_beat);
+    largest_addr_t _addr = beat_addr(addr, size, len, burst, i_beat);
+    return _addr - (_addr / strobe_width) * strobe_width;
+  endfunction
+
+  /// Index of highest byte in beat (see A3-51).
+  function automatic shortint unsigned
+  beat_upper_byte(largest_addr_t addr, size_t size, len_t len, burst_t burst,
+      shortint unsigned strobe_width, shortint unsigned i_beat);
+    if (i_beat == 0) begin
+      return aligned_addr(addr, size) + (num_bytes(size) - 1) - (addr / strobe_width) * strobe_width;
+    end else begin
+      return beat_lower_byte(addr, size, len, burst, strobe_width, i_beat) + num_bytes(size) - 1;
+    end
+  endfunction
+
+  /// Is the bufferable bit set?
+  function automatic logic bufferable(cache_t cache);
+    return |(cache & CACHE_BUFFERABLE);
+  endfunction
+
+  /// Is the modifiable bit set?
+  function automatic logic modifiable(cache_t cache);
+    return |(cache & CACHE_MODIFIABLE);
+  endfunction
+
+  /// Memory Type.
+  typedef enum logic [3:0] {
+    DEVICE_NONBUFFERABLE,
+    DEVICE_BUFFERABLE,
+    NORMAL_NONCACHEABLE_NONBUFFERABLE,
+    NORMAL_NONCACHEABLE_BUFFERABLE,
+    WTHRU_NOALLOCATE,
+    WTHRU_RALLOCATE,
+    WTHRU_WALLOCATE,
+    WTHRU_RWALLOCATE,
+    WBACK_NOALLOCATE,
+    WBACK_RALLOCATE,
+    WBACK_WALLOCATE,
+    WBACK_RWALLOCATE
+  } mem_type_t;
+
+  /// Create an `AR_CACHE` field from a `mem_type_t` type.
+  function automatic logic [3:0] get_arcache(mem_type_t mtype);
+    unique case (mtype)
+      DEVICE_NONBUFFERABLE              : return 4'b0000;
+      DEVICE_BUFFERABLE                 : return 4'b0001;
+      NORMAL_NONCACHEABLE_NONBUFFERABLE : return 4'b0010;
+      NORMAL_NONCACHEABLE_BUFFERABLE    : return 4'b0011;
+      WTHRU_NOALLOCATE                  : return 4'b1010;
+      WTHRU_RALLOCATE                   : return 4'b1110;
+      WTHRU_WALLOCATE                   : return 4'b1010;
+      WTHRU_RWALLOCATE                  : return 4'b1110;
+      WBACK_NOALLOCATE                  : return 4'b1011;
+      WBACK_RALLOCATE                   : return 4'b1111;
+      WBACK_WALLOCATE                   : return 4'b1011;
+      WBACK_RWALLOCATE                  : return 4'b1111;
+    endcase // mtype
+  endfunction
+
+  /// Create an `AW_CACHE` field from a `mem_type_t` type.
+  function automatic logic [3:0] get_awcache(mem_type_t mtype);
+    unique case (mtype)
+      DEVICE_NONBUFFERABLE              : return 4'b0000;
+      DEVICE_BUFFERABLE                 : return 4'b0001;
+      NORMAL_NONCACHEABLE_NONBUFFERABLE : return 4'b0010;
+      NORMAL_NONCACHEABLE_BUFFERABLE    : return 4'b0011;
+      WTHRU_NOALLOCATE                  : return 4'b0110;
+      WTHRU_RALLOCATE                   : return 4'b0110;
+      WTHRU_WALLOCATE                   : return 4'b1110;
+      WTHRU_RWALLOCATE                  : return 4'b1110;
+      WBACK_NOALLOCATE                  : return 4'b0111;
+      WBACK_RALLOCATE                   : return 4'b0111;
+      WBACK_WALLOCATE                   : return 4'b1111;
+      WBACK_RWALLOCATE                  : return 4'b1111;
+    endcase // mtype
+  endfunction
+
+  /// RESP precedence: DECERR > SLVERR > OKAY > EXOKAY.  This is not defined in the AXI standard but
+  /// depends on the implementation.  We consistently use the precedence above.  Rationale:
+  /// - EXOKAY means an exclusive access was successful, whereas OKAY means it was not.  Thus, if
+  ///   OKAY and EXOKAY are to be merged, OKAY precedes because the exclusive access was not fully
+  ///   successful.
+  /// - Both DECERR and SLVERR mean (part of) a transaction were unsuccessful, whereas OKAY means an
+  ///   entire transaction was successful.  Thus both DECERR and SLVERR precede OKAY.
+  /// - DECERR means (part of) a transactions could not be routed to a slave component, whereas
+  ///   SLVERR means the transaction reached a slave component but lead to an error condition there.
+  ///   Thus DECERR precedes SLVERR because DECERR happens earlier in the handling of a transaction.
+  function automatic resp_t resp_precedence(resp_t resp_a, resp_t resp_b);
+    unique case (resp_a)
+      RESP_OKAY: begin
+        // Any response except EXOKAY precedes OKAY.
+        if (resp_b == RESP_EXOKAY) begin
+          return resp_a;
+        end else begin
+          return resp_b;
+        end
+      end
+      RESP_EXOKAY: begin
+        // Any response precedes EXOKAY.
+        return resp_b;
+      end
+      RESP_SLVERR: begin
+        // Only DECERR precedes SLVERR.
+        if (resp_b == RESP_DECERR) begin
+          return resp_b;
+        end else begin
+          return resp_a;
+        end
+      end
+      RESP_DECERR: begin
+        // No response precedes DECERR.
+        return resp_a;
+      end
+    endcase
+  endfunction
+
+  // ATOP[5:0]
+  /// - Sends a single data value with an address.
+  /// - The target swaps the value at the addressed location with the data value that is supplied in
+  ///   the transaction.
+  /// - The original data value at the addressed location is returned.
+  /// - Outbound data size is 1, 2, 4, or 8 bytes.
+  /// - Inbound data size is the same as the outbound data size.
+  localparam ATOP_ATOMICSWAP  = 6'b110000;
+  /// - Sends two data values, the compare value and the swap value, to the addressed location.
+  ///   The compare and swap values are of equal size.
+  /// - The data value at the addressed location is checked against the compare value:
+  ///   - If the values match, the swap value is written to the addressed location.
+  ///   - If the values do not match, the swap value is not written to the addressed location.
+  /// - The original data value at the addressed location is returned.
+  /// - Outbound data size is 2, 4, 8, 16, or 32 bytes.
+  /// - Inbound data size is half of the outbound data size because the outbound data contains both
+  ///   compare and swap values, whereas the inbound data has only the original data value.
+  localparam ATOP_ATOMICCMP   = 6'b110001;
+  // ATOP[5:4]
+  /// Perform no atomic operation.
+  localparam ATOP_NONE        = 2'b00;
+  /// - Sends a single data value with an address and the atomic operation to be performed.
+  /// - The target performs the operation using the sent data and value at the addressed location as
+  ///   operands.
+  /// - The result is stored in the address location.
+  /// - A single response is given without data.
+  /// - Outbound data size is 1, 2, 4, or 8 bytes.
+  localparam ATOP_ATOMICSTORE = 2'b01;
+  /// Sends a single data value with an address and the atomic operation to be performed.
+  /// - The original data value at the addressed location is returned.
+  /// - The target performs the operation using the sent data and value at the addressed location as
+  ///   operands.
+  /// - The result is stored in the address location.
+  /// - Outbound data size is 1, 2, 4, or 8 bytes.
+  /// - Inbound data size is the same as the outbound data size.
+  localparam ATOP_ATOMICLOAD  = 2'b10;
+  // ATOP[3]
+  /// For AtomicStore and AtomicLoad transactions `AWATOP[3]` indicates the endianness that is
+  /// required for the atomic operation.  The value of `AWATOP[3]` applies to arithmetic operations
+  /// only and is ignored for bitwise logical operations.
+  /// When deasserted, this bit indicates that the operation is little-endian.
+  localparam ATOP_LITTLE_END  = 1'b0;
+  /// When asserted, this bit indicates that the operation is big-endian.
+  localparam ATOP_BIG_END     = 1'b1;
+  // ATOP[2:0]
+  /// The value in memory is added to the sent data and the result stored in memory.
+  localparam ATOP_ADD   = 3'b000;
+  /// Every set bit in the sent data clears the corresponding bit of the data in memory.
+  localparam ATOP_CLR   = 3'b001;
+  /// Bitwise exclusive OR of the sent data and value in memory.
+  localparam ATOP_EOR   = 3'b010;
+  /// Every set bit in the sent data sets the corresponding bit of the data in memory.
+  localparam ATOP_SET   = 3'b011;
+  /// The value stored in memory is the maximum of the existing value and sent data. This operation
+  /// assumes signed data.
+  localparam ATOP_SMAX  = 3'b100;
+  /// The value stored in memory is the minimum of the existing value and sent data. This operation
+  /// assumes signed data.
+  localparam ATOP_SMIN  = 3'b101;
+  /// The value stored in memory is the maximum of the existing value and sent data. This operation
+  /// assumes unsigned data.
+  localparam ATOP_UMAX  = 3'b110;
+  /// The value stored in memory is the minimum of the existing value and sent data. This operation
+  /// assumes unsigned data.
+  localparam ATOP_UMIN  = 3'b111;
+  // ATOP[5] == 1'b1 indicated that an atomic transaction has a read response
+  // Ussage eg: if (req_i.aw.atop[axi_pkg::ATOP_R_RESP]) begin
+  localparam ATOP_R_RESP = 32'd5;
+
+  // `xbar_latency_e` and `xbar_cfg_t` are documented in `doc/axi_xbar.md`.
+  /// Slice on Demux AW channel.
+  localparam logic [9:0] DemuxAw = (1 << 9);
+  /// Slice on Demux W channel.
+  localparam logic [9:0] DemuxW  = (1 << 8);
+  /// Slice on Demux B channel.
+  localparam logic [9:0] DemuxB  = (1 << 7);
+  /// Slice on Demux AR channel.
+  localparam logic [9:0] DemuxAr = (1 << 6);
+  /// Slice on Demux R channel.
+  localparam logic [9:0] DemuxR  = (1 << 5);
+  /// Slice on Mux AW channel.
+  localparam logic [9:0] MuxAw   = (1 << 4);
+  /// Slice on Mux W channel.
+  localparam logic [9:0] MuxW    = (1 << 3);
+  /// Slice on Mux B channel.
+  localparam logic [9:0] MuxB    = (1 << 2);
+  /// Slice on Mux AR channel.
+  localparam logic [9:0] MuxAr   = (1 << 1);
+  /// Slice on Mux R channel.
+  localparam logic [9:0] MuxR    = (1 << 0);
+  /// Latency configuration for `axi_xbar`.
+  typedef enum logic [9:0] {
+    NO_LATENCY    = 10'b000_00_000_00,
+    CUT_SLV_AX    = DemuxAw | DemuxAr,
+    CUT_MST_AX    = MuxAw | MuxAr,
+    CUT_ALL_AX    = DemuxAw | DemuxAr | MuxAw | MuxAr,
+    CUT_SLV_PORTS = DemuxAw | DemuxW | DemuxB | DemuxAr | DemuxR,
+    CUT_MST_PORTS = MuxAw | MuxW | MuxB | MuxAr | MuxR,
+    CUT_ALL_PORTS = 10'b111_11_111_11
+  } xbar_latency_e;
+
+  /// Configuration for `axi_xbar`.
+  typedef struct packed {
+    int unsigned   NoSlvPorts;
+    int unsigned   NoMstPorts;
+    int unsigned   MaxMstTrans;
+    int unsigned   MaxSlvTrans;
+    bit            FallThrough;
+    xbar_latency_e LatencyMode;
+    int unsigned   AxiIdWidthSlvPorts;
+    int unsigned   AxiIdUsedSlvPorts;
+    bit            UniqueIds;
+    int unsigned   AxiAddrWidth;
+    int unsigned   AxiDataWidth;
+    int unsigned   NoAddrRules;
+  } xbar_cfg_t;
+
+  /// Commonly used rule types for `axi_xbar` (64-bit addresses).
+  typedef struct packed {
+    int unsigned idx;
+    logic [63:0] start_addr;
+    logic [63:0] end_addr;
+  } xbar_rule_64_t;
+
+  /// Commonly used rule types for `axi_xbar` (32-bit addresses).
+  typedef struct packed {
+    int unsigned idx;
+    logic [31:0] start_addr;
+    logic [31:0] end_addr;
+  } xbar_rule_32_t;
+endpackage

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/cf_math_pkg.sv
@@ -1,0 +1,61 @@
+// Copyright 2016 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// cf_math_pkg: Constant Function Implementations of Mathematical Functions for HDL Elaboration
+///
+/// This package contains a collection of mathematical functions that are commonly used when defining
+/// the value of constants in HDL code.  These functions are implemented as Verilog constants
+/// functions.  Introduced in Verilog 2001 (IEEE Std 1364-2001), a constant function (§ 10.3.5) is a
+/// function whose value can be evaluated at compile time or during elaboration.  A constant function
+/// must be called with arguments that are constants.
+package cf_math_pkg;
+
+    /// Ceiled Division of Two Natural Numbers
+    ///
+    /// Returns the quotient of two natural numbers, rounded towards plus infinity.
+    function automatic integer ceil_div (input longint dividend, input longint divisor);
+        automatic longint remainder;
+
+        // pragma translate_off
+        `ifndef VERILATOR
+        if (dividend < 0) begin
+            $fatal(1, "Dividend %0d is not a natural number!", dividend);
+        end
+
+        if (divisor < 0) begin
+            $fatal(1, "Divisor %0d is not a natural number!", divisor);
+        end
+
+        if (divisor == 0) begin
+            $fatal(1, "Division by zero!");
+        end
+        `endif
+        // pragma translate_on
+
+        remainder = dividend;
+        for (ceil_div = 0; remainder > 0; ceil_div++) begin
+            remainder = remainder - divisor;
+        end
+    endfunction
+
+    /// Index width required to be able to represent up to `num_idx` indices as a binary
+    /// encoded signal.
+    /// Ensures that the minimum width if an index signal is `1`, regardless of parametrization.
+    ///
+    /// Sample usage in type definition:
+    /// As parameter:
+    ///   `parameter type idx_t = logic[cf_math_pkg::idx_width(NumIdx)-1:0]`
+    /// As typedef:
+    ///   `typedef logic [cf_math_pkg::idx_width(NumIdx)-1:0] idx_t`
+    function automatic integer unsigned idx_width (input integer unsigned num_idx);
+        return (num_idx > 32'd1) ? unsigned'($clog2(num_idx)) : 32'd1;
+    endfunction
+
+endpackage

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/counter.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/counter.sv
@@ -1,0 +1,43 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba
+// Description: Generic up/down counter
+
+module counter #(
+    parameter int unsigned WIDTH = 4,
+    parameter bit STICKY_OVERFLOW = 1'b0
+)(
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             clear_i, // synchronous clear
+    input  logic             en_i,    // enable the counter
+    input  logic             load_i,  // load a new value
+    input  logic             down_i,  // downcount, default is up
+    input  logic [WIDTH-1:0] d_i,
+    output logic [WIDTH-1:0] q_o,
+    output logic             overflow_o
+);
+    delta_counter #(
+        .WIDTH          (WIDTH),
+        .STICKY_OVERFLOW (STICKY_OVERFLOW)
+    ) i_counter (
+        .clk_i,
+        .rst_ni,
+        .clear_i,
+        .en_i,
+        .load_i,
+        .down_i,
+        .delta_i({{WIDTH-1{1'b0}}, 1'b1}),
+        .d_i,
+        .q_o,
+        .overflow_o
+    );
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/delta_counter.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/delta_counter.sv
@@ -1,0 +1,74 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Up/down counter with variable delta
+
+module delta_counter #(
+    parameter int unsigned WIDTH = 4,
+    parameter bit STICKY_OVERFLOW = 1'b0
+)(
+    input  logic             clk_i,
+    input  logic             rst_ni,
+    input  logic             clear_i, // synchronous clear
+    input  logic             en_i,    // enable the counter
+    input  logic             load_i,  // load a new value
+    input  logic             down_i,  // downcount, default is up
+    input  logic [WIDTH-1:0] delta_i,
+    input  logic [WIDTH-1:0] d_i,
+    output logic [WIDTH-1:0] q_o,
+    output logic             overflow_o
+);
+    logic [WIDTH:0] counter_q, counter_d;
+    if (STICKY_OVERFLOW) begin : gen_sticky_overflow
+        logic overflow_d, overflow_q;
+        always_ff @(posedge clk_i or negedge rst_ni) overflow_q <= ~rst_ni ? 1'b0 : overflow_d;
+        always_comb begin
+            overflow_d = overflow_q;
+            if (clear_i || load_i) begin
+                overflow_d = 1'b0;
+            end else if (!overflow_q && en_i) begin
+                if (down_i) begin
+                    overflow_d = delta_i > counter_q[WIDTH-1:0];
+                end else begin
+                    overflow_d = counter_q[WIDTH-1:0] > ({WIDTH{1'b1}} - delta_i);
+                end
+            end
+        end
+        assign overflow_o = overflow_q;
+    end else begin : gen_transient_overflow
+        // counter overflowed if the MSB is set
+        assign overflow_o = counter_q[WIDTH];
+    end
+    assign q_o = counter_q[WIDTH-1:0];
+
+    always_comb begin
+        counter_d = counter_q;
+
+        if (clear_i) begin
+            counter_d = '0;
+        end else if (load_i) begin
+            counter_d = {1'b0, d_i};
+        end else if (en_i) begin
+            if (down_i) begin
+                counter_d = counter_q - delta_i;
+            end else begin
+                counter_d = counter_q + delta_i;
+            end
+        end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if (!rst_ni) begin
+           counter_q <= '0;
+        end else begin
+           counter_q <= counter_d;
+        end
+    end
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/exp_backoff.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/exp_backoff.sv
@@ -1,0 +1,98 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 10.04.2019
+// Description: exponential backoff counter with randomization.
+//
+// For each failed trial (set_i pulsed), this unit exponentially increases the
+// (average) backoff time by masking an LFSR with a shifted mask in order to
+// create the backoff counter initial value.
+//
+// The shift register mask and the counter value are both reset to '0 in case of
+// a successful trial (clr_i).
+//
+
+module exp_backoff #(
+  /// Seed for 16bit LFSR
+  parameter int unsigned Seed   = 'hffff,
+  /// 2**MaxExp-1 determines the maximum range from which random wait counts are drawn
+  parameter int unsigned MaxExp = 16
+) (
+  input  logic clk_i,
+  input  logic rst_ni,
+  /// Sets the backoff counter (pulse) -> use when trial did not succeed
+  input  logic set_i,
+  /// Clears the backoff counter (pulse) -> use when trial succeeded
+  input  logic clr_i,
+  /// Indicates whether the backoff counter is equal to zero and a new trial can be launched
+  output logic is_zero_o
+);
+
+  // leave this constant
+  localparam int unsigned WIDTH = 16;
+
+  logic [WIDTH-1:0] lfsr_d, lfsr_q, cnt_d, cnt_q, mask_d, mask_q;
+  logic lfsr;
+
+  // generate random wait counts
+  // note: we use a flipped lfsr here to
+  // avoid strange correlation effects between
+  // the (left-shifted) mask and the lfsr
+  assign lfsr = lfsr_q[15-15] ^
+                lfsr_q[15-13] ^
+                lfsr_q[15-12] ^
+                lfsr_q[15-10];
+
+  assign lfsr_d = (set_i) ? {lfsr, lfsr_q[$high(lfsr_q):1]} :
+                            lfsr_q;
+
+  // mask the wait counts with exponentially increasing mask (shift reg)
+  assign mask_d = (clr_i) ? '0                                :
+                  (set_i) ? {{(WIDTH-MaxExp){1'b0}},mask_q[MaxExp-2:0], 1'b1} :
+                            mask_q;
+
+  assign cnt_d =  (clr_i)      ? '0                :
+                  (set_i)      ? (mask_q & lfsr_q) :
+                  (!is_zero_o) ? cnt_q - 1'b1      : '0;
+
+  assign is_zero_o = (cnt_q=='0);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+    if (!rst_ni) begin
+      lfsr_q <= WIDTH'(Seed);
+      mask_q <= '0;
+      cnt_q  <= '0;
+    end else begin
+      lfsr_q <= lfsr_d;
+      mask_q <= mask_d;
+      cnt_q  <= cnt_d;
+    end
+  end
+
+///////////////////////////////////////////////////////
+// assertions
+///////////////////////////////////////////////////////
+
+//pragma translate_off
+`ifndef VERILATOR
+  initial begin
+    // assert wrong parameterizations
+    assert (MaxExp>0)
+      else $fatal(1,"MaxExp must be greater than 0");
+    assert (MaxExp<=16)
+      else $fatal(1,"MaxExp cannot be greater than 16");
+    assert (Seed>0)
+      else $fatal(1,"Zero seed is not allowed for LFSR");
+  end
+`endif
+//pragma translate_on
+
+endmodule // exp_backoff

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/fifo_v3.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/fifo_v3.sv
@@ -1,0 +1,156 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Florian Zaruba <zarubaf@iis.ee.ethz.ch>
+
+module fifo_v3 #(
+    parameter bit          FALL_THROUGH = 1'b0, // fifo is in fall-through mode
+    parameter int unsigned DATA_WIDTH   = 32,   // default data width if the fifo is of type logic
+    parameter int unsigned DEPTH        = 8,    // depth can be arbitrary from 0 to 2**32
+    parameter type dtype                = logic [DATA_WIDTH-1:0],
+    // DO NOT OVERWRITE THIS PARAMETER
+    parameter int unsigned ADDR_DEPTH   = (DEPTH > 1) ? $clog2(DEPTH) : 1
+)(
+    input  logic  clk_i,            // Clock
+    input  logic  rst_ni,           // Asynchronous reset active low
+    input  logic  flush_i,          // flush the queue
+    input  logic  testmode_i,       // test_mode to bypass clock gating
+    // status flags
+    output logic  full_o,           // queue is full
+    output logic  empty_o,          // queue is empty
+    output logic  [ADDR_DEPTH-1:0] usage_o,  // fill pointer
+    // as long as the queue is not full we can push new data
+    input  dtype  data_i,           // data to push into the queue
+    input  logic  push_i,           // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    output dtype  data_o,           // output data
+    input  logic  pop_i             // pop head from queue
+);
+    // local parameter
+    // FIFO depth - handle the case of pass-through, synthesizer will do constant propagation
+    localparam int unsigned FifoDepth = (DEPTH > 0) ? DEPTH : 1;
+    // clock gating control
+    logic gate_clock;
+    // pointer to the read and write section of the queue
+    logic [ADDR_DEPTH - 1:0] read_pointer_n, read_pointer_q, write_pointer_n, write_pointer_q;
+    // keep a counter to keep track of the current queue status
+    // this integer will be truncated by the synthesis tool
+    logic [ADDR_DEPTH:0] status_cnt_n, status_cnt_q;
+    // actual memory
+    dtype [FifoDepth - 1:0] mem_n, mem_q;
+
+    assign usage_o = status_cnt_q[ADDR_DEPTH-1:0];
+
+    if (DEPTH == 0) begin : gen_pass_through
+        assign empty_o     = ~push_i;
+        assign full_o      = ~pop_i;
+    end else begin : gen_fifo
+        assign full_o       = (status_cnt_q == FifoDepth[ADDR_DEPTH:0]);
+        assign empty_o      = (status_cnt_q == 0) & ~(FALL_THROUGH & push_i);
+    end
+    // status flags
+
+    // read and write queue logic
+    always_comb begin : read_write_comb
+        // default assignment
+        read_pointer_n  = read_pointer_q;
+        write_pointer_n = write_pointer_q;
+        status_cnt_n    = status_cnt_q;
+        data_o          = (DEPTH == 0) ? data_i : mem_q[read_pointer_q];
+        mem_n           = mem_q;
+        gate_clock      = 1'b1;
+
+        // push a new element to the queue
+        if (push_i && ~full_o) begin
+            // push the data onto the queue
+            mem_n[write_pointer_q] = data_i;
+            // un-gate the clock, we want to write something
+            gate_clock = 1'b0;
+            // increment the write counter
+            // this is dead code when DEPTH is a power of two
+            if (write_pointer_q == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                write_pointer_n = '0;
+            else
+                write_pointer_n = write_pointer_q + 1;
+            // increment the overall counter
+            status_cnt_n    = status_cnt_q + 1;
+        end
+
+        if (pop_i && ~empty_o) begin
+            // read from the queue is a default assignment
+            // but increment the read pointer...
+            // this is dead code when DEPTH is a power of two
+            if (read_pointer_n == FifoDepth[ADDR_DEPTH-1:0] - 1)
+                read_pointer_n = '0;
+            else
+                read_pointer_n = read_pointer_q + 1;
+            // ... and decrement the overall count
+            status_cnt_n   = status_cnt_q - 1;
+        end
+
+        // keep the count pointer stable if we push and pop at the same time
+        if (push_i && pop_i &&  ~full_o && ~empty_o)
+            status_cnt_n   = status_cnt_q;
+
+        // FIFO is in pass through mode -> do not change the pointers
+        if (FALL_THROUGH && (status_cnt_q == 0) && push_i) begin
+            data_o = data_i;
+            if (pop_i) begin
+                status_cnt_n = status_cnt_q;
+                read_pointer_n = read_pointer_q;
+                write_pointer_n = write_pointer_q;
+            end
+        end
+    end
+
+    // sequential process
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            read_pointer_q  <= '0;
+            write_pointer_q <= '0;
+            status_cnt_q    <= '0;
+        end else begin
+            if (flush_i) begin
+                read_pointer_q  <= '0;
+                write_pointer_q <= '0;
+                status_cnt_q    <= '0;
+             end else begin
+                read_pointer_q  <= read_pointer_n;
+                write_pointer_q <= write_pointer_n;
+                status_cnt_q    <= status_cnt_n;
+            end
+        end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+        if(~rst_ni) begin
+            mem_q <= '0;
+        end else if (!gate_clock) begin
+            mem_q <= mem_n;
+        end
+    end
+
+`ifndef SYNTHESIS
+`ifndef COMMON_CELLS_ASSERTS_OFF
+    initial begin
+        assert (DEPTH > 0)             else $error("DEPTH must be greater than 0.");
+    end
+
+    full_write : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (full_o |-> ~push_i))
+        else $fatal (1, "Trying to push new data although the FIFO is full.");
+
+    empty_read : assert property(
+        @(posedge clk_i) disable iff (~rst_ni) (empty_o |-> ~pop_i))
+        else $fatal (1, "Trying to pop data although the FIFO is empty.");
+`endif
+`endif
+
+endmodule // fifo_v3

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lfsr.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lfsr.sv
@@ -1,0 +1,315 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+// Date: 26.04.2019
+//
+// Description: This is a parametric LFSR with precomputed coefficients for
+// LFSR lengths from 4 to 64bit.
+
+// Additional block cipher layers can be instantiated to non-linearly transform
+// the pseudo-random LFSR sequence at the output, and hence break the shifting
+// patterns. The additional cipher layers can only be used for an LFSR width
+// of 64bit, since the block cipher has been designed for that block length.
+
+module lfsr #(
+  parameter int unsigned          LfsrWidth     = 64,   // [4,64]
+  parameter int unsigned          OutWidth      = 8,    // [1,LfsrWidth]
+  parameter logic [LfsrWidth-1:0] RstVal        = '1,   // [1,2^LfsrWidth-1]
+  // 0: disabled, the present cipher uses 31, but just a few layers (1-3) are enough
+  // to break linear shifting patterns
+  parameter int unsigned          CipherLayers  = 0,
+  parameter bit                   CipherReg     = 1'b1  // additional output reg after cipher
+) (
+  input  logic                 clk_i,
+  input  logic                 rst_ni,
+  input  logic                 en_i,
+  output logic [OutWidth-1:0]  out_o
+);
+
+// Galois LFSR feedback masks
+// Automatically generated with get_lfsr_masks.py
+// Masks are from https://users.ece.cmu.edu/~koopman/lfsr/
+localparam logic [63:0] Masks [4:64] = '{64'hC,
+                                         64'h1E,
+                                         64'h39,
+                                         64'h7E,
+                                         64'hFA,
+                                         64'h1FD,
+                                         64'h3FC,
+                                         64'h64B,
+                                         64'hD8F,
+                                         64'h1296,
+                                         64'h2496,
+                                         64'h4357,
+                                         64'h8679,
+                                         64'h1030E,
+                                         64'h206CD,
+                                         64'h403FE,
+                                         64'h807B8,
+                                         64'h1004B2,
+                                         64'h2006A8,
+                                         64'h4004B2,
+                                         64'h800B87,
+                                         64'h10004F3,
+                                         64'h200072D,
+                                         64'h40006AE,
+                                         64'h80009E3,
+                                         64'h10000583,
+                                         64'h20000C92,
+                                         64'h400005B6,
+                                         64'h80000EA6,
+                                         64'h1000007A3,
+                                         64'h200000ABF,
+                                         64'h400000842,
+                                         64'h80000123E,
+                                         64'h100000074E,
+                                         64'h2000000AE9,
+                                         64'h400000086A,
+                                         64'h8000001213,
+                                         64'h1000000077E,
+                                         64'h2000000123B,
+                                         64'h40000000877,
+                                         64'h8000000108D,
+                                         64'h100000000AE9,
+                                         64'h200000000E9F,
+                                         64'h4000000008A6,
+                                         64'h80000000191E,
+                                         64'h100000000090E,
+                                         64'h2000000000FB3,
+                                         64'h4000000000D7D,
+                                         64'h80000000016A5,
+                                         64'h10000000000B4B,
+                                         64'h200000000010AF,
+                                         64'h40000000000DDE,
+                                         64'h8000000000181A,
+                                         64'h100000000000B65,
+                                         64'h20000000000102D,
+                                         64'h400000000000CD5,
+                                         64'h8000000000024C1,
+                                         64'h1000000000000EF6,
+                                         64'h2000000000001363,
+                                         64'h4000000000000FCD,
+                                         64'h80000000000019E2};
+
+// this S-box and permutation P has been taken from the Present Cipher,
+// a super lightweight block cipher. use the cipher layers to add additional
+// non-linearity to the LFSR output. note one layer does not fully correspond
+// to the present cipher round, since the key and rekeying function is not applied here.
+//
+// See also:
+// "PRESENT: An Ultra-Lightweight Block Cipher", A. Bogdanov et al., Ches 2007
+// http://www.lightweightcrypto.org/present/present_ches2007.pdf
+
+// this is the sbox from the present cipher
+localparam logic[15:0][3:0] Sbox4 = {4'h2, 4'h1, 4'h7, 4'h4,
+                                     4'h8, 4'hF, 4'hE, 4'h3,
+                                     4'hD, 4'hA, 4'h0, 4'h9,
+                                     4'hB, 4'h6, 4'h5, 4'hC };
+
+// these are the permutation indices of the present cipher
+localparam logic[63:0][5:0] Perm = {6'd63, 6'd47, 6'd31, 6'd15, 6'd62, 6'd46, 6'd30, 6'd14,
+                                    6'd61, 6'd45, 6'd29, 6'd13, 6'd60, 6'd44, 6'd28, 6'd12,
+                                    6'd59, 6'd43, 6'd27, 6'd11, 6'd58, 6'd42, 6'd26, 6'd10,
+                                    6'd57, 6'd41, 6'd25, 6'd09, 6'd56, 6'd40, 6'd24, 6'd08,
+                                    6'd55, 6'd39, 6'd23, 6'd07, 6'd54, 6'd38, 6'd22, 6'd06,
+                                    6'd53, 6'd37, 6'd21, 6'd05, 6'd52, 6'd36, 6'd20, 6'd04,
+                                    6'd51, 6'd35, 6'd19, 6'd03, 6'd50, 6'd34, 6'd18, 6'd02,
+                                    6'd49, 6'd33, 6'd17, 6'd01, 6'd48, 6'd32, 6'd16, 6'd00};
+
+
+function automatic logic [63:0] sbox4_layer(logic [63:0] in);
+  logic [63:0] out;
+  //for (logic [4:0] j = '0; j<16; j++) out[j*4 +: 4] = sbox4[in[j*4 +: 4]];
+  // this simulates much faster than the loop
+  out[0*4  +: 4] = Sbox4[in[0*4  +: 4]];
+  out[1*4  +: 4] = Sbox4[in[1*4  +: 4]];
+  out[2*4  +: 4] = Sbox4[in[2*4  +: 4]];
+  out[3*4  +: 4] = Sbox4[in[3*4  +: 4]];
+
+  out[4*4  +: 4] = Sbox4[in[4*4  +: 4]];
+  out[5*4  +: 4] = Sbox4[in[5*4  +: 4]];
+  out[6*4  +: 4] = Sbox4[in[6*4  +: 4]];
+  out[7*4  +: 4] = Sbox4[in[7*4  +: 4]];
+
+  out[8*4  +: 4] = Sbox4[in[8*4  +: 4]];
+  out[9*4  +: 4] = Sbox4[in[9*4  +: 4]];
+  out[10*4 +: 4] = Sbox4[in[10*4 +: 4]];
+  out[11*4 +: 4] = Sbox4[in[11*4 +: 4]];
+
+  out[12*4 +: 4] = Sbox4[in[12*4 +: 4]];
+  out[13*4 +: 4] = Sbox4[in[13*4 +: 4]];
+  out[14*4 +: 4] = Sbox4[in[14*4 +: 4]];
+  out[15*4 +: 4] = Sbox4[in[15*4 +: 4]];
+  return out;
+endfunction : sbox4_layer
+
+function automatic logic [63:0] perm_layer(logic [63:0] in);
+  logic [63:0] out;
+  // for (logic [7:0] j = '0; j<64; j++) out[perm[j]] = in[j];
+  // this simulates much faster than the loop
+  out[Perm[0]] = in[0];
+  out[Perm[1]] = in[1];
+  out[Perm[2]] = in[2];
+  out[Perm[3]] = in[3];
+  out[Perm[4]] = in[4];
+  out[Perm[5]] = in[5];
+  out[Perm[6]] = in[6];
+  out[Perm[7]] = in[7];
+  out[Perm[8]] = in[8];
+  out[Perm[9]] = in[9];
+
+  out[Perm[10]] = in[10];
+  out[Perm[11]] = in[11];
+  out[Perm[12]] = in[12];
+  out[Perm[13]] = in[13];
+  out[Perm[14]] = in[14];
+  out[Perm[15]] = in[15];
+  out[Perm[16]] = in[16];
+  out[Perm[17]] = in[17];
+  out[Perm[18]] = in[18];
+  out[Perm[19]] = in[19];
+
+  out[Perm[20]] = in[20];
+  out[Perm[21]] = in[21];
+  out[Perm[22]] = in[22];
+  out[Perm[23]] = in[23];
+  out[Perm[24]] = in[24];
+  out[Perm[25]] = in[25];
+  out[Perm[26]] = in[26];
+  out[Perm[27]] = in[27];
+  out[Perm[28]] = in[28];
+  out[Perm[29]] = in[29];
+
+  out[Perm[30]] = in[30];
+  out[Perm[31]] = in[31];
+  out[Perm[32]] = in[32];
+  out[Perm[33]] = in[33];
+  out[Perm[34]] = in[34];
+  out[Perm[35]] = in[35];
+  out[Perm[36]] = in[36];
+  out[Perm[37]] = in[37];
+  out[Perm[38]] = in[38];
+  out[Perm[39]] = in[39];
+
+  out[Perm[40]] = in[40];
+  out[Perm[41]] = in[41];
+  out[Perm[42]] = in[42];
+  out[Perm[43]] = in[43];
+  out[Perm[44]] = in[44];
+  out[Perm[45]] = in[45];
+  out[Perm[46]] = in[46];
+  out[Perm[47]] = in[47];
+  out[Perm[48]] = in[48];
+  out[Perm[49]] = in[49];
+
+  out[Perm[50]] = in[50];
+  out[Perm[51]] = in[51];
+  out[Perm[52]] = in[52];
+  out[Perm[53]] = in[53];
+  out[Perm[54]] = in[54];
+  out[Perm[55]] = in[55];
+  out[Perm[56]] = in[56];
+  out[Perm[57]] = in[57];
+  out[Perm[58]] = in[58];
+  out[Perm[59]] = in[59];
+
+  out[Perm[60]] = in[60];
+  out[Perm[61]] = in[61];
+  out[Perm[62]] = in[62];
+  out[Perm[63]] = in[63];
+  return out;
+endfunction : perm_layer
+
+////////////////////////////////////////////////////////////////////////
+// lfsr
+////////////////////////////////////////////////////////////////////////
+
+logic [LfsrWidth-1:0] lfsr_d, lfsr_q;
+assign lfsr_d =
+  (en_i) ? (lfsr_q>>1) ^ ({LfsrWidth{lfsr_q[0]}} & Masks[LfsrWidth][LfsrWidth-1:0]) : lfsr_q;
+
+always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+  //$display("%b %h", en_i, lfsr_d);
+  if (!rst_ni) begin
+    lfsr_q <= LfsrWidth'(RstVal);
+  end else begin
+    lfsr_q <= lfsr_d;
+  end
+end
+
+////////////////////////////////////////////////////////////////////////
+// block cipher layers
+////////////////////////////////////////////////////////////////////////
+
+if (CipherLayers > unsigned'(0)) begin : g_cipher_layers
+  logic [63:0] ciph_layer;
+  localparam int unsigned NumRepl = ((64+LfsrWidth)/LfsrWidth);
+
+  always_comb begin : p_ciph_layer
+    automatic logic [63:0] tmp;
+    tmp = 64'({NumRepl{lfsr_q}});
+    for(int unsigned k = 0; k < CipherLayers; k++) begin
+      tmp = perm_layer(sbox4_layer(tmp));
+    end
+    ciph_layer = tmp;
+  end
+
+  // additiona output reg after cipher
+  if (CipherReg) begin : g_cipher_reg
+    logic [OutWidth-1:0] out_d, out_q;
+
+    assign out_d = (en_i) ? ciph_layer[OutWidth-1:0] : out_q;
+    assign out_o = out_q[OutWidth-1:0];
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+      if (!rst_ni) begin
+        out_q <= '0;
+      end else begin
+        out_q <= out_d;
+      end
+    end
+  // no outreg
+  end else begin : g_no_out_reg
+    assign out_o  = ciph_layer[OutWidth-1:0];
+  end
+
+// no block cipher
+end else begin : g_no_cipher_layers
+  assign out_o    = lfsr_q[OutWidth-1:0];
+end
+
+////////////////////////////////////////////////////////////////////////
+// assertions
+////////////////////////////////////////////////////////////////////////
+
+// pragma translate_off
+initial begin
+  // these are the LUT limits
+  assert(OutWidth <= LfsrWidth) else
+    $fatal(1,"OutWidth must be smaller equal the LfsrWidth.");
+  assert(RstVal > unsigned'(0)) else
+    $fatal(1,"RstVal must be nonzero.");
+  assert((LfsrWidth >= $low(Masks)) && (LfsrWidth <= $high(Masks))) else
+    $fatal(1,"Unsupported LfsrWidth.");
+  assert(Masks[LfsrWidth][LfsrWidth-1]) else
+    $fatal(1, "LFSR mask is not correct. The MSB must be 1." );
+  assert((CipherLayers > 0) && (LfsrWidth == 64) || (CipherLayers == 0)) else
+    $fatal(1, "Use additional cipher layers only in conjunction with an LFSR width of 64 bit." );
+end
+
+`ifndef VERILATOR
+  all_zero: assert property (
+    @(posedge clk_i) disable iff (!rst_ni) en_i |-> lfsr_d)
+      else $fatal(1,"Lfsr must not be all-zero.");
+`endif
+// pragma translate_on
+
+endmodule // lfsr

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lfsr_8bit.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lfsr_8bit.sv
@@ -1,0 +1,61 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Igor Loi - University of Bologna
+// Author: Florian Zaruba, ETH Zurich
+// Date: 12.11.2017
+// Description: 8-bit LFSR
+
+/// 8 bit Linear Feedback Shift register
+module lfsr_8bit #(
+  parameter logic        [7:0] SEED  = 8'b0,
+  parameter int unsigned       WIDTH = 8
+) (
+  input  logic                     clk_i,
+  input  logic                     rst_ni,
+  input  logic                     en_i,
+  output logic [        WIDTH-1:0] refill_way_oh,
+  output logic [$clog2(WIDTH)-1:0] refill_way_bin
+);
+
+  localparam int unsigned LogWidth = $clog2(WIDTH);
+
+  logic [7:0] shift_d, shift_q;
+
+  always_comb begin
+
+    automatic logic shift_in;
+    shift_in = !(shift_q[7] ^ shift_q[3] ^ shift_q[2] ^ shift_q[1]);
+
+    shift_d = shift_q;
+
+    if (en_i) shift_d = {shift_q[6:0], shift_in};
+
+    // output assignment
+    refill_way_oh = 'b0;
+    refill_way_oh[shift_q[LogWidth - 1:0]] = 1'b1;
+    refill_way_bin = shift_q;
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : proc_
+    if (~rst_ni) begin
+      shift_q <= SEED;
+    end else begin
+      shift_q <= shift_d;
+    end
+  end
+
+  //pragma translate_off
+  initial begin
+    assert (WIDTH <= 8) else $fatal(1, "WIDTH needs to be less than 8 because of the 8-bit LFSR");
+  end
+  //pragma translate_on
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lzc.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/lzc.sv
@@ -1,0 +1,112 @@
+// Copyright (c) 2018 - 2019 ETH Zurich, University of Bologna
+// All rights reserved.
+//
+// This code is under development and not yet released to the public.
+// Until it is released, the code is under the copyright of ETH Zurich and
+// the University of Bologna, and may contain confidential and/or unpublished
+// work. Any reuse/redistribution is strictly forbidden without written
+// permission from ETH Zurich.
+//
+// Bug fixes and contributions will eventually be released under the
+// SolderPad open hardware license in the context of the PULP platform
+// (http://www.pulp-platform.org), under the copyright of ETH Zurich and the
+// University of Bologna.
+
+/// A trailing zero counter / leading zero counter.
+/// Set MODE to 0 for trailing zero counter => cnt_o is the number of trailing zeros (from the LSB)
+/// Set MODE to 1 for leading zero counter  => cnt_o is the number of leading zeros  (from the MSB)
+/// If the input does not contain a zero, `empty_o` is asserted. Additionally `cnt_o` contains
+/// the maximum number of zeros - 1. For example:
+///   in_i = 000_0000, empty_o = 1, cnt_o = 6 (mode = 0)
+///   in_i = 000_0001, empty_o = 0, cnt_o = 0 (mode = 0)
+///   in_i = 000_1000, empty_o = 0, cnt_o = 3 (mode = 0)
+/// Furthermore, this unit contains a more efficient implementation for Verilator (simulation only).
+/// This speeds up simulation significantly.
+module lzc #(
+  /// The width of the input vector.
+  parameter int unsigned WIDTH = 2,
+  /// Mode selection: 0 -> trailing zero, 1 -> leading zero
+  parameter bit          MODE  = 1'b0,
+  /// Dependent parameter. Do **not** change!
+  ///
+  /// Width of the output signal with the zero count.
+  parameter int unsigned CNT_WIDTH = cf_math_pkg::idx_width(WIDTH)
+) (
+  /// Input vector to be counted.
+  input  logic [WIDTH-1:0]     in_i,
+  /// Count of the leading / trailing zeros.
+  output logic [CNT_WIDTH-1:0] cnt_o,
+  /// Counter is empty: Asserted if all bits in in_i are zero.
+  output logic                 empty_o
+);
+
+  if (WIDTH == 1) begin : gen_degenerate_lzc
+
+    assign cnt_o[0] = !in_i[0];
+    assign empty_o = !in_i[0];
+
+  end else begin : gen_lzc
+
+    localparam int unsigned NumLevels = $clog2(WIDTH);
+
+    // pragma translate_off
+    initial begin
+      assert(WIDTH > 0) else $fatal(1, "input must be at least one bit wide");
+    end
+    // pragma translate_on
+
+    logic [WIDTH-1:0][NumLevels-1:0] index_lut;
+    logic [2**NumLevels-1:0] sel_nodes;
+    logic [2**NumLevels-1:0][NumLevels-1:0] index_nodes;
+
+    logic [WIDTH-1:0] in_tmp;
+
+    // reverse vector if required
+    always_comb begin : flip_vector
+      for (int unsigned i = 0; i < WIDTH; i++) begin
+        in_tmp[i] = (MODE) ? in_i[WIDTH-1-i] : in_i[i];
+      end
+    end
+
+    for (genvar j = 0; unsigned'(j) < WIDTH; j++) begin : g_index_lut
+      assign index_lut[j] = (NumLevels)'(unsigned'(j));
+    end
+
+    for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : g_levels
+      if (unsigned'(level) == NumLevels - 1) begin : g_last_level
+        for (genvar k = 0; k < 2 ** level; k++) begin : g_level
+          // if two successive indices are still in the vector...
+          if (unsigned'(k) * 2 < WIDTH - 1) begin : g_reduce
+            assign sel_nodes[2 ** level - 1 + k] = in_tmp[k * 2] | in_tmp[k * 2 + 1];
+            assign index_nodes[2 ** level - 1 + k] = (in_tmp[k * 2] == 1'b1)
+              ? index_lut[k * 2] :
+                index_lut[k * 2 + 1];
+          end
+          // if only the first index is still in the vector...
+          if (unsigned'(k) * 2 == WIDTH - 1) begin : g_base
+            assign sel_nodes[2 ** level - 1 + k] = in_tmp[k * 2];
+            assign index_nodes[2 ** level - 1 + k] = index_lut[k * 2];
+          end
+          // if index is out of range
+          if (unsigned'(k) * 2 > WIDTH - 1) begin : g_out_of_range
+            assign sel_nodes[2 ** level - 1 + k] = 1'b0;
+            assign index_nodes[2 ** level - 1 + k] = '0;
+          end
+        end
+      end else begin : g_not_last_level
+        for (genvar l = 0; l < 2 ** level; l++) begin : g_level
+          assign sel_nodes[2 ** level - 1 + l] =
+              sel_nodes[2 ** (level + 1) - 1 + l * 2] | sel_nodes[2 ** (level + 1) - 1 + l * 2 + 1];
+          assign index_nodes[2 ** level - 1 + l] = (sel_nodes[2 ** (level + 1) - 1 + l * 2] == 1'b1)
+            ? index_nodes[2 ** (level + 1) - 1 + l * 2] :
+              index_nodes[2 ** (level + 1) - 1 + l * 2 + 1];
+        end
+      end
+    end
+
+    assign cnt_o = NumLevels > unsigned'(0) ? index_nodes[0] : {($clog2(WIDTH)) {1'b0}};
+    assign empty_o = NumLevels > unsigned'(0) ? ~sel_nodes[0] : ~(|in_i);
+
+  end : gen_lzc
+
+endmodule : lzc

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/popcount.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/popcount.sv
@@ -1,0 +1,57 @@
+// Copyright (C) 2013-2018 ETH Zurich, University of Bologna
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Manuel Eggimann <meggimann@iis.ee.ethz.ch>
+
+// Description: This module calculates the hamming weight (number of ones) in
+// its input vector using a balanced binary adder tree. Recursive instantiation
+// is used to build the tree.  Any unsigned INPUT_WIDTH larger or equal 2 is
+// legal.  The module pads the signal internally to the next power of two.  The
+// output result width is ceil(log2(INPUT_WIDTH))+1.
+
+module popcount #(
+    parameter int unsigned INPUT_WIDTH = 256,
+    localparam int unsigned PopcountWidth = $clog2(INPUT_WIDTH)+1
+) (
+    input logic [INPUT_WIDTH-1:0]     data_i,
+    output logic [PopcountWidth-1:0] popcount_o
+);
+
+   localparam int unsigned PaddedWidth = 1 << $clog2(INPUT_WIDTH);
+
+   logic [PaddedWidth-1:0]           padded_input;
+   logic [PopcountWidth-2:0]         left_child_result, right_child_result;
+
+   //Zero pad the input to next power of two
+   assign padded_input = {{{PaddedWidth-INPUT_WIDTH}{1'b0}}, data_i};
+
+   //Recursive instantiation to build binary adder tree
+   if (INPUT_WIDTH == 1) begin : single_node
+     assign left_child_result  = 1'b0;
+     assign right_child_result = padded_input[0];
+   end else if (INPUT_WIDTH == 2) begin : leaf_node
+     assign left_child_result  = padded_input[1];
+     assign right_child_result = padded_input[0];
+   end else begin : non_leaf_node
+     popcount #(.INPUT_WIDTH(PaddedWidth / 2))
+         left_child(
+                    .data_i(padded_input[PaddedWidth-1:PaddedWidth/2]),
+                    .popcount_o(left_child_result));
+
+     popcount #(.INPUT_WIDTH(PaddedWidth / 2))
+         right_child(
+                     .data_i(padded_input[PaddedWidth/2-1:0]),
+                     .popcount_o(right_child_result));
+   end
+
+   //Output assignment
+   assign popcount_o = left_child_result + right_child_result;
+
+endmodule : popcount

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/rr_arb_tree.sv
@@ -1,0 +1,348 @@
+// Copyright 2019 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Michael Schaffner <schaffner@iis.ee.ethz.ch>, ETH Zurich
+//         Wolfgang Roenninger <wroennin@iis.ee.ethz.ch>, ETH Zurich
+// Date: 02.04.2019
+// Description: logarithmic arbitration tree with round robin arbitration scheme.
+
+/// The rr_arb_tree employs non-starving round robin-arbitration - i.e., the priorities
+/// rotate each cycle.
+///
+/// ## Fair vs. unfair Arbitration
+///
+/// This refers to fair throughput distribution when not all inputs have active requests.
+/// This module has an internal state `rr_q` which defines the highest priority input. (When
+/// `ExtPrio` is `1'b1` this state is provided from the outside.) The arbitration tree will
+/// choose the input with the same index as currently defined by the state if it has an active
+/// request. Otherwise a *random* other active input is selected. The parameter `FairArb` is used
+/// to distinguish between two methods of calculating the next state.
+/// * `1'b0`: The next state is calculated by advancing the current state by one. This leads to the
+///           state being calculated without the context of the active request. Leading to an
+///           unfair throughput distribution if not all inputs have active requests.
+/// * `1'b1`: The next state jumps to the next unserved request with higher index.
+///           This is achieved by using two trailing-zero-counters (`lzc`). The upper has the masked
+///           `req_i` signal with all indices which will have a higher priority in the next state.
+///           The trailing zero count defines the input index with the next highest priority after
+///           the current one is served. When the upper is empty the lower `lzc` provides the
+///           wrapped index if there are outstanding requests with lower or same priority.
+/// The implication of throughput fairness on the module timing are:
+/// * The trailing zero counter (`lzc`) has a loglog relation of input to output timing. This means
+///   that in this module the input to register path scales with Log(Log(`NumIn`)).
+/// * The `rr_arb_tree` data multiplexing scales with Log(`NumIn`). This means that the input to output
+///   timing path of this module also scales scales with Log(`NumIn`).
+/// This implies that in this module the input to output path is always longer than the input to
+/// register path. As the output data usually also terminates in a register the parameter `FairArb`
+/// only has implications on the area. When it is `1'b0` a static plus one adder is instantiated.
+/// If it is `1'b1` two `lzc`, a masking logic stage and a two input multiplexer are instantiated.
+/// However these are small in respect of the data multiplexers needed, as the width of the `req_i`
+/// signal is usually less as than `DataWidth`.
+module rr_arb_tree #(
+  /// Number of inputs to be arbitrated.
+  parameter int unsigned NumIn      = 64,
+  /// Data width of the payload in bits. Not needed if `DataType` is overwritten.
+  parameter int unsigned DataWidth  = 32,
+  /// Data type of the payload, can be overwritten with custom type. Only use of `DataWidth`.
+  parameter type         DataType   = logic [DataWidth-1:0],
+  /// The `ExtPrio` option allows to override the internal round robin counter via the
+  /// `rr_i` signal. This can be useful in case multiple arbiters need to have
+  /// rotating priorities that are operating in lock-step. If static priority arbitration
+  /// is needed, just connect `rr_i` to '0.
+  ///
+  /// Set to 1'b1 to enable.
+  parameter bit          ExtPrio    = 1'b0,
+  /// If `AxiVldRdy` is set, the req/gnt signals are compliant with the AXI style vld/rdy
+  /// handshake. Namely, upstream vld (req) must not depend on rdy (gnt), as it can be deasserted
+  /// again even though vld is asserted. Enabling `AxiVldRdy` leads to a reduction of arbiter
+  /// delay and area.
+  ///
+  /// Set to `1'b1` to treat req/gnt as vld/rdy.
+  parameter bit          AxiVldRdy  = 1'b0,
+  /// The `LockIn` option prevents the arbiter from changing the arbitration
+  /// decision when the arbiter is disabled. I.e., the index of the first request
+  /// that wins the arbitration will be locked in case the destination is not
+  /// able to grant the request in the same cycle.
+  ///
+  /// Set to `1'b1` to enable.
+  parameter bit          LockIn     = 1'b0,
+  /// When set, ensures that throughput gets distributed evenly between all inputs.
+  ///
+  /// Set to `1'b0` to disable.
+  parameter bit          FairArb    = 1'b1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Width of the arbitration priority signal and the arbitrated index.
+  parameter int unsigned IdxWidth   = (NumIn > 32'd1) ? unsigned'($clog2(NumIn)) : 32'd1,
+  /// Dependent parameter, do **not** overwrite.
+  /// Type for defining the arbitration priority and arbitrated index signal.
+  parameter type         idx_t      = logic [IdxWidth-1:0]
+) (
+  /// Clock, positive edge triggered.
+  input  logic                clk_i,
+  /// Asynchronous reset, active low.
+  input  logic                rst_ni,
+  /// Clears the arbiter state. Only used if `ExtPrio` is `1'b0` or `LockIn` is `1'b1`.
+  input  logic                flush_i,
+  /// External round-robin priority. Only used if `ExtPrio` is `1'b1.`
+  input  idx_t                rr_i,
+  /// Input requests arbitration.
+  input  logic    [NumIn-1:0] req_i,
+  /* verilator lint_off UNOPTFLAT */
+  /// Input request is granted.
+  output logic    [NumIn-1:0] gnt_o,
+  /* verilator lint_on UNOPTFLAT */
+  /// Input data for arbitration.
+  input  DataType [NumIn-1:0] data_i,
+  /// Output request is valid.
+  output logic                req_o,
+  /// Output request is granted.
+  input  logic                gnt_i,
+  /// Output data.
+  output DataType             data_o,
+  /// Index from which input the data came from.
+  output idx_t                idx_o
+);
+
+  // pragma translate_off
+  `ifndef VERILATOR
+  `ifndef XSIM
+  // Default SVA reset
+  default disable iff (!rst_ni || flush_i);
+  `endif
+  `endif
+  // pragma translate_on
+
+  // just pass through in this corner case
+  if (NumIn == unsigned'(1)) begin : gen_pass_through
+    assign req_o    = req_i[0];
+    assign gnt_o[0] = gnt_i;
+    assign data_o   = data_i[0];
+    assign idx_o    = '0;
+  // non-degenerate cases
+  end else begin : gen_arbiter
+    localparam int unsigned NumLevels = unsigned'($clog2(NumIn));
+
+    /* verilator lint_off UNOPTFLAT */
+    idx_t    [2**NumLevels-2:0] index_nodes; // used to propagate the indices
+    DataType [2**NumLevels-2:0] data_nodes;  // used to propagate the data
+    logic    [2**NumLevels-2:0] gnt_nodes;   // used to propagate the grant to masters
+    logic    [2**NumLevels-2:0] req_nodes;   // used to propagate the requests to slave
+    /* lint_off */
+    idx_t                       rr_q;
+    logic [NumIn-1:0]           req_d;
+
+    // the final arbitration decision can be taken from the root of the tree
+    assign req_o        = req_nodes[0];
+    assign data_o       = data_nodes[0];
+    assign idx_o        = index_nodes[0];
+
+    if (ExtPrio) begin : gen_ext_rr
+      assign rr_q       = rr_i;
+      assign req_d      = req_i;
+    end else begin : gen_int_rr
+      idx_t rr_d;
+
+      // lock arbiter decision in case we got at least one req and no acknowledge
+      if (LockIn) begin : gen_lock
+        logic  lock_d, lock_q;
+        logic [NumIn-1:0] req_q;
+
+        assign lock_d     = req_o & ~gnt_i;
+        assign req_d      = (lock_q) ? req_q : req_i;
+
+        always_ff @(posedge clk_i or negedge rst_ni) begin : p_lock_reg
+          if (!rst_ni) begin
+            lock_q <= '0;
+          end else begin
+            if (flush_i) begin
+              lock_q <= '0;
+            end else begin
+              lock_q <= lock_d;
+            end
+          end
+        end
+
+        // pragma translate_off
+        `ifndef VERILATOR
+          lock: assert property(
+            @(posedge clk_i) LockIn |-> req_o &&
+                             (!gnt_i && !flush_i) |=> idx_o == $past(idx_o)) else
+                $fatal (1, "Lock implies same arbiter decision in next cycle if output is not \
+                            ready.");
+
+          logic [NumIn-1:0] req_tmp;
+          assign req_tmp = req_q & req_i;
+          lock_req: assume property(
+            @(posedge clk_i) LockIn |-> lock_d |=> req_tmp == req_q) else
+                $fatal (1, "It is disallowed to deassert unserved request signals when LockIn is \
+                            enabled.");
+        `endif
+        // pragma translate_on
+
+        always_ff @(posedge clk_i or negedge rst_ni) begin : p_req_regs
+          if (!rst_ni) begin
+            req_q  <= '0;
+          end else begin
+            if (flush_i) begin
+              req_q  <= '0;
+            end else begin
+              req_q  <= req_d;
+            end
+          end
+        end
+      end else begin : gen_no_lock
+        assign req_d = req_i;
+      end
+
+      if (FairArb) begin : gen_fair_arb
+        logic [NumIn-1:0] upper_mask,  lower_mask;
+        idx_t             upper_idx,   lower_idx,   next_idx;
+        logic             upper_empty, lower_empty;
+
+        for (genvar i = 0; i < NumIn; i++) begin : gen_mask
+          assign upper_mask[i] = (i >  rr_q) ? req_d[i] : 1'b0;
+          assign lower_mask[i] = (i <= rr_q) ? req_d[i] : 1'b0;
+        end
+
+        lzc #(
+          .WIDTH ( NumIn ),
+          .MODE  ( 1'b0  )
+        ) i_lzc_upper (
+          .in_i    ( upper_mask  ),
+          .cnt_o   ( upper_idx   ),
+          .empty_o ( upper_empty )
+        );
+
+        lzc #(
+          .WIDTH ( NumIn ),
+          .MODE  ( 1'b0  )
+        ) i_lzc_lower (
+          .in_i    ( lower_mask  ),
+          .cnt_o   ( lower_idx   ),
+          .empty_o ( /*unused*/  )
+        );
+
+        assign next_idx = upper_empty      ? lower_idx : upper_idx;
+        assign rr_d     = (gnt_i && req_o) ? next_idx  : rr_q;
+
+      end else begin : gen_unfair_arb
+        assign rr_d = (gnt_i && req_o) ? ((rr_q == idx_t'(NumIn-1)) ? '0 : rr_q + 1'b1) : rr_q;
+      end
+
+      // this holds the highest priority
+      always_ff @(posedge clk_i or negedge rst_ni) begin : p_rr_regs
+        if (!rst_ni) begin
+          rr_q   <= '0;
+        end else begin
+          if (flush_i) begin
+            rr_q   <= '0;
+          end else begin
+            rr_q   <= rr_d;
+          end
+        end
+      end
+    end
+
+    assign gnt_nodes[0] = gnt_i;
+
+    // arbiter tree
+    for (genvar level = 0; unsigned'(level) < NumLevels; level++) begin : gen_levels
+      for (genvar l = 0; l < 2**level; l++) begin : gen_level
+        // local select signal
+        logic sel;
+        // index calcs
+        localparam int unsigned Idx0 = 2**level-1+l;// current node
+        localparam int unsigned Idx1 = 2**(level+1)-1+l*2;
+        //////////////////////////////////////////////////////////////
+        // uppermost level where data is fed in from the inputs
+        if (unsigned'(level) == NumLevels-1) begin : gen_first_level
+          // if two successive indices are still in the vector...
+          if (unsigned'(l) * 2 < NumIn-1) begin : gen_reduce
+            assign req_nodes[Idx0]   = req_d[l*2] | req_d[l*2+1];
+
+            // arbitration: round robin
+            assign sel =  ~req_d[l*2] | req_d[l*2+1] & rr_q[NumLevels-1-level];
+
+            assign index_nodes[Idx0] = idx_t'(sel);
+            assign data_nodes[Idx0]  = (sel) ? data_i[l*2+1] : data_i[l*2];
+            assign gnt_o[l*2]        = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2])   & ~sel;
+            assign gnt_o[l*2+1]      = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2+1]) & sel;
+          end
+          // if only the first index is still in the vector...
+          if (unsigned'(l) * 2 == NumIn-1) begin : gen_first
+            assign req_nodes[Idx0]   = req_d[l*2];
+            assign index_nodes[Idx0] = '0;// always zero in this case
+            assign data_nodes[Idx0]  = data_i[l*2];
+            assign gnt_o[l*2]        = gnt_nodes[Idx0] & (AxiVldRdy | req_d[l*2]);
+          end
+          // if index is out of range, fill up with zeros (will get pruned)
+          if (unsigned'(l) * 2 > NumIn-1) begin : gen_out_of_range
+            assign req_nodes[Idx0]   = 1'b0;
+            assign index_nodes[Idx0] = idx_t'('0);
+            assign data_nodes[Idx0]  = DataType'('0);
+          end
+        //////////////////////////////////////////////////////////////
+        // general case for other levels within the tree
+        end else begin : gen_other_levels
+          assign req_nodes[Idx0]   = req_nodes[Idx1] | req_nodes[Idx1+1];
+
+          // arbitration: round robin
+          assign sel =  ~req_nodes[Idx1] | req_nodes[Idx1+1] & rr_q[NumLevels-1-level];
+
+          assign index_nodes[Idx0] = (sel) ?
+            idx_t'({1'b1, index_nodes[Idx1+1][NumLevels-unsigned'(level)-2:0]}) :
+            idx_t'({1'b0, index_nodes[Idx1][NumLevels-unsigned'(level)-2:0]});
+
+          assign data_nodes[Idx0]  = (sel) ? data_nodes[Idx1+1] : data_nodes[Idx1];
+          assign gnt_nodes[Idx1]   = gnt_nodes[Idx0] & ~sel;
+          assign gnt_nodes[Idx1+1] = gnt_nodes[Idx0] & sel;
+        end
+        //////////////////////////////////////////////////////////////
+      end
+    end
+
+    // pragma translate_off
+    `ifndef VERILATOR
+    `ifndef XSIM
+    initial begin : p_assert
+      assert(NumIn)
+        else $fatal(1, "Input must be at least one element wide.");
+      assert(!(LockIn && ExtPrio))
+        else $fatal(1,"Cannot use LockIn feature together with external ExtPrio.");
+    end
+
+    hot_one : assert property(
+      @(posedge clk_i) $onehot0(gnt_o))
+        else $fatal (1, "Grant signal must be hot1 or zero.");
+
+    gnt0 : assert property(
+      @(posedge clk_i) |gnt_o |-> gnt_i)
+        else $fatal (1, "Grant out implies grant in.");
+
+    gnt1 : assert property(
+      @(posedge clk_i) req_o |-> gnt_i |-> |gnt_o)
+        else $fatal (1, "Req out and grant in implies grant out.");
+
+    gnt_idx : assert property(
+      @(posedge clk_i) req_o |->  gnt_i |-> gnt_o[idx_o])
+        else $fatal (1, "Idx_o / gnt_o do not match.");
+
+    req0 : assert property(
+      @(posedge clk_i) |req_i |-> req_o)
+        else $fatal (1, "Req in implies req out.");
+
+    req1 : assert property(
+      @(posedge clk_i) req_o |-> |req_i)
+        else $fatal (1, "Req out implies req in.");
+    `endif
+    `endif
+    // pragma translate_on
+  end
+
+endmodule : rr_arb_tree

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/shift_reg.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/shift_reg.sv
@@ -1,0 +1,53 @@
+
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: <zarubaf@iis.ee.ethz.ch>
+//
+// Description: Simple shift register for arbitrary depth and types
+
+module shift_reg #(
+    parameter type dtype         = logic,
+    parameter int unsigned Depth = 1
+)(
+    input  logic clk_i,    // Clock
+    input  logic rst_ni,   // Asynchronous reset active low
+    input  dtype d_i,
+    output dtype d_o
+);
+
+    // register of depth 0 is a wire
+    if (Depth == 0) begin : gen_pass_through
+        assign d_o = d_i;
+    // register of depth 1 is a simple register
+    end else if (Depth == 1) begin : gen_register
+        always_ff @(posedge clk_i or negedge rst_ni) begin
+            if (~rst_ni) begin
+                d_o <= '0;
+            end else begin
+                d_o <= d_i;
+            end
+        end
+    // if depth is greater than 1 it becomes a shift register
+    end else if (Depth > 1) begin : gen_shift_reg
+        dtype [Depth-1:0] reg_d, reg_q;
+        assign d_o = reg_q[Depth-1];
+        assign reg_d = {reg_q[Depth-2:0], d_i};
+
+        always_ff @(posedge clk_i or negedge rst_ni) begin
+            if (~rst_ni) begin
+                reg_q <= '0;
+            end else begin
+                reg_q <= reg_d;
+            end
+        end
+    end
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_arbiter.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_arbiter.sv
@@ -1,0 +1,49 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Stream arbiter: Arbitrates a parametrizable number of input streams (i.e., valid-ready
+// handshaking with dependency rules as in AXI4) to a single output stream.  Once `oup_valid_o` is
+// asserted, `oup_data_o` remains invariant until the output handshake has occurred.  The
+// arbitration scheme is round-robin with "look ahead", see the `rrarbiter` for details.
+
+module stream_arbiter #(
+    parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
+    parameter integer   N_INP = -1,       // Synopsys DC requires a default value for parameters.
+    parameter           ARBITER = "rr"    // "rr" or "prio"
+) (
+    input  logic              clk_i,
+    input  logic              rst_ni,
+
+    input  DATA_T [N_INP-1:0] inp_data_i,
+    input  logic  [N_INP-1:0] inp_valid_i,
+    output logic  [N_INP-1:0] inp_ready_o,
+
+    output DATA_T             oup_data_o,
+    output logic              oup_valid_o,
+    input  logic              oup_ready_i
+);
+
+  stream_arbiter_flushable #(
+    .DATA_T   (DATA_T),
+    .N_INP    (N_INP),
+    .ARBITER  (ARBITER)
+  ) i_arb (
+    .clk_i        (clk_i),
+    .rst_ni       (rst_ni),
+    .flush_i      (1'b0),
+    .inp_data_i   (inp_data_i),
+    .inp_valid_i  (inp_valid_i),
+    .inp_ready_o  (inp_ready_o),
+    .oup_data_o   (oup_data_o),
+    .oup_valid_o  (oup_valid_o),
+    .oup_ready_i  (oup_ready_i)
+  );
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_arbiter_flushable.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_arbiter_flushable.sv
@@ -1,0 +1,82 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Stream arbiter: Arbitrates a parametrizable number of input streams (i.e., valid-ready
+// handshaking with dependency rules as in AXI4) to a single output stream.  Once `oup_valid_o` is
+// asserted, `oup_data_o` remains invariant until the output handshake has occurred.  The
+// arbitration scheme is fair round-robin tree, see `rr_arb_tree` for details.
+
+module stream_arbiter_flushable #(
+    parameter type      DATA_T = logic,   // Vivado requires a default value for type parameters.
+    parameter integer   N_INP = -1,       // Synopsys DC requires a default value for parameters.
+    parameter           ARBITER = "rr"    // "rr" or "prio"
+) (
+    input  logic              clk_i,
+    input  logic              rst_ni,
+    input  logic              flush_i,
+
+    input  DATA_T [N_INP-1:0] inp_data_i,
+    input  logic  [N_INP-1:0] inp_valid_i,
+    output logic  [N_INP-1:0] inp_ready_o,
+
+    output DATA_T             oup_data_o,
+    output logic              oup_valid_o,
+    input  logic              oup_ready_i
+);
+
+  if (ARBITER == "rr") begin : gen_rr_arb
+    rr_arb_tree #(
+      .NumIn      (N_INP),
+      .DataType   (DATA_T),
+      .ExtPrio    (1'b0),
+      .AxiVldRdy  (1'b1),
+      .LockIn     (1'b1)
+    ) i_arbiter (
+      .clk_i,
+      .rst_ni,
+      .flush_i,
+      .rr_i   ('0),
+      .req_i  (inp_valid_i),
+      .gnt_o  (inp_ready_o),
+      .data_i (inp_data_i),
+      .gnt_i  (oup_ready_i),
+      .req_o  (oup_valid_o),
+      .data_o (oup_data_o),
+      .idx_o  ()
+    );
+
+  end else if (ARBITER == "prio") begin : gen_prio_arb
+    rr_arb_tree #(
+      .NumIn      (N_INP),
+      .DataType   (DATA_T),
+      .ExtPrio    (1'b1),
+      .AxiVldRdy  (1'b1),
+      .LockIn     (1'b1)
+    ) i_arbiter (
+      .clk_i,
+      .rst_ni,
+      .flush_i,
+      .rr_i   ('0),
+      .req_i  (inp_valid_i),
+      .gnt_o  (inp_ready_o),
+      .data_i (inp_data_i),
+      .gnt_i  (oup_ready_i),
+      .req_o  (oup_valid_o),
+      .data_o (oup_data_o),
+      .idx_o  ()
+    );
+
+  end else begin : gen_arb_error
+    // pragma translate_off
+    $fatal(1, "Invalid value for parameter 'ARBITER'!");
+    // pragma translate_on
+  end
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_demux.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_demux.sv
@@ -1,0 +1,36 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// Connects the input stream (valid-ready) handshake to one of `N_OUP` output stream handshakes.
+///
+/// This module has no data ports because stream data does not need to be demultiplexed: the data of
+/// the input stream can just be applied at all output streams.
+module stream_demux #(
+  /// Number of connected outputs.
+  parameter int unsigned N_OUP     = 32'd1,
+  /// Dependent parameters, DO NOT OVERRIDE!
+  parameter int unsigned LOG_N_OUP = (N_OUP > 32'd1) ? unsigned'($clog2(N_OUP)) : 1'b1
+) (
+  input  logic                 inp_valid_i,
+  output logic                 inp_ready_o,
+
+  input  logic [LOG_N_OUP-1:0] oup_sel_i,
+
+  output logic [N_OUP-1:0]     oup_valid_o,
+  input  logic [N_OUP-1:0]     oup_ready_i
+);
+
+  always_comb begin
+    oup_valid_o = '0;
+    oup_valid_o[oup_sel_i] = inp_valid_i;
+  end
+  assign inp_ready_o = oup_ready_i[oup_sel_i];
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_mux.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/stream_mux.sv
@@ -1,0 +1,46 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License. You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+/// Stream multiplexer: connects the output to one of `N_INP` data streams with valid-ready
+/// handshaking.
+
+module stream_mux #(
+  parameter type DATA_T = logic,  // Vivado requires a default value for type parameters.
+  parameter integer N_INP = 0,    // Synopsys DC requires a default value for value parameters.
+  /// Dependent parameters, DO NOT OVERRIDE!
+  parameter integer LOG_N_INP = $clog2(N_INP)
+) (
+  input  DATA_T [N_INP-1:0]     inp_data_i,
+  input  logic  [N_INP-1:0]     inp_valid_i,
+  output logic  [N_INP-1:0]     inp_ready_o,
+
+  input  logic  [LOG_N_INP-1:0] inp_sel_i,
+
+  output DATA_T                 oup_data_o,
+  output logic                  oup_valid_o,
+  input  logic                  oup_ready_i
+);
+
+  always_comb begin
+    inp_ready_o = '0;
+    inp_ready_o[inp_sel_i] = oup_ready_i;
+  end
+  assign oup_data_o   = inp_data_i[inp_sel_i];
+  assign oup_valid_o  = inp_valid_i[inp_sel_i];
+
+// pragma translate_off
+`ifndef VERILATOR
+  initial begin: p_assertions
+    assert (N_INP >= 1) else $fatal (1, "The number of inputs must be at least 1!");
+  end
+`endif
+// pragma translate_on
+
+endmodule

--- a/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/unread.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/common_cells/src/unread.sv
@@ -1,0 +1,21 @@
+// Copyright 2018 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// Author: Florian Zaruba, ETH Zurich
+// Date: 29.10.2018
+// Description: Dummy circuit to mitigate Open Pin warnings
+
+/* verilator lint_off UNUSED */
+module unread (
+    input logic d_i
+);
+
+endmodule
+/* verilator lint_on UNUSED */

--- a/flow/designs/src/cva6/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
+++ b/flow/designs/src/cva6/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv
@@ -1,0 +1,248 @@
+// Copyright (c) 2020 ETH Zurich and University of Bologna.
+// Copyright and related rights are licensed under the Solderpad Hardware
+// License, Version 0.51 (the "License"); you may not use this file except in
+// compliance with the License.  You may obtain a copy of the License at
+// http://solderpad.org/licenses/SHL-0.51. Unless required by applicable law
+// or agreed to in writing, software, hardware and materials distributed under
+// this License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+// Author: Wolfgang Roenninger <wroennin@ethz.ch>
+
+// Description: Functional module of a generic SRAM
+//
+// Parameters:
+// - NumWords:    Number of words in the macro. Address width can be calculated with:
+//                `AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1`
+//                The module issues a warning if there is a request on an address which is
+//                not in range.
+// - DataWidth:   Width of the ports `wdata_i` and `rdata_o`.
+// - ByteWidth:   Width of a byte, the byte enable signal `be_i` can be calculated with the
+//                ceiling division `ceil(DataWidth, ByteWidth)`.
+// - NumPorts:    Number of read and write ports. Each is a full port. Ports with a higher
+//                index read and write after the ones with lower indices.
+// - Latency:     Read latency, the read data is available this many cycles after a request.
+// - SimInit:     Macro simulation initialization. Values are:
+//                "zeros":  Each bit gets initialized with 1'b0.
+//                "ones":   Each bit gets initialized with 1'b1.
+//                "random": Each bit gets random initialized with 1'b0 or 1'b1.
+//                "none":   Each bit gets initialized with 1'bx. (default)
+// - PrintSimCfg: Prints at the beginning of the simulation a `Hello` message with
+//                the instantiated parameters and signal widths.
+// - ImplKey:     Key by which an instance can refer to a specific implementation (e.g. macro).
+//                May be used to look up additional parameters for implementation (e.g. generator,
+//                line width, muxing) in an external reference, such as a configuration file.
+//
+// Ports:
+// - `clk_i`:   Clock
+// - `rst_ni`:  Asynchronous reset, active low
+// - `req_i`:   Request, active high
+// - `we_i`:    Write request, active high
+// - `addr_i`:  Request address
+// - `wdata_i`: Write data, has to be valid on request
+// - `be_i`:    Byte enable, active high
+// - `rdata_o`: Read data, valid `Latency` cycles after a request with `we_i` low.
+//
+// Behaviour:
+// - Address collision:  When Ports are making a write access onto the same address,
+//                       the write operation will start at the port with the lowest address
+//                       index, each port will overwrite the changes made by the previous ports
+//                       according how the respective `be_i` signal is set.
+// - Read data on write: This implementation will not produce a read data output on the signal
+//                       `rdata_o` when `req_i` and `we_i` are asserted. The output data is stable
+//                       on write requests.
+
+module tc_sram #(
+  parameter int unsigned NumWords     = 32'd1024, // Number of Words in data array
+  parameter int unsigned DataWidth    = 32'd128,  // Data signal width
+  parameter int unsigned ByteWidth    = 32'd8,    // Width of a data byte
+  parameter int unsigned NumPorts     = 32'd2,    // Number of read and write ports
+  parameter int unsigned Latency      = 32'd1,    // Latency when the read data is available
+  parameter              SimInit      = "none",   // Simulation initialization
+  parameter bit          PrintSimCfg  = 1'b0,     // Print configuration
+  parameter              ImplKey      = "none",   // Reference to specific implementation
+  // DEPENDENT PARAMETERS, DO NOT OVERWRITE!
+  parameter int unsigned AddrWidth = (NumWords > 32'd1) ? $clog2(NumWords) : 32'd1,
+  parameter int unsigned BeWidth   = (DataWidth + ByteWidth - 32'd1) / ByteWidth, // ceil_div
+  parameter type         addr_t    = logic [AddrWidth-1:0],
+  parameter type         data_t    = logic [DataWidth-1:0],
+  parameter type         be_t      = logic [BeWidth-1:0]
+) (
+  input  logic                 clk_i,      // Clock
+  input  logic                 rst_ni,     // Asynchronous reset active low
+  // input ports
+  input  logic  [NumPorts-1:0] req_i,      // request
+  input  logic  [NumPorts-1:0] we_i,       // write enable
+  input  addr_t [NumPorts-1:0] addr_i,     // request address
+  input  data_t [NumPorts-1:0] wdata_i,    // write data
+  input  be_t   [NumPorts-1:0] be_i,       // write byte enable
+  // output ports
+  output data_t [NumPorts-1:0] rdata_o     // read data
+);
+
+  // memory array
+  data_t sram [NumWords-1:0];
+  // hold the read address when no read access is made
+  addr_t [NumPorts-1:0] r_addr_q;
+
+  // SRAM simulation initialization
+  data_t init_val[NumWords-1:0];
+  initial begin : proc_sram_init
+    for (int unsigned i = 0; i < NumWords; i++) begin
+      case (SimInit)
+        "zeros":  init_val[i] = {DataWidth{1'b0}};
+        "ones":   init_val[i] = {DataWidth{1'b1}};
+        "random": init_val[i] = {DataWidth{$urandom()}};
+        default:  init_val[i] = {DataWidth{1'bx}};
+      endcase
+    end
+  end
+
+  // set the read output if requested
+  // The read data at the highest array index is set combinational.
+  // It gets then delayed for a number of cycles until it gets available at the output at
+  // array index 0.
+
+  // read data output assignment
+  data_t [NumPorts-1:0][Latency-1:0] rdata_q,  rdata_d;
+  if (Latency == 32'd0) begin : gen_no_read_lat
+    for (genvar i = 0; i < NumPorts; i++) begin : gen_port
+      assign rdata_o[i] = (req_i[i] && !we_i[i]) ? sram[addr_i[i]] : sram[r_addr_q[i]];
+    end
+  end else begin : gen_read_lat
+
+    always_comb begin
+      for (int unsigned i = 0; i < NumPorts; i++) begin
+        rdata_o[i] = rdata_q[i][0];
+        for (int unsigned j = 0; j < (Latency-1); j++) begin
+          rdata_d[i][j] = rdata_q[i][j+1];
+        end
+        rdata_d[i][Latency-1] = (req_i[i] && !we_i[i]) ? sram[addr_i[i]] : sram[r_addr_q[i]];
+      end
+    end
+  end
+
+  // In case simulation initialization is disabled (SimInit == 'none'), don't assign to the sram
+  // content at all. This improves simulation performance in tools like verilator
+  if (SimInit == "none") begin
+    // write memory array without initialization
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        for (int i = 0; i < NumPorts; i++) begin
+          r_addr_q[i] <= {AddrWidth{1'b0}};
+        end
+      end else begin
+        // read value latch happens before new data is written to the sram
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (Latency != 0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= rdata_d[i][j];
+            end
+          end
+        end
+        // there is a request for the SRAM, latch the required register
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (req_i[i]) begin
+            if (we_i[i]) begin
+              // update value when write is set at clock
+              for (int unsigned j = 0; j < BeWidth; j++) begin
+                if (be_i[i][j]) begin
+                  sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
+                end
+              end
+            end else begin
+              // otherwise update read address for subsequent non request cycles
+              r_addr_q[i] <= addr_i[i];
+            end
+          end // if req_i
+        end // for ports
+      end // if !rst_ni
+    end
+  end else begin
+    // write memory array
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        // Fix to avoid runtime space reaching maximum capacity in simulation
+        foreach (init_val[i]) begin
+          sram[i] <= init_val[i];
+        end
+        for (int i = 0; i < NumPorts; i++) begin
+          r_addr_q[i] <= {AddrWidth{1'b0}};
+          // initialize the read output register for each port
+          if (Latency != 32'd0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= init_val[{AddrWidth{1'b0}}];
+            end
+          end
+        end
+      end else begin
+        // read value latch happens before new data is written to the sram
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (Latency != 0) begin
+            for (int unsigned j = 0; j < Latency; j++) begin
+              rdata_q[i][j] <= rdata_d[i][j];
+            end
+          end
+        end
+        // there is a request for the SRAM, latch the required register
+        for (int unsigned i = 0; i < NumPorts; i++) begin
+          if (req_i[i]) begin
+            if (we_i[i]) begin
+              // update value when write is set at clock
+              for (int unsigned j = 0; j < BeWidth; j++) begin
+                if (be_i[i][j]) begin
+                  sram[addr_i[i]][j*ByteWidth+:ByteWidth] <= wdata_i[i][j*ByteWidth+:ByteWidth];
+                end
+              end
+            end else begin
+              // otherwise update read address for subsequent non request cycles
+              r_addr_q[i] <= addr_i[i];
+            end
+          end // if req_i
+        end // for ports
+      end // if !rst_ni
+    end
+  end
+
+// Validate parameters.
+// pragma translate_off
+`ifndef VERILATOR
+`ifndef TARGET_SYNTHESIS
+  initial begin: p_assertions
+    assert ($bits(addr_i)  == NumPorts * AddrWidth) else $fatal(1, "AddrWidth problem on `addr_i`");
+    assert ($bits(wdata_i) == NumPorts * DataWidth) else $fatal(1, "DataWidth problem on `wdata_i`");
+    assert ($bits(be_i)    == NumPorts * BeWidth)   else $fatal(1, "BeWidth   problem on `be_i`"   );
+    assert ($bits(rdata_o) == NumPorts * DataWidth) else $fatal(1, "DataWidth problem on `rdata_o`");
+    assert (NumWords  >= 32'd1) else $fatal(1, "NumWords has to be > 0");
+    assert (DataWidth >= 32'd1) else $fatal(1, "DataWidth has to be > 0");
+    assert (ByteWidth >= 32'd1) else $fatal(1, "ByteWidth has to be > 0");
+    assert (NumPorts  >= 32'd1) else $fatal(1, "The number of ports must be at least 1!");
+  end
+  initial begin: p_sim_hello
+    if (PrintSimCfg) begin
+      $display("#################################################################################");
+      $display("tc_sram functional instantiated with the configuration:"                          );
+      $display("Instance: %m"                                                                     );
+      $display("Number of ports   (dec): %0d", NumPorts                                           );
+      $display("Number of words   (dec): %0d", NumWords                                           );
+      $display("Address width     (dec): %0d", AddrWidth                                          );
+      $display("Data width        (dec): %0d", DataWidth                                          );
+      $display("Byte width        (dec): %0d", ByteWidth                                          );
+      $display("Byte enable width (dec): %0d", BeWidth                                            );
+      $display("Latency Cycles    (dec): %0d", Latency                                            );
+      $display("Simulation init   (str): %0s", SimInit                                            );
+      $display("#################################################################################");
+    end
+  end
+  for (genvar i = 0; i < NumPorts; i++) begin : gen_assertions
+    assert property ( @(posedge clk_i) disable iff (!rst_ni)
+        (req_i[i] |-> (addr_i[i] < NumWords))) else
+      $warning("Request address %0h not mapped, port %0d, expect random write or read behavior!",
+          addr_i[i], i);
+  end
+
+`endif
+`endif
+// pragma translate_on
+endmodule


### PR DESCRIPTION
Enabling snapshot of cva6 on asap7. yosys-slang was used as the front end.

Metrics:
score: 141368.0
clk_period: 17.0
worst_slack: -1396.68
effective_clk_period: 1413.68
num_drc: 0

![cva6_200](https://github.com/user-attachments/assets/a1f92b26-d790-44c4-9cd2-947aa164e44d)

TODOs as part of yosys-slang enablement: https://github.com/povik/yosys-slang/issues/74
