### PR TITLE
bazel: use local ORFS files

### DIFF
--- a/flow/BUILD.bazel
+++ b/flow/BUILD.bazel
@@ -1,0 +1,62 @@
+load("@bazel-orfs//:openroad.bzl", "orfs_pdk")
+
+# files shared between scripts/synth.sh and scripts/flow.sh steps
+MAKEFILE_SHARED = [
+    "scripts/*.py",
+    "scripts/*.sh",
+    "scripts/*.yaml",
+    "scripts/*.mk",
+]
+
+# makefile and scripts used by script/synth.sh steps
+filegroup(
+    name = "makefile_yosys",
+    srcs = ["Makefile"],
+    data = glob(MAKEFILE_SHARED + [
+        "scripts/*.script",
+        "scripts/util.tcl",
+        "scripts/synth*.tcl",
+         "platforms/common/**/*.v",
+    ]) +
+    ["//util:makefile_yosys"],
+    visibility = ["//visibility:public"],
+)
+
+# makefile and scripts used in the scripts/flow.sh steps
+filegroup(
+    name = "makefile",
+    srcs = ["Makefile"],
+    data = glob(MAKEFILE_SHARED + [
+        "scripts/*.tcl",
+         "platforms/common/**/*.v",
+    ]) + [
+        "//util:makefile",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# These are the only PDKs for which we have BUILD.bazel files for now
+[orfs_pdk(
+    name = pdk,
+    config = ":platforms/{pdk}/config.mk".format(pdk = pdk),
+    srcs = glob([
+                    "platforms/{pdk}/**/*.{ext}".format(pdk = pdk, ext = ext)
+                    for ext in [
+                        "gds",
+                        "lib.gz",
+                        "lef",
+                        "lib",
+                        "lyt",
+                        "mk",
+                        "rules",
+                        "sdc",
+                        "tcl",
+                        "v",
+                        "tlef",
+                    ]
+                ]),
+    visibility = ["//visibility:public"],
+) for pdk in [
+    "asap7",
+    "sky130hd",
+]]

--- a/flow/MODULE.bazel
+++ b/flow/MODULE.bazel
@@ -9,7 +9,7 @@ module(
 bazel_dep(name = "bazel-orfs")
 git_override(
     module_name = "bazel-orfs",
-    commit = "41354d9de46816b79858e43baadf701cf7e997e5",
+    commit = "48cc8783f285d2a274b1613004dcbea21195f49c",
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
@@ -50,8 +50,17 @@ orfs.default(
     # and update "image" to point to the local image.
 
     # Official image https://hub.docker.com/r/openroad/orfs/tags
-    image = "docker.io/openroad/orfs:v3.0-2707-g044183f3",
-    sha256 = "34db776930937b94b22f96b68feea87381de70727d12efc47f342b88c8cb3db6",
+    image = "docker.io/openroad/orfs:v3.0-2734-gcf6f0417",
+    # Use local files instead of docker image
+    makefile = "//:makefile",
+    pdk = "//:asap7",
+    makefile_yosys = "//:makefile_yosys",
+    # TODO once openroad is switched to MODULE.bazel, use
+    # local_path_override(module_name = "openroad", path = "../tools/OpenROAD")
+    # to point to the local openroad Bazel module instead of
+    # getting the openroad binary from the docker image.
+    openroad = "@docker_orfs//:openroad",
+    sha256 = "ef685898a5e3a2db7166c55238275adcf2dbec7ee0a7eb895a78657bcc27220a",
 )
 use_repo(orfs, "com_github_nixos_patchelf_download")
 use_repo(orfs, "docker_orfs")

--- a/flow/MODULE.bazel.lock
+++ b/flow/MODULE.bazel.lock
@@ -637,8 +637,8 @@
     },
     "@@bazel-orfs~//:extension.bzl%orfs_repositories": {
       "general": {
-        "bzlTransitiveDigest": "vmcGR7h5VgEPebKSKqrF0UgcqrgFTr0lE5jdk/LXXdg=",
-        "usagesDigest": "++qkJGwzVlDwnStH4xnAiNPqiDtVi9a5np4IugarkVw=",
+        "bzlTransitiveDigest": "gEO3L8nT0efjc8b8O8nLk9gxcVCkKh3Bavx36cohUrk=",
+        "usagesDigest": "6SJmAKcd2KxJVq2SuJDm7KXBQOsTMd2iLGU9PBPwTkw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -658,17 +658,32 @@
             "bzlFile": "@@bazel-orfs~//:docker.bzl",
             "ruleClassName": "docker_pkg",
             "attributes": {
-              "image": "docker.io/openroad/orfs:v3.0-2707-g044183f3",
-              "sha256": "34db776930937b94b22f96b68feea87381de70727d12efc47f342b88c8cb3db6",
+              "image": "docker.io/openroad/orfs:v3.0-2734-gcf6f0417",
+              "sha256": "ef685898a5e3a2db7166c55238275adcf2dbec7ee0a7eb895a78657bcc27220a",
               "build_file": "@@bazel-orfs~//:docker.BUILD.bazel",
               "timeout": 3600,
               "patch_cmds": [
                 "find . -name BUILD.bazel -delete"
               ]
             }
+          },
+          "config": {
+            "bzlFile": "@@bazel-orfs~//:config.bzl",
+            "ruleClassName": "global_config",
+            "attributes": {
+              "makefile": "@@//:makefile",
+              "pdk": "@@//:asap7",
+              "makefile_yosys": "@@//:makefile_yosys",
+              "openroad": "@@bazel-orfs~~orfs_repositories~docker_orfs//:openroad"
+            }
           }
         },
         "recordedRepoMappingEntries": [
+          [
+            "",
+            "docker_orfs",
+            "bazel-orfs~~orfs_repositories~docker_orfs"
+          ],
           [
             "bazel-orfs~",
             "bazel_tools",
@@ -678,6 +693,11 @@
             "bazel-orfs~",
             "com_github_nixos_patchelf_download",
             "bazel-orfs~~orfs_repositories~com_github_nixos_patchelf_download"
+          ],
+          [
+            "bazel-orfs~",
+            "docker_orfs",
+            "bazel-orfs~~orfs_repositories~docker_orfs"
           ]
         ]
       }

--- a/flow/util/BUILD.bazel
+++ b/flow/util/BUILD.bazel
@@ -16,3 +16,28 @@ compile_pip_requirements(
     src = "requirements.in",
     requirements_txt = "requirements_lock.txt",
 )
+
+MAKEFILE_SHARED = [
+    "*.mk",
+]
+
+# for scripts/flow.sh steps
+filegroup(
+    name = "makefile",
+    srcs = glob(MAKEFILE_SHARED + [
+        "*.pl",
+        "*.py",
+        "*.sh",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+# for scripts/synth.sh steps
+filegroup(
+    name = "makefile_yosys",
+    srcs = glob(MAKEFILE_SHARED) + [
+        "preprocessLib.py",
+        "mergeLib.pl",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Another snapshot for further discussion and collaboration. ORFS Bazel support is not under CI and not officially relied upon yet.

It is now possible to modify PDK + make scripts and test them without having to spin a new docker image first. The idea is to gradually wean ORFS Bazel support off the docker image.

To build all ORFS targets for which there are BUILD.bazel files:

```
$ cd flow
$ bazelisk build ...
```

Bring up a design in the GUI:

```
$ bazelisk run //designs/asap7/gcd:gcd_route /tmp/route gui_route
```

![image](https://github.com/user-attachments/assets/a12af734-52eb-427d-b43e-42de3cd67b54)
