### PR TITLE
ngt45/bp_be: remove custom MPL settings to allow clustering

### DIFF
--- a/flow/designs/nangate45/bp_be_top/config.mk
+++ b/flow/designs/nangate45/bp_be_top/config.mk
@@ -3,12 +3,6 @@ export DESIGN_NAME = bp_be_top
 export PLATFORM    = nangate45
 
 export SYNTH_HIERARCHICAL = 1
-#
-# RTL_MP Settings
-export RTLMP_MAX_INST = 30000
-export RTLMP_MIN_INST = 5000
-export RTLMP_MAX_MACRO = 12
-export RTLMP_MIN_MACRO = 4 
 
 export VERILOG_FILES = $(DESIGN_HOME)/src/$(DESIGN_NAME)/pickled.v \
                        $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/macros.v


### PR DESCRIPTION
We're at the edge of having a congestion problem with the current MPL result in master. This is mainly due to the poor clustering results for this design.

I believe that the rationale of the removed thresholds was avoiding doing clustering (i.e., calling PAR) as the design is relatively small. However, without the custom thresholds, clustering results get reasonably better taking us out of this congestion imminence.

This should also facilitate merging a series of fixes - beginning by [#7027](https://github.com/The-OpenROAD-Project/OpenROAD/pull/7027).