### PR TITLE
Fixed CTS handling of flow variables

### DIFF
--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 594,
+        "value": 1088,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 36,
+        "value": 51,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {

--- a/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
+++ b/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
@@ -8,7 +8,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 177178,
+        "value": 173952,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.92,
+        "value": -0.72,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -23.85,
+        "value": -19.8,
         "compare": ">="
     }
 }

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -18,9 +18,10 @@ set cts_args [list \
           -sink_clustering_enable \
           -balance_levels]
 
-append_env_var cts_args -distance_between_buffers CTS_BUF_DISTANCE 1
-append_env_var cts_args -sink_clustering_size CTS_CLUSTER_SIZE 1
-append_env_var cts_args -sink_clustering_max_diameter CTS_CLUSTER_DIAMETER 1
+append_env_var cts_args CTS_BUF_DISTANCE -distance_between_buffers 1
+append_env_var cts_args CTS_CLUSTER_SIZE -sink_clustering_size 1
+append_env_var cts_args CTS_CLUSTER_DIAMETER -sink_clustering_max_diameter 1
+append_env_var cts_args CTS_BUF_LIST -buf_list 1
 
 if {[env_var_exists_and_non_empty CTS_ARGS]} {
   set cts_args $::env(CTS_ARGS)

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -721,6 +721,11 @@ CTS_BUF_DISTANCE:
     Distance (in microns) between buffers.
   stages:
     - cts
+CTS_BUF_LIST:
+  description: |
+    List of cells used to construct the clock tree.
+  stages:
+    - cts
 CTS_CLUSTER_DIAMETER:
   description: >
     Maximum diameter (in microns) of sink cluster.


### PR DESCRIPTION
Includes the following mods:

1. Fixed calling of append_env_var in cts.tcl since the argument order was incorrect
2. Added CTS_BUF_LIST env var (also updated variables.yaml document)
3. Updated rules files for three designs (ihp-sg13g2/ibex, ihp-sg13g2/riscvi, sky130hd/microwatt) which explicitly set CTS_BUF_DISTANCE. Due to item 1 above, the flow variable was ignored
4. Included at- in branch name to run AutoTuner tests (all autotuner.json files include CTS_CLUSTER_DIAMETER and CTS_CLUSTER_SIZE in their parameter list - I tested asap7/gcd locally before PR'ing

Updated stats:

### ihp ibex
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      594 |     1088 | Failing  |
| detailedroute__antenna__violating__nets       |       36 |       51 | Failing  |

### ihp_riscv32i
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |   177178 |   173952 | Tighten  |
| finish__timing__setup__ws                     |    -0.92 |    -0.72 | Tighten  |
| finish__timing__wns_percent_delay             |   -23.85 |    -19.8 | Tighten  |

### sky130hd microwatt
No change
