### PR TITLE
cva6 mods to support multiple SV front ends

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -126,8 +126,8 @@ export VERILOG_FILES          = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp_entry.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/pmp/src/pmp_data_if.sv \
+	$(PLATFORM_DIR)/verilog/fakeram7_256x32.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/tc_sram_wrapper.sv \
-	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/tc_sram_wrapper_cache_techno.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/sram.sv \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/common/local/util/sram_cache.sv \
@@ -180,6 +180,10 @@ export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/include
 
 VERILOG_DEFINES += -D HPDCACHE_ASSERT_OFF
+
+export ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/fakeram7_256x32.lef
+
+export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x32.lib
 
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
 

--- a/flow/designs/src/cva6/common/local/util/sram_cache.sv
+++ b/flow/designs/src/cva6/common/local/util/sram_cache.sv
@@ -52,25 +52,34 @@ module sram_cache #(
         rdata_o    = rdata_user[DATA_AND_USER_WIDTH-1:DATA_WIDTH];
         ruser_o    = rdata_user[USER_WIDTH-1:0];
       end
-      tc_sram_wrapper_cache_techno #(
-        .NumWords(NUM_WORDS),           // Number of Words in data array
-        .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
-        .ByteWidth(32'd8),              // Width of a data byte
-        .NumPorts(32'd1),               // Number of read and write ports
-        .Latency(32'd1),                // Latency when the read data is available
-        .SimInit(SIM_INIT),             // Simulation initialization
-        .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
-        .PrintSimCfg(1'b0)              // Print configuration
-      ) i_tc_sram_wrapper (
-        .clk_i    ( clk_i                     ),
-        .rst_ni   ( rst_ni                    ),
-        .req_i    ( req_i                     ),
-        .we_i     ( we_i                      ),
-        .be_i     ( be                        ),
-        .wdata_i  ( wdata_user                ),
-        .addr_i   ( addr_i                    ),
-        .rdata_o  ( rdata_user                )
-      );
+       fakeram7_256x32 i_tc_sram_wrapper(
+        .clk    ( clk_i                     ),
+        .ce_in    ( req_i                     ),
+        .we_in     ( we_i                      ),
+        .wd_in  ( wdata_user                ),
+        .addr_in   ( addr_i                    ),
+        .rd_out  ( rdata_user                )
+                                         );
+       
+      // tc_sram_wrapper_cache_techno #(
+      //   .NumWords(NUM_WORDS),           // Number of Words in data array
+      //   .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
+      //   .ByteWidth(32'd8),              // Width of a data byte
+      //   .NumPorts(32'd1),               // Number of read and write ports
+      //   .Latency(32'd1),                // Latency when the read data is available
+      //   .SimInit(SIM_INIT),             // Simulation initialization
+      //   .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
+      //   .PrintSimCfg(1'b0)              // Print configuration
+      // ) i_tc_sram_wrapper (
+      //   .clk_i    ( clk_i                     ),
+      //   .rst_ni   ( rst_ni                    ),
+      //   .req_i    ( req_i                     ),
+      //   .we_i     ( we_i                      ),
+      //   .be_i     ( be                        ),
+      //   .wdata_i  ( wdata_user                ),
+      //   .addr_i   ( addr_i                    ),
+      //   .rdata_o  ( rdata_user                )
+      // );
     end else begin
       logic [DATA_WIDTH-1:0] wdata_user;
       logic [DATA_WIDTH-1:0] rdata_user;
@@ -82,25 +91,34 @@ module sram_cache #(
         rdata_o    = rdata_user;
         ruser_o    = '0;
       end
-      tc_sram_wrapper_cache_techno #(
-        .NumWords(NUM_WORDS),           // Number of Words in data array
-        .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
-        .ByteWidth(32'd8),              // Width of a data byte
-        .NumPorts(32'd1),               // Number of read and write ports
-        .Latency(32'd1),                // Latency when the read data is available
-        .SimInit(SIM_INIT),             // Simulation initialization
-        .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
-        .PrintSimCfg(1'b0)              // Print configuration
-      ) i_tc_sram_wrapper (
-        .clk_i    ( clk_i                     ),
-        .rst_ni   ( rst_ni                    ),
-        .req_i    ( req_i                     ),
-        .we_i     ( we_i                      ),
-        .be_i     ( be                        ),
-        .wdata_i  ( wdata_user                ),
-        .addr_i   ( addr_i                    ),
-        .rdata_o  ( rdata_user                )
-      );
+       fakeram7_256x32 i_tc_sram_wrapper(
+        .clk    ( clk_i                     ),
+        .ce_in    ( req_i                     ),
+        .we_in     ( we_i                      ),
+        .wd_in  ( wdata_user                ),
+        .addr_in   ( addr_i                    ),
+        .rd_out  ( rdata_user                )
+                                         );
+       
+      // tc_sram_wrapper_cache_techno #(
+      //   .NumWords(NUM_WORDS),           // Number of Words in data array
+      //   .DataWidth(DATA_AND_USER_WIDTH),// Data signal width
+      //   .ByteWidth(32'd8),              // Width of a data byte
+      //   .NumPorts(32'd1),               // Number of read and write ports
+      //   .Latency(32'd1),                // Latency when the read data is available
+      //   .SimInit(SIM_INIT),             // Simulation initialization
+      //   .BYTE_ACCESS(BYTE_ACCESS),      // ACCESS byte or full word
+      //   .PrintSimCfg(1'b0)              // Print configuration
+      // ) i_tc_sram_wrapper (
+      //   .clk_i    ( clk_i                     ),
+      //   .rst_ni   ( rst_ni                    ),
+      //   .req_i    ( req_i                     ),
+      //   .we_i     ( we_i                      ),
+      //   .be_i     ( be                        ),
+      //   .wdata_i  ( wdata_user                ),
+      //   .addr_i   ( addr_i                    ),
+      //   .rdata_o  ( rdata_user                )
+      // );
     end
   end else begin
     sram #(

--- a/flow/designs/src/cva6/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram.sv
+++ b/flow/designs/src/cva6/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram.sv
@@ -39,18 +39,26 @@ module hpdcache_sram
     output logic [DATA_SIZE-1:0]  rdata
 );
 
-    hpdcache_sram_1rw #(
-        .ADDR_SIZE(ADDR_SIZE),
-        .DATA_SIZE(DATA_SIZE),
-        .DEPTH(DEPTH)
-    ) ram_i (
-        .clk,
-        .rst_n,
-        .cs,
-        .we,
-        .addr,
-        .wdata,
-        .rdata
+    fakeram7_256x32 ram_i (
+        .clk(clk),
+        .ce_in(cs),
+        .we_in(we),
+        .addr_in(addr),
+        .wd_in(wdata),
+        .rd_out(rdata)
     );
+    // hpdcache_sram_1rw #(
+    //     .ADDR_SIZE(ADDR_SIZE),
+    //     .DATA_SIZE(DATA_SIZE),
+    //     .DEPTH(DEPTH)
+    // ) ram_i (
+    //     .clk,
+    //     .rst_n,
+    //     .cs,
+    //     .we,
+    //     .addr,
+    //     .wdata,
+    //     .rdata
+    // );
 
 endmodule : hpdcache_sram

--- a/flow/designs/src/cva6/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram_wbyteenable.sv
+++ b/flow/designs/src/cva6/core/cache_subsystem/hpdcache/rtl/src/common/hpdcache_sram_wbyteenable.sv
@@ -39,20 +39,27 @@ module hpdcache_sram_wbyteenable
     input  logic [DATA_SIZE/8-1:0] wbyteenable,
     output logic [DATA_SIZE-1:0]   rdata
 );
-
-    hpdcache_sram_wbyteenable_1rw #(
-        .ADDR_SIZE(ADDR_SIZE),
-        .DATA_SIZE(DATA_SIZE),
-        .DEPTH(DEPTH)
-    ) ram_i (
-        .clk,
-        .rst_n,
-        .cs,
-        .we,
-        .addr,
-        .wdata,
-        .wbyteenable,
-        .rdata
+   fakeram7_256x32 ram_i (
+        .clk (clk),
+        .ce_in(cs),
+        .we_in(we),
+        .addr_in(addr),
+        .wd_in(wdata),
+        .rd_out(rdata)
     );
+    // hpdcache_sram_wbyteenable_1rw #(
+    //     .ADDR_SIZE(ADDR_SIZE),
+    //     .DATA_SIZE(DATA_SIZE),
+    //     .DEPTH(DEPTH)
+    // ) ram_i (
+    //     .clk,
+    //     .rst_n,
+    //     .cs,
+    //     .we,
+    //     .addr,
+    //     .wdata,
+    //     .wbyteenable,
+    //     .rdata
+    // );
 
 endmodule : hpdcache_sram_wbyteenable

--- a/flow/platforms/asap7/verilog/fakeram7_256x32.sv
+++ b/flow/platforms/asap7/verilog/fakeram7_256x32.sv
@@ -1,0 +1,9 @@
+module fakeram7_256x32 (
+   output reg [31:0] rd_out,
+   input [7:0] addr_in,
+   input we_in,
+   input [31:0] wd_in,
+   input clk,
+   input ce_in
+);
+endmodule


### PR DESCRIPTION
Replaced some of the parameterized RAMs with a fake ram. The fake ram isn't perfect since it doesn't have a reset or a byte enable, but hopefully it's semi-close. These mods go through both SV frontends that are being tested.
