### PR TITLE
make: make OPENROAD_ variables visible in environment to facilitate scripting

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -226,10 +226,10 @@ endif
 export OPENROAD_EXE      ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/openroad)
 export OPENSTA_EXE       ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/sta)
 
-OPENROAD_ARGS            = -no_init -threads $(NUM_CORES) $(OR_ARGS)
-OPENROAD_CMD             = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
-OPENROAD_NO_EXIT_CMD     = $(OPENROAD_EXE) $(OPENROAD_ARGS)
-OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
+export OPENROAD_ARGS            = -no_init -threads $(NUM_CORES) $(OR_ARGS)
+export OPENROAD_CMD             = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
+export OPENROAD_NO_EXIT_CMD     = $(OPENROAD_EXE) $(OPENROAD_ARGS)
+export OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
 
 YOSYS_EXE               ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
 


### PR DESCRIPTION
I think this should be a simple change with no fallout :sweat_smile:, but good to have in master to know.