### PR TITLE
Update metrics for MPL fixes

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -24,7 +24,7 @@
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1024,
+        "value": 1491,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -119.26,
+        "value": -118.73,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 100,
+        "value": 419,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -40,15 +40,15 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 3,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1899,
+        "value": 3636,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -3.1,
+        "value": -2.62,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -21.69,
+        "value": -21.23,
         "compare": ">="
     }
 }


### PR DESCRIPTION
For [#7027](https://github.com/The-OpenROAD-Project/OpenROAD/pull/7027)

#### sky130hd/uW

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna__violating__nets       |        1 |        3 | Failing  |
| detailedroute__antenna_diodes_count           |     1899 |     3636 | Failing  |
| finish__timing__setup__ws                     |     -3.1 |    -2.62 | Tighten  |
| finish__timing__wns_percent_delay             |   -21.69 |   -21.23 | Tighten  |

#### asap7/aes-block

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__design__instance__count__hold_buffer     |     1024 |     1491 | Failing  |
| finish__timing__setup__ws                     |  -119.26 |  -118.73 | Tighten  |
| finish__timing__drv__hold_violation_count     |      100 |      419 | Failing  |