### PR TITLE
Removing hardcoded hashes from Nix flake.

### DIFF
--- a/.github/workflows/github-actions-cron-update-OR.yml
+++ b/.github/workflows/github-actions-cron-update-OR.yml
@@ -23,21 +23,28 @@ jobs:
           git checkout master
           git pull
       - if: "steps.remote-update.outputs.has_update != ''"
-        name: Create Draft PR
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ github.token }}
-          signoff: true
-          delete-branch: true
-          title: 'Update OpenROAD submodule'
-          body: |
-            Automated action to update tools/OpenROAD submodule and tighten CI rule checking.
-            [ci:rules-tighten]
-          labels: UpdateRules
-          reviewers: |
-            vvbandeira
-            maliberty
-          draft: true
-          branch: update-openroad
-          commit-message: |
-              [BOT] Update OpenROAD submodule
+        steps:
+        - name: Install Nix
+          uses: cachix/install-nix-action@v31
+          with:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Update flake.lock
+          run: nix --extra-experimental-features "nix-command flakes" flake update openroad-abc-src openroad-opensta-src openroad-flake
+        - name: Create Draft PR
+          uses: peter-evans/create-pull-request@v7
+          with:
+            token: ${{ github.token }}
+            signoff: true
+            delete-branch: true
+            title: 'Update OpenROAD submodule'
+            body: |
+              Automated action to update tools/OpenROAD submodule and tighten CI rule checking.
+              [ci:rules-tighten]
+            labels: UpdateRules
+            reviewers: |
+              vvbandeira
+              maliberty
+            draft: true
+            branch: update-openroad
+            commit-message: |
+                [BOT] Update OpenROAD submodule

--- a/.github/workflows/github-actions-cron-update-yosys.yml
+++ b/.github/workflows/github-actions-cron-update-yosys.yml
@@ -27,16 +27,23 @@ jobs:
           echo "::set-output name=has_update::$(git --no-pager diff --name-only ${latesttag}..HEAD)"
           git checkout ${latesttag}
       - if: "steps.remote-update.outputs.has_update != ''"
-        name: Create Draft PR
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ github.token }}
-          signoff: true
-          delete-branch: true
-          title: 'Update yosys submodule'
-          reviewers: |
-            habibayassin
-          draft: true
-          branch: update-yosys
-          commit-message: |
-              [BOT] Update yosys submodule
+        steps:
+          - name: Install Nix
+            uses: cachix/install-nix-action@v31
+            with:
+              github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          - name: Update flake.lock
+            run: nix --extra-experimental-features "nix-command flakes" flake update yosys-abc-src yosys-cxxopts-src yosys-flake
+          - name: Create Draft PR
+            uses: peter-evans/create-pull-request@v6
+            with:
+              token: ${{ github.token }}
+              signoff: true
+              delete-branch: true
+              title: 'Update yosys submodule'
+              reviewers: |
+                habibayassin
+              draft: true
+              branch: update-yosys
+              commit-message: |
+                  [BOT] Update yosys submodule

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741851582,
-        "narHash": "sha256-cPfs8qMccim2RBgtKGF+x9IBCduRvd/N5F4nYpU0TVE=",
+        "lastModified": 1742288794,
+        "narHash": "sha256-Txwa5uO+qpQXrNG4eumPSD+hHzzYi/CdaM80M9XRLCo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6607cf789e541e7873d40d3a8f7815ea92204f32",
+        "rev": "b6eaf97c6960d97350c584de1b6dcff03c9daf42",
         "type": "github"
       },
       "original": {
@@ -84,33 +84,63 @@
         "type": "github"
       }
     },
-    "openroad": {
+    "openroad-abc-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1735605591,
+        "narHash": "sha256-GF2EnSbXWHasKXqqPDoCP8GlatwZm+0WLX0BiDUJ1Qk=",
+        "rev": "5c9448c085eb8bf1e433a22a954532e44206c6f9",
+        "revCount": 5622,
+        "type": "git",
+        "url": "file:tools/OpenROAD/third-party/abc"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:tools/OpenROAD/third-party/abc"
+      }
+    },
+    "openroad-flake": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741801451,
-        "narHash": "sha256-fzWCeq0o6vx8/GoFcOtnaIENes3jXzNk9qfWnIaxtHI=",
-        "ref": "refs/heads/master",
-        "rev": "ec1bf1a13902813b722f8341c432cd09714d9e55",
-        "revCount": 27845,
-        "submodules": true,
+        "lastModified": 1744179775,
+        "narHash": "sha256-+w6lnpbuh39QKI6oG6rZxMKSxyfufD+4PB2pIxO8AfA=",
+        "rev": "33cc7567fa495b89ed9a273c08f21e04c7a31397",
+        "revCount": 28690,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
+        "url": "file:tools/OpenROAD"
       },
       "original": {
-        "rev": "ec1bf1a13902813b722f8341c432cd09714d9e55",
-        "submodules": true,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
+        "url": "file:tools/OpenROAD"
+      }
+    },
+    "openroad-opensta-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740616817,
+        "narHash": "sha256-y1zELJFgfWAyZGiiRaDH3Ie72CSzLBx7yiyXQsnc36k=",
+        "rev": "5a46b3ceb2ad40eddcf7f118093a24258240c74c",
+        "revCount": 1831,
+        "type": "git",
+        "url": "file:tools/OpenROAD/src/sta"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:tools/OpenROAD/src/sta"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "openroad": "openroad",
-        "yosys": "yosys"
+        "openroad-abc-src": "openroad-abc-src",
+        "openroad-flake": "openroad-flake",
+        "openroad-opensta-src": "openroad-opensta-src",
+        "yosys-abc-src": "yosys-abc-src",
+        "yosys-cxxopts-src": "yosys-cxxopts-src",
+        "yosys-flake": "yosys-flake"
       }
     },
     "systems": {
@@ -143,26 +173,52 @@
         "type": "github"
       }
     },
-    "yosys": {
+    "yosys-abc-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741760927,
+        "narHash": "sha256-yu5O8bbUJYgN5GIA5cCT+KQ//QVTDx4SrDS8XHR3khs=",
+        "rev": "f2d68d590fa6f8fc32295a2edd79afc0d14a1414",
+        "revCount": 5821,
+        "type": "git",
+        "url": "file:tools/yosys/abc"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:tools/yosys/abc"
+      }
+    },
+    "yosys-cxxopts-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708418392,
+        "narHash": "sha256-aOF3owz7SIV4trJY0PnMtIcwqoUpDbB3tNxZcsl9dzM=",
+        "rev": "4bf61f08697b110d9e3991864650a405b3dd515d",
+        "revCount": 412,
+        "type": "git",
+        "url": "file:tools/yosys/libs/cxxopts"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:tools/yosys/libs/cxxopts"
+      }
+    },
+    "yosys-flake": {
       "inputs": {
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1741764697,
-        "narHash": "sha256-5jQ9l0cyRhEI4UFInW3kqw5B+mdLFr66nfG716rO454=",
-        "ref": "refs/heads/master",
+        "narHash": "sha256-z7hV4LpfSSpDo/LKD8xwb5id6K2lxJmaULiSzkTKKoA=",
         "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
         "revCount": 14791,
-        "submodules": true,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/yosys"
+        "url": "file:tools/yosys"
       },
       "original": {
-        "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
-        "submodules": true,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/yosys"
+        "url": "file:tools/yosys"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,28 +2,90 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    openroad = {
-      type = "git";
-      url = "https://github.com/The-OpenROAD-Project/OpenROAD";
-      submodules = true;
-      rev = "ec1bf1a13902813b722f8341c432cd09714d9e55";
+    openroad-abc-src = {
+      url = "git+file:tools/OpenROAD/third-party/abc";
+      flake = false;
     };
-    yosys = {
-      type = "git";
-      url = "https://github.com/The-OpenROAD-Project/yosys";
-      submodules = true;
-      rev = "c4b5190229616f7ebf8197f43990b4429de3e420";
+    openroad-opensta-src = {
+      url = "git+file:tools/OpenROAD/src/sta";
+      flake = false;
+    };
+    openroad-flake = {
+      url = "git+file:tools/OpenROAD";
+      flake = true;
+    };
+    yosys-abc-src = {
+      url = "git+file:tools/yosys/abc";
+      flake = false;
+    };
+    yosys-cxxopts-src = {
+      url = "git+file:tools/yosys/libs/cxxopts";
+      flake = false;
+    };
+    yosys-flake = {
+      url = "git+file:tools/yosys";
+      flake = true;
     };
   };
-  outputs = { self, nixpkgs, flake-utils, openroad, yosys }: flake-utils.lib.eachDefaultSystem (
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    openroad-abc-src,
+    openroad-opensta-src,
+    openroad-flake,
+    yosys-abc-src,
+    yosys-cxxopts-src,
+    yosys-flake,
+  }: flake-utils.lib.eachDefaultSystem (
     system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-      in {
+        openroad = (openroad-flake.packages.${system}.default.overrideAttrs (previousAttrs: {
+          prePatch = builtins.concatStringsSep "\n" [
+            (''
+              cp -r --preserve=mode ${openroad-opensta-src} src/sta
+              chmod -R +w src/sta
+              cp -r --preserve=mode ${openroad-abc-src} third-party/abc
+              chmod -R +w third-party/abc
+            '')
+            (previousAttrs.prePatch or "")
+          ];
+        }));
+        yosys-abc = pkgs.stdenv.mkDerivation {
+          name = "yosys-abc";
+          src = "${yosys-abc-src}";
+          nativeBuildInputs = [ pkgs.cmake ];
+          buildInputs = [ pkgs.readline ];
+          installPhase = ''
+            runHook preInstall
+            install -Dm755 'abc' "$out/bin/abc"
+            install -Dm444 'libabc.a' "$out/lib/libabc.a"
+            runHook postInstall
+          '';
+          buildPhase = ''
+            make ABC_USE_PIC=1 abc libabc.a
+          '';
+        };
+        yosys = (yosys-flake.packages.${system}.default.overrideAttrs (previousAttrs: {
+          prePatch = builtins.concatStringsSep "\n" [
+            (''
+              cp -r --preserve=mode ${yosys-cxxopts-src} libs/cxxopts
+              chmod -R +w libs/cxxopts
+            '')
+            (previousAttrs.prePatch or "")
+          ];
+          installPhase = ''
+            make install PREFIX=$out ABCEXTERNAL=yosys-abc
+            ln -s ${yosys-abc}/bin/abc $out/bin/yosys-abc
+          '';
+        }));
+    in {
       devShells.default = pkgs.mkShell {
         buildInputs = [
-          openroad.packages.${system}.default
-          yosys.packages.${system}.default
+          openroad
+          yosys-abc
+          yosys
           pkgs.time
           pkgs.klayout
           pkgs.verilator
@@ -37,6 +99,9 @@
           pkgs.python3Packages.yamlfix
         ];
       };
+      packages.openroad = openroad;
+      packages.yosys-abc = yosys-abc;
+      packages.yosys = yosys;
     }
   );
 }


### PR DESCRIPTION
Previously the flake would require periodically updating the commit hashes for the submodules (and their submodules, etc.). However, the flake should now handle changes to those without direct user interaction.