### PR TITLE
[DO NOT REVIEW] makefile: break out time consuming metrics in separate target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -595,6 +595,7 @@ endef
 # STEP 1: Translate verilog to odb
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL) $(DONT_USE_SC_LIB),floorplan))
+$(eval $(call do-step,2_1_floorplan_metrics,$(RESULTS_DIR)/2_1_floorplan.odb $(RESULTS_DIR)/2_1_floorplan.sdc,floorplan-metrics))
 
 # STEP 2: Random IO placement
 #-------------------------------------------------------------------------------

--- a/flow/scripts/floorplan-metrics.tcl
+++ b/flow/scripts/floorplan-metrics.tcl
@@ -1,0 +1,6 @@
+utl::set_metrics_stage "floorplan__{}"
+source $::env(SCRIPTS_DIR)/load.tcl
+erase_non_stage_variables floorplan
+load_design 2_1_floorplan.odb 2_1_floorplan.sdc
+
+report_metrics 2 "floorplan final" false false

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -149,7 +149,6 @@ if { [env_var_equals RESYNTH_TIMING_RECOVER 1] } {
 puts "Default units for flow"
 report_units
 report_units_metric
-report_metrics 2 "floorplan final" false false
 
 if { [env_var_equals RESYNTH_AREA_RECOVER 1] } {
 


### PR DESCRIPTION
@maliberty A thought: do the time consuming reporting in a separate project to make the flow progress faster

This creates two .json files now that would have to be combined.

```json
{
	"floorplan__timing__setup__tns": 0,
	"floorplan__timing__hold__tns": 0,
	"floorplan__timing__setup__ws": 0.0148687,
	"floorplan__timing__hold__ws": 0.0997134,
	"floorplan__power__internal__total": 0.00120063,
	"floorplan__power__switching__total": 0.000809229,
	"floorplan__power__leakage__total": 1.46085e-05,
	"floorplan__power__total": 0.00202447,
	"floorplan__design__io": 54,
	"floorplan__design__die__area": 1262.03,
	"floorplan__design__core__area": 1070.65,
	"floorplan__design__instance__count": 499,
	"floorplan__design__instance__area": 618.184,
	"floorplan__design__instance__count__stdcell": 499,
	"floorplan__design__instance__area__stdcell": 618.184,
	"floorplan__design__instance__count__macros": 0,
	"floorplan__design__instance__area__macros": 0,
	"floorplan__design__instance__count__padcells": 0,
	"floorplan__design__instance__area__padcells": 0,
	"floorplan__design__instance__count__cover": 0,
	"floorplan__design__instance__area__cover": 0,
	"floorplan__design__instance__utilization": 0.577391,
	"floorplan__design__instance__utilization__stdcell": 0.577391,
	"floorplan__design__rows": 23,
	"floorplan__design__rows:FreePDK45_38x28_10R_NP_162NW_34O": 23,
	"floorplan__design__sites": 4025,
	"floorplan__design__sites:FreePDK45_38x28_10R_NP_162NW_34O": 4025,
	"floorplan__flow__warnings__count": 0,
	"floorplan__flow__errors__count": 0
}
```

and

```json
{
	"floorplan__design__instance__count__setup_buffer": 0,
	"floorplan__design__instance__count__hold_buffer": 0,
	"run__flow__platform__time_units": "1ns",
	"run__flow__platform__capacitance_units": "1fF",
	"run__flow__platform__resistance_units": "1kohm",
	"run__flow__platform__voltage_units": "1v",
	"run__flow__platform__current_units": "1mA",
	"run__flow__platform__power_units": "1nW",
	"run__flow__platform__distance_units": "1um",
	"floorplan__flow__warnings__count": 2,
	"floorplan__flow__errors__count": 0
}
```