### PR TITLE
bazel: mock-array cleanup

### DIFF
--- a/flow/designs/asap7/mock-array/BUILD.bazel
+++ b/flow/designs/asap7/mock-array/BUILD.bazel
@@ -1,5 +1,88 @@
 load("@bazel-orfs//:openroad.bzl", "orfs_flow")
 
+# single source of truth for defaults.
+# each number is a unit
+# current unit is configured as 2.16 which is on the routing grid for M5
+
+# table of Elements - (rows cols width height pitch_x pitch_y)
+MOCK_ARRAY_TABLE = [
+    8,
+    8,
+    20,
+    20,
+    20,
+    22,
+]
+
+# Element'd data width
+MOCK_ARRAY_DATAWIDTH = 64
+
+# Must be zero for routing by abutment
+MACRO_BLOCKAGE_HALO = 0
+
+MOCK_ARRAY_SCALE = 45
+
+# Routing pitches for relevant metal layers.
+#  For x, this is M5; for y, this is M4.
+#  Pitches are specified in OpenROAD-flow-scripts/flow/platforms/asap7/lef/asap7_tech_1x_201209.lef.
+#  For asap7, x and y pitch is the same.
+#
+# make_tracks M5 -x_offset 0.012 -x_pitch 0.048 -y_offset 0.012 -y_pitch 0.048
+#
+# the macro needs to be on a multiple of the track pattern
+placement_grid_x = 0.048 * MOCK_ARRAY_SCALE
+
+placement_grid_y = 0.048 * MOCK_ARRAY_SCALE
+
+# number of Elements in row and column, can be control by user via environment variable
+# MOCK_ARRAY_TABLE (rows, cols, width, height, pitch_x, pitch_y)
+#  rows, cols       - number of Element in rows, cols
+#  width, height    - width and height of each Element
+#
+# When the pitch is equal to the width/height, we have routing by abutment
+# https://en.wikipedia.org/wiki/Pitch#Linear_measurement
+#
+#  pitch_x, pitch_y - placement pitch for each Element, in x and y direction
+# specification are in unit of placement grid
+rows, cols, ce_x, ce_y, pitch_x, pitch_y = MOCK_ARRAY_TABLE
+
+# Element size is set to multiple of placement grid above
+ce_width = ce_x * placement_grid_x
+
+ce_height = ce_y * placement_grid_y
+
+# top level core offset
+margin_x = placement_grid_x
+
+margin_y = placement_grid_y
+
+# Element core margin
+ce_margin_x = placement_grid_x * 0.5
+
+ce_margin_y = placement_grid_y * 0.5
+
+# PDN problems if it is smaller. Not investigated.
+array_spacing_x = margin_x * 2
+
+array_spacing_y = margin_y * 2
+
+array_offset_x = array_spacing_x + margin_x
+
+array_offset_y = array_spacing_y + margin_y
+
+# top level core and die size
+core_width = (
+    2 * array_spacing_x + ((placement_grid_x * pitch_x) * (cols - 1)) + ce_width
+)
+
+core_height = (
+    2 * array_spacing_y + ((placement_grid_y * pitch_y) * (rows - 1)) + ce_height
+)
+
+die_width = core_width + (margin_x * 2)
+
+die_height = core_height + (margin_y * 2)
+
 filegroup(
     name = "mock-array-constraints",
     srcs = [
@@ -24,8 +107,16 @@ orfs_flow(
     arguments = {
         "PLACE_PINS_ARGS": "-annealing",
         "PLACE_DENSITY": "0.30",
-        "DIE_AREA": "0 0 358.56 388.8",
-        "CORE_AREA": "2.16 2.16 356.40000000000003 386.64000000000004",
+        "CORE_AREA": "{} {} {} {}".format(
+            margin_x,
+            margin_y,
+            core_width + margin_x,
+            core_height + margin_y,
+        ),
+        "DIE_AREA": "0 0 {} {}".format(
+            die_width,
+            die_height,
+        ),
         "MACRO_PLACE_HALO": "0 2.16",
         "RTLMP_BOUNDARY_WT": "0",
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCKS_grid_strategy.tcl",
@@ -38,11 +129,13 @@ orfs_flow(
         "GND_NETS_VOLTAGES": "",
         "IO_PLACER_V": "M5 M7",
         "IO_PLACER_H": "M4 M6",
+        "DETAILED_ROUTE_END_ITERATION": "6",
     },
     macros = ["Element_generate_abstract"],
     sources = {
         "SDC_FILE": [":mock-array-constraints"],
         "IO_CONSTRAINTS": [":mock-array-io"],
+        # "MACRO_PLACEMENT_TCL": [":macro-placement.tcl"],
     },
     verilog_files = ["//designs/src/mock-array:verilog"],
 )
@@ -73,8 +166,16 @@ orfs_flow(
         "PLACE_PINS_ARGS": "-annealing",
         "GND_NETS_VOLTAGES": "",
         "PWR_NETS_VOLTAGES": "",
-        "DIE_AREA": "0 0 43.2 43.2",
-        "CORE_AREA": "1.08 1.08 42.120000000000005 42.120000000000005",
+        "CORE_AREA": "{} {} {} {}".format(
+            ce_margin_x,
+            ce_margin_y,
+            ce_width - ce_margin_x,
+            ce_height - ce_margin_y,
+        ),
+        "DIE_AREA": "0 0 {} {}".format(
+            ce_width,
+            ce_height,
+        ),
         "PDN_TCL": "$(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl",
     },
     sources = {


### PR DESCRIPTION
Instead of using Python + bash + make, there's a tiny bit of Starlark that calculates DIE/CORE_AREA for Element/MockArray, *much* nicer.

One day when ORFS/OpenROAD maintainers can accept mock-array in Bazel as a regression test, I would like to delete the ORFS Makefile version as it is nasty; I think mock-array with .vcd power reporting pushes ORFS makefiles to a point of discomfort.

Before then I want to expand the Bazel mock-array to accept all the test cases, including power .vcd reporting.