### PR TITLE
floorplan: move metrics code into report_metrics utility fn

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -148,7 +148,6 @@ if { [env_var_equals RESYNTH_TIMING_RECOVER 1] } {
 
 puts "Default units for flow"
 report_units
-report_units_metric
 report_metrics 2 "floorplan final" false false
 
 if { [env_var_equals RESYNTH_AREA_RECOVER 1] } {

--- a/flow/scripts/report_metrics.tcl
+++ b/flow/scripts/report_metrics.tcl
@@ -10,6 +10,9 @@ proc report_metrics { stage when {include_erc true} {include_clock_skew true} } 
   if {[env_var_equals SKIP_REPORT_METRICS 1]} {
     return
   }
+  if {$stage == 2} {
+    report_units_metric
+  }
   puts "Report metrics stage $stage, $when..."
   set filename $::env(REPORTS_DIR)/${stage}_[string map {" " "_"} $when].rpt
   set fileId [open $filename w]


### PR DESCRIPTION
Heeds SKIP_REPORT_METRICS=1 now, useful with Bazel testing since report_units_metrics isn't supported in Bazel OpenROAD builds yet.