### PR TITLE
asap7/aes-block: update metrics for mpl-soft-sa-resizing

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -86.3,
+        "value": -138.55,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 319,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {


### PR DESCRIPTION
For [#6697](https://github.com/The-OpenROAD-Project/OpenROAD/pull/6697)

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |    -86.3 |  -138.55 | Failing  |
| finish__timing__drv__hold_violation_count     |      319 |      100 | Tighten  |