### PR TITLE
makefile: break out scripts/synth.sh and scripts/flow.sh utilities

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -285,12 +285,12 @@ yosys-dependencies: $(YOSYS_DEPENDENCIES)
 .PHONY: do-yosys
 do-yosys: $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	($(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SYNTH_SCRIPT)) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys.log)
+	$(SCRIPTS_DIR)/synth.sh $(SYNTH_SCRIPT) $(LOG_DIR)/1_1_yosys.log
 
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)
 	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	($(TIME_CMD) $(YOSYS_EXE) $(YOSYS_FLAGS) -c $(SCRIPTS_DIR)/synth_canonicalize.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_1_yosys_canonicalize.log)
+	$(SCRIPTS_DIR)/synth.sh $(SCRIPTS_DIR)/synth_canonicalize.tcl $(LOG_DIR)/1_1_yosys_canonicalize.log
 
 $(RESULTS_DIR)/1_synth.rtlil: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
@@ -397,13 +397,7 @@ endif
 
 .PHONY: do-$(1)
 do-$(1): $(OBJECTS_DIR)/copyright.txt
-	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	@echo Running $(3).tcl, stage $(1)
-	@(set -eo pipefail; \
-	trap 'mv $(LOG_DIR)/$(1).tmp.log $(LOG_DIR)/$(1).log' EXIT; \
-	$(OPENROAD_EXE) $(OPENROAD_ARGS) -exit $(SCRIPTS_DIR)/noop.tcl 2>&1 >$(LOG_DIR)/$(1).tmp.log; \
-	$(TIME_CMD) $(OPENROAD_CMD) -no_splash $(SCRIPTS_DIR)/$(3).tcl -metrics $(LOG_DIR)/$(1).json 2>&1 | \
-	tee -a $(abspath $(LOG_DIR)/$(1).tmp.log))
+	$(SCRIPTS_DIR)/flow.sh $(1) $(3)
 endef
 
 # generate make rules to copy a file, if a dependency change and

--- a/flow/scripts/README.md
+++ b/flow/scripts/README.md
@@ -57,6 +57,10 @@ It is also possible to evaluate the variables without using the ORFS `Makefile`,
     Design area 38 u^2 19% utilization.
     $
 
+### flow.sh and synth.sh
+
+Utility scripts that can be used in combination with `variables.mk` to invoke synthesis and flow steps without going through the ORFS `Makefile`.
+
 ## make run-yosys
 
 Sets up all the ORFS environment variables and launches Yosys.

--- a/flow/scripts/flow.sh
+++ b/flow/scripts/flow.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -u -eo pipefail
+mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
+echo Running $2.tcl, stage $1
+(trap 'mv $LOG_DIR/$1.tmp.log $LOG_DIR/$1.log' EXIT; \
+ $OPENROAD_EXE $OPENROAD_ARGS -exit $SCRIPTS_DIR/noop.tcl 2>&1 >$LOG_DIR/$1.tmp.log; \
+ eval "$TIME_CMD $OPENROAD_CMD -no_splash $SCRIPTS_DIR/$2.tcl -metrics $LOG_DIR/$1.json" 2>&1 | \
+ tee -a $(realpath $LOG_DIR/$1.tmp.log))

--- a/flow/scripts/synth.sh
+++ b/flow/scripts/synth.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -u -eo pipefail
+mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
+eval "$TIME_CMD $YOSYS_EXE $YOSYS_FLAGS -c $1" 2>&1 | tee $(realpath $2)

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -86,6 +86,7 @@ TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
 ifeq (,$(strip $(TIME_TEST)))
   TIME_CMD = $(TIME_BIN)
 endif
+export TIME_CMD
 
 # The following determine the executable location for each tool used by this flow.
 # Priority is given to
@@ -102,16 +103,17 @@ else
   export OPENSTA_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/OpenROAD/bin/sta)
 endif
 
-OPENROAD_ARGS            = -no_init -threads $(NUM_CORES) $(OR_ARGS)
-OPENROAD_CMD             = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
-OPENROAD_NO_EXIT_CMD     = $(OPENROAD_EXE) $(OPENROAD_ARGS)
-OPENROAD_GUI_CMD         = $(OPENROAD_EXE) -gui $(OR_ARGS)
+export OPENROAD_ARGS = -no_init -threads $(NUM_CORES) $(OR_ARGS)
+export OPENROAD_CMD = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
+export OPENROAD_NO_EXIT_CMD = $(OPENROAD_EXE) $(OPENROAD_ARGS)
+export OPENROAD_GUI_CMD = $(OPENROAD_EXE) -gui $(OR_ARGS)
 
 ifneq (${IN_NIX_SHELL},)
   YOSYS_EXE := $(shell command -v yosys)
 else
   YOSYS_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
 endif
+export YOSYS_EXE
 
 # Use locally installed and built klayout if it exists, otherwise use klayout in path
 KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)


### PR DESCRIPTION
These can be used in combination with variables.mk to invoke OpenROAD/yosys directly without without going through the Makefile