### PR TITLE
[AutoTuner] Refactor: shift scripts out of utils folder

### DIFF
--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -41,7 +41,7 @@ echo "Running Autotuner plotting smoke test"
 all_experiments=$(ls -d ./flow/logs/${PLATFORM}/${DESIGN_NAME}/smoke-test-tune*)
 all_experiments=$(basename -a $all_experiments)
 for expt in $all_experiments; do
-  python3 tools/AutoTuner/src/autotuner/utils/plot.py \
+  python3 tools/AutoTuner/scripts/plot.py \
     --platform ${PLATFORM} \
     --design ${DESIGN_NAME} \
     --experiment $expt

--- a/tools/AutoTuner/scripts/plot.py
+++ b/tools/AutoTuner/scripts/plot.py
@@ -91,6 +91,8 @@ def load_dir(dir: str) -> pd.DataFrame:
             params.append(_dict)
         except Exception as e:
             failed.append(metrics_fname)
+            print("Failed to load", metrics_fname)
+            print(e)
             continue
 
     # Merge all dataframe
@@ -98,6 +100,8 @@ def load_dir(dir: str) -> pd.DataFrame:
     try:
         progress_df = progress_df.merge(params_df, on="trial_id")
     except KeyError:
+        print(params_df)
+        print(progress_df)
         print(
             "Unable to merge DFs due to missing trial_id in params.json (possibly due to failed trials.)"
         )

--- a/tools/AutoTuner/scripts/plot.py
+++ b/tools/AutoTuner/scripts/plot.py
@@ -50,7 +50,7 @@ AT_REGEX = r"variant-AutoTunerBase-([\w-]+)-\w+"
 METRIC = "metric"
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
-root_dir = os.path.join(cur_dir, "../../../../../")
+root_dir = os.path.join(cur_dir, "../../../")
 os.chdir(root_dir)
 
 

--- a/tools/AutoTuner/scripts/plot.py
+++ b/tools/AutoTuner/scripts/plot.py
@@ -100,8 +100,6 @@ def load_dir(dir: str) -> pd.DataFrame:
     try:
         progress_df = progress_df.merge(params_df, on="trial_id")
     except KeyError:
-        print(params_df)
-        print(progress_df)
         print(
             "Unable to merge DFs due to missing trial_id in params.json (possibly due to failed trials.)"
         )

--- a/tools/AutoTuner/src/autotuner/utils.py
+++ b/tools/AutoTuner/src/autotuner/utils.py
@@ -332,7 +332,7 @@ def openroad(
         stdout_file=os.path.join(log_path, "make-finish-stdout.log"),
     )
 
-    metrics_file = os.path.abspath(os.path.join(report_path, "metrics.json"))
+    metrics_file = os.path.abspath(os.path.join(log_path, "metrics.json"))
     metrics_command = export_command
     metrics_command += f"{base_dir}/flow/util/genMetrics.py -x"
     metrics_command += f" -v {flow_variant}"


### PR DESCRIPTION
Rationale is to disambiguate the `utils.py` and the `utils` folder -> which should really be a scripts directory.