### PR TITLE
[Docs] Add permalink to git guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ perf.data.old
 # documentation specific
 docs/main
 docs/build
-GitGuide.md
 SupportedOS.md
 index2.md
 Manpage.md

--- a/docs/contrib/GitGuide.md
+++ b/docs/contrib/GitGuide.md
@@ -1,0 +1,3 @@
+# Git Quickstart
+
+If you have reached this file on GitHub - please refer to this [link](https://openroad-flow-scripts.readthedocs.io/en/latest/contrib/GitGuide.html) for latest documentation.


### PR DESCRIPTION
Fixes #2912 by adding a permalink to ORFS readthedocs site's page. Actual file should be overwritten during sphinx compilation.

See verification: https://openroad-flow-scripts--3026.org.readthedocs.build/en/3026/contrib/GitGuide.html