### PR TITLE
scripts: use log_cmd more consistently rather than ad-hoc puts

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -56,8 +56,7 @@ if {$methods_defined > 1} {
 
 if {$use_floorplan_def} {
     # Initialize floorplan by reading in floorplan DEF
-    puts "Read in Floorplan DEF to initialize floorplan:  $env(FLOORPLAN_DEF)"
-    read_def -floorplan_initialize $env(FLOORPLAN_DEF)
+    log_cmd read_def -floorplan_initialize $env(FLOORPLAN_DEF)
 } elseif {$use_footprint} {
     # Initialize floorplan using ICeWall FOOTPRINT
     ICeWall load_footprint $env(FOOTPRINT)
@@ -93,18 +92,15 @@ if {$use_floorplan_def} {
 }
 
 if { [env_var_exists_and_non_empty MAKE_TRACKS] } {
-  puts "Reading $::env(MAKE_TRACKS)"
-  source $::env(MAKE_TRACKS)
+  log_cmd source $::env(MAKE_TRACKS)
 } elseif {[file exists $::env(PLATFORM_DIR)/make_tracks.tcl]} {
-  puts "Reading $::env(PLATFORM_DIR)/make_tracks.tcl"
-  source $::env(PLATFORM_DIR)/make_tracks.tcl
+  log_cmd source $::env(PLATFORM_DIR)/make_tracks.tcl
 } else {
   make_tracks
 }
 
 if {[env_var_exists_and_non_empty FOOTPRINT_TCL]} {
-  puts "Reading $::env(FOOTPRINT_TCL)"
-  source $::env(FOOTPRINT_TCL)
+  log_cmd source $::env(FOOTPRINT_TCL)
 }
 
 if { [env_var_equals REMOVE_ABC_BUFFERS 1] } {
@@ -193,14 +189,12 @@ if { [env_var_equals RESYNTH_AREA_RECOVER 1] } {
 }
 
 if { [env_var_exists_and_non_empty POST_FLOORPLAN_TCL] } {
-  puts "Reading $::env(POST_FLOORPLAN_TCL)"
-  source $::env(POST_FLOORPLAN_TCL)
+  log_cmd source $::env(POST_FLOORPLAN_TCL)
 }
 
 
 if {[env_var_exists_and_non_empty IO_CONSTRAINTS]} {
-  puts "Reading $::env(IO_CONSTRAINTS)"
-  source $::env(IO_CONSTRAINTS)
+  log_cmd source $::env(IO_CONSTRAINTS)
 }
 
 write_db $::env(RESULTS_DIR)/2_1_floorplan.odb

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -28,12 +28,10 @@ proc load_design {design_file sdc_file} {
   read_sdc $::env(RESULTS_DIR)/$sdc_file
 
   if [file exists $::env(PLATFORM_DIR)/derate.tcl] {
-    puts "Reading in $::env(PLATFORM_DIR)/derate.tcl"
-    source $::env(PLATFORM_DIR)/derate.tcl
+    log_cmd source $::env(PLATFORM_DIR)/derate.tcl
   }
 
-  puts "Reading in $::env(PLATFORM_DIR)/setRC.tcl"
-  source $::env(PLATFORM_DIR)/setRC.tcl
+  log_cmd source $::env(PLATFORM_DIR)/setRC.tcl
 
   if { [env_var_equals LIB_MODEL CCS] } {
     puts "Using CCS delay calculation"


### PR DESCRIPTION
log_cmd is terse, accurate and consistent with other places in the code.