### PR TITLE
open_synth: make it work with OpenSTA

### DIFF
--- a/flow/scripts/read_liberty.tcl
+++ b/flow/scripts/read_liberty.tcl
@@ -1,3 +1,12 @@
+if {![expr [llength [info commands read_lef]] > 0]} {
+  proc suppress_message {a b} {
+    # not used in OpenSTA
+  }
+  proc unsuppress_message {a b} {
+    # not used in OpenSTA
+  }
+}
+
 # To remove [WARNING STA-1212] from the logs for ASAP7.
 # /OpenROAD-flow-scripts/flow/platforms/asap7/lib/asap7sc7p5t_SIMPLE_RVT_TT_nldm_211120.lib.gz line 13178, timing group from output port.
 # Added following suppress_message

--- a/flow/scripts/sta-synth.tcl
+++ b/flow/scripts/sta-synth.tcl
@@ -1,2 +1,14 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 load_design 1_synth.v 1_synth.sdc
+
+if {[env_var_equals GUI_TIMING 1]} {
+  puts "GUI_TIMING=1 reading timing, takes a little while for large designs..."
+  set openroad [expr [llength [info commands ord::openroad_version]] > 0]
+
+  if {$openroad && [gui::enabled]} {
+    gui::select_chart "Endpoint Slack"
+    log_cmd gui::update_timing_report
+  } else {
+    report_checks
+  }
+}


### PR DESCRIPTION
Modify scripts so that make open_synth can work with OpenSTA, this simplifies reporting issues. Turnaround times on real test cases is long, so it is nice to have this debugged in ORFS.

To examine timing of a design using OpenSTA:

    make OPENROAD_EXE=../tools/install/OpenROAD/bin/sta open_synth

To create an OpenSTA standalone issue, run:

    make open_issue

Tinker with run-*.sh script, create a small script, source scripts/sta-synth.tcl and create test-case.