### PR TITLE
added blackbox annotation to cva6 fakeram

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -179,7 +179,7 @@ export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/common_cells/include \
 	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/include
 
-VERILOG_DEFINES += -D HPDCACHE_ASSERT_OFF
+export VERILOG_DEFINES += -D HPDCACHE_ASSERT_OFF
 
 export ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/fakeram7_256x32.lef
 
@@ -187,10 +187,10 @@ export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x32.lib
 
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
 
-export DIE_AREA               = 0 0 200 200
-export CORE_AREA              = 1.08 1.08 190 190
+export DIE_AREA               = 0 0 250 250
+export CORE_AREA              = 1.08 1.08 240 240
 
-export PLACE_DENSITY          = 0.40
+export PLACE_DENSITY          = 0.50
 
 # a smoketest for this option, there are a
 # few last gasp iterations

--- a/flow/platforms/asap7/verilog/fakeram7_256x32.sv
+++ b/flow/platforms/asap7/verilog/fakeram7_256x32.sv
@@ -1,3 +1,4 @@
+(* blackbox *)
 module fakeram7_256x32 (
    output reg [31:0] rd_out,
    input [7:0] addr_in,


### PR DESCRIPTION
Also updated place density and die area in order to complete GRT/DRT.

@povik , I'm able to see the fakerams in the hierarchy browser via the yosys-slang flow.