### PR TITLE
[DO NO REVIEW] bazel: local OpenROAD with bazel-orfs

### DIFF
--- a/flow/MODULE.bazel
+++ b/flow/MODULE.bazel
@@ -56,3 +56,14 @@ orfs.default(
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")
+
+
+# Use local OpenROAD files instead of OpenROAD from ORFS docker image
+bazel_dep(
+    name = "openroad",
+    version = "0.1.0"
+)
+local_path_override(
+    module_name = "openroad",
+    path = "../tools/OpenROAD"
+)


### PR DESCRIPTION
@hzeller @maliberty Once OpenROAD uses MODULE.bazel, I'll be able to switch ORFS to use the locally checked out OpenROAD instead of the OpenROAD from the docker image in ORFS [bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs) targets:

The workflow locally run build ORFS test designs then becomes:

1. Modify tools/OpenROAD
2. cd flow/
3. bazel build ...


bazel-orfs needs to grow a capability so that ORFS, a user of bazel-orfs, can set "_openroad" to point to another label:

https://github.com/The-OpenROAD-Project/bazel-orfs/blob/a2e6a3a37693e3ab4c0459d508c08c3c667d2809/openroad.bzl#L384-L390