### PR TITLE
variables.mk: PLATFORM_DIR can be provided from some non-ORFS location

### DIFF
--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -37,14 +37,16 @@ ifeq ($(origin DESIGN_NAME), undefined)
   $(error DESIGN_NAME variable net set.)
 endif
 
-ifneq ($(wildcard $(PLATFORM_HOME)/$(PLATFORM)),)
-  export PLATFORM_DIR = $(PLATFORM_HOME)/$(PLATFORM)
-else ifneq ($(findstring $(PLATFORM),$(PUBLIC)),)
-  export PLATFORM_DIR = ./platforms/$(PLATFORM)
-else ifneq ($(wildcard ../../$(PLATFORM)),)
-  export PLATFORM_DIR = ../../$(PLATFORM)
-else
-  $(error [ERROR][FLOW] Platform '$(PLATFORM)' not found.)
+ifeq ($(PLATFORM_DIR),)
+  ifneq ($(wildcard $(PLATFORM_HOME)/$(PLATFORM)),)
+    export PLATFORM_DIR = $(PLATFORM_HOME)/$(PLATFORM)
+  else ifneq ($(findstring $(PLATFORM),$(PUBLIC)),)
+    export PLATFORM_DIR = ./platforms/$(PLATFORM)
+  else ifneq ($(wildcard ../../$(PLATFORM)),)
+    export PLATFORM_DIR = ../../$(PLATFORM)
+  else
+    $(error [ERROR][FLOW] Platform '$(PLATFORM)' not found.)
+  endif
 endif
 
 include $(PLATFORM_DIR)/config.mk

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -37,16 +37,15 @@ ifeq ($(origin DESIGN_NAME), undefined)
   $(error DESIGN_NAME variable net set.)
 endif
 
-ifeq ($(PLATFORM_DIR),)
-  ifneq ($(wildcard $(PLATFORM_HOME)/$(PLATFORM)),)
-    export PLATFORM_DIR = $(PLATFORM_HOME)/$(PLATFORM)
-  else ifneq ($(findstring $(PLATFORM),$(PUBLIC)),)
-    export PLATFORM_DIR = ./platforms/$(PLATFORM)
-  else ifneq ($(wildcard ../../$(PLATFORM)),)
-    export PLATFORM_DIR = ../../$(PLATFORM)
-  else
-    $(error [ERROR][FLOW] Platform '$(PLATFORM)' not found.)
-  endif
+ifneq ($(PLATFORM_DIR),)
+else ifneq ($(wildcard $(PLATFORM_HOME)/$(PLATFORM)),)
+  export PLATFORM_DIR = $(PLATFORM_HOME)/$(PLATFORM)
+else ifneq ($(findstring $(PLATFORM),$(PUBLIC)),)
+  export PLATFORM_DIR = ./platforms/$(PLATFORM)
+else ifneq ($(wildcard ../../$(PLATFORM)),)
+  export PLATFORM_DIR = ../../$(PLATFORM)
+else
+  $(error [ERROR][FLOW] Platform '$(PLATFORM)' not found.)
 endif
 
 include $(PLATFORM_DIR)/config.mk


### PR DESCRIPTION
TL;DR useful for local `bazel build ...` in ORFS when testing PDK changes.

Initial application is to use it in bazel builds in ORFS where local files instead of docker image files are used.