### PR TITLE
Fixed handling of CTS flow variables

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -18,11 +18,9 @@ set cts_args [list \
           -sink_clustering_enable \
           -balance_levels]
 
-# TODO: The first three are no-ops since the arg order is wrong, but hard to get
-# through CI since nine designs change metrics and the PR is blocked
-append_env_var cts_args -distance_between_buffers CTS_BUF_DISTANCE 1
-append_env_var cts_args -sink_clustering_size CTS_CLUSTER_SIZE 1
-append_env_var cts_args -sink_clustering_max_diameter CTS_CLUSTER_DIAMETER 1
+append_env_var cts_args CTS_BUF_DISTANCE -distance_between_buffers 1
+append_env_var cts_args CTS_CLUSTER_SIZE -sink_clustering_size 1
+append_env_var cts_args CTS_CLUSTER_DIAMETER -sink_clustering_max_diameter 1
 append_env_var cts_args CTS_BUF_LIST -buf_list 1
 
 if {[env_var_exists_and_non_empty CTS_ARGS]} {


### PR DESCRIPTION
Replaces https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2997.

Fixed calling of append_env_var in cts.tcl since the argument order was incorrect

Included at- in branch name to run AutoTuner tests (all autotuner.json files include CTS_CLUSTER_DIAMETER and CTS_CLUSTER_SIZE in their parameter list)

