### PR TITLE
update metrics for public ci

### DIFF
--- a/flow/designs/gf180/jpeg/rules-base.json
+++ b/flow/designs/gf180/jpeg/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 9,
+        "value": 15,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 8,
+        "value": 5,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
+++ b/flow/designs/ihp-sg13g2/riscv32i/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 216,
+        "value": 362,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 30,
+        "value": 20,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.72,
+        "value": -0.65,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -19.84,
+        "value": -18.36,
         "compare": ">="
     }
 }

--- a/flow/designs/nangate45/black_parrot/rules-base.json
+++ b/flow/designs/nangate45/black_parrot/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -3.72,
+        "value": -3.63,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 100,
+        "value": 429,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -8,7 +8,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 756670,
+        "value": 755961,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.53,
+        "value": -0.38,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,11 +60,11 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 245,
+        "value": 678,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -27.05,
+        "value": -21.69,
         "compare": ">="
     }
 }

--- a/flow/designs/sky130hd/aes/rules-base.json
+++ b/flow/designs/sky130hd/aes/rules-base.json
@@ -44,11 +44,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 26,
+        "value": 40,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.39,
+        "value": -0.26,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -40,11 +40,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 3,
+        "value": 6,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 3636,
+        "value": 3219,
         "compare": "<="
     },
     "finish__timing__setup__ws": {


### PR DESCRIPTION
./designs/sky130hd/aes/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna_diodes_count           |       26 |       40 | Failing  |
| finish__timing__setup__ws                     |    -0.39 |    -0.26 | Tighten  |

./designs/nangate45/black_parrot/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |    -3.72 |    -3.63 | Tighten  |
| finish__timing__drv__hold_violation_count     |      100 |      429 | Failing  |

./designs/gf180/jpeg/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |        9 |       15 | Failing  |
| detailedroute__antenna_diodes_count           |        8 |        5 | Tighten  |

./designs/sky130hd/microwatt/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna__violating__nets       |        3 |        6 | Failing  |
| detailedroute__antenna_diodes_count           |     3636 |     3219 | Tighten  |

./designs/ihp-sg13g2/riscv32i/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |      216 |      362 | Failing  |
| detailedroute__antenna__violating__nets       |       30 |       20 | Tighten  |
| finish__timing__setup__ws                     |    -0.72 |    -0.65 | Tighten  |
| finish__timing__wns_percent_delay             |   -19.84 |   -18.36 | Tighten  |

./designs/nangate45/swerv_wrapper/
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |   756670 |   755961 | Tighten  |
| finish__timing__setup__ws                     |    -0.53 |    -0.38 | Tighten  |
| finish__timing__drv__hold_violation_count     |      245 |      678 | Failing  |
| finish__timing__wns_percent_delay             |   -27.05 |   -21.69 | Tighten  |