### PR TITLE
synth: consistent with other .tcl scripts, it knows its input

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -436,8 +436,7 @@ yosys-dependencies: $(YOSYS_DEPENDENCIES)
 .PHONY: do-yosys
 do-yosys: $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	(export VERILOG_FILES=$(RESULTS_DIR)/1_synth.rtlil; \
-	$(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys.log)
+	($(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys.log)
 
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -1,3 +1,5 @@
+set ::env(VERILOG_FILES) $::env(RESULTS_DIR)/1_synth.rtlil
+
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 
 hierarchy -check -top $::env(DESIGN_NAME)


### PR DESCRIPTION
other scripts, like floorplan.tcl, knows what inputs to load. This makes synth.tcl consistent with this convention rather than encoding this in the Makefile