### PR TITLE
platforms: IO_PLACER_H/V can be overriden by designs

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -75,8 +75,8 @@ export MATCH_CELL_FOOTPRINT = 1
 export PLACE_SITE = CoreSite
 
 # IO Placer pin layers
-export IO_PLACER_H = Metal2
-export IO_PLACER_V = Metal3
+export IO_PLACER_H ?= Metal2
+export IO_PLACER_V ?= Metal3
 
 # Define default PDN config
 export PDN_TCL ?= $(PLATFORM_DIR)/pdn.tcl

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -50,8 +50,8 @@ export ABC_LOAD_IN_FF = 3.898
 export PLACE_SITE = FreePDK45_38x28_10R_NP_162NW_34O
 
 # IO Placer pin layers
-export IO_PLACER_H = metal5
-export IO_PLACER_V = metal6
+export IO_PLACER_H ?= metal5
+export IO_PLACER_V ?= metal6
 
 # Define default PDN config
 export PDN_TCL ?= $(PLATFORM_DIR)/grid_strategy-M1-M4-M7.tcl

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -93,8 +93,8 @@ export MATCH_CELL_FOOTPRINT = 1
 export PLACE_SITE = unithd
 
 # IO Placer pin layers
-export IO_PLACER_H = met3
-export IO_PLACER_V = met2
+export IO_PLACER_H ?= met3
+export IO_PLACER_V ?= met2
 
 # Define default PDN config
 export PDN_TCL ?= $(PLATFORM_DIR)/pdn.tcl

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -55,8 +55,8 @@ export MATCH_CELL_FOOTPRINT = 1
 export PLACE_SITE = unit
 
 # IO Placer pin layers
-export IO_PLACER_H = met3
-export IO_PLACER_V = met2
+export IO_PLACER_H ?= met3
+export IO_PLACER_V ?= met2
 
 # Define default PDN config
 export PDN_TCL ?= $(PLATFORM_DIR)/pdn.tcl


### PR DESCRIPTION
platforms are now consistent here. Changed all in case an existing platform is used as a template for some future platform.

![image](https://github.com/user-attachments/assets/67d7d5c2-52a4-4564-97b6-c2da63e1218e)

Discovered while tinkering with https://github.com/olofk/serv/pull/146