### PR TITLE
[AutoTuner] Restore resume check 

### DIFF
--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -30,8 +30,7 @@ if [ "$PLATFORM_WITHOUT_DASHES" == "asap7" ] && [ "$DESIGN_NAME" == "gcd" ]; the
   python3 -m unittest tools.AutoTuner.test.ref_file_check.RefFileCheck.test_files
 
   echo "Running AutoTuner resume test (only once)"
-  # Temporarily disable resume check test due to flakiness
-  #python3 -m unittest tools.AutoTuner.test.resume_check.ResumeCheck.test_tune_resume
+  python3 -m unittest tools.AutoTuner.test.resume_check.ResumeCheck.test_tune_resume
 
   echo "Running AutoTuner binary check (only once)"
   openroad_autotuner -h

--- a/tools/AutoTuner/test/resume_check.py
+++ b/tools/AutoTuner/test/resume_check.py
@@ -90,9 +90,9 @@ class ResumeCheck(unittest.TestCase):
             for c in options
         ]
 
-    def check_trial_times(self, iteration: int = 0) -> int:
+    def get_trial_times(self, iteration: int = 0) -> int:
         """
-        Checks the nth iteration time of a trial.
+        Returns the nth iteration time of a trial.
 
         :param iteration: The iteration to check.
         :return: The latest modified UNIX time of the nth iteration.

--- a/tools/AutoTuner/test/resume_check.py
+++ b/tools/AutoTuner/test/resume_check.py
@@ -119,7 +119,7 @@ class ResumeCheck(unittest.TestCase):
             time.sleep(30)
             # Check if first config is complete
             while True:
-                cur_modified_time = self.check_trial_times()
+                cur_modified_time = self.get_trial_times()
                 print(f"Current modified time: {cur_modified_time}")
                 print(f"Latest modified time: {latest_modified_time}")
                 if abs(cur_modified_time - latest_modified_time) < 1e-3:

--- a/tools/AutoTuner/test/resume_check.py
+++ b/tools/AutoTuner/test/resume_check.py
@@ -99,7 +99,7 @@ class ResumeCheck(unittest.TestCase):
                  If no folders are found, returns a default value of 9e99.
         """
         if iteration < 0 or iteration >= self.iterations:
-            raise ValueError("Iteration must be between 0 and iterations - 1")
+            raise ValueError("Iteration must be between 0 and (iterations - 1)")
 
         experiment_dir = os.path.join(
             cur_dir,


### PR DESCRIPTION
This pull request includes several changes to the `AutoTuner` tests to re-enable previously disabled tests, improve the test setup, and add new utility methods.

Fixes #3005 

Re-enabling tests and improving setup:

* [`flow/test/test_autotuner.sh`](diffhunk://#diff-d56eec4dd48b40016002ea5ffe97f45482b50e63a53f9fef7edb9065883ca489L33-R33): Re-enabled the `test_tune_resume` test in the `AutoTuner` script by uncommenting the test execution line.

Codebase simplification and improvements:

* [`tools/AutoTuner/test/resume_check.py`](diffhunk://#diff-018940b904a40ee28b33e9d60e767ffafe7a8b5dbc291b8cb609667bbac376c2R35): Removed unnecessary directory changes and imported the `glob` module to facilitate file pattern matching. [[1]](diffhunk://#diff-018940b904a40ee28b33e9d60e767ffafe7a8b5dbc291b8cb609667bbac376c2R35) [[2]](diffhunk://#diff-018940b904a40ee28b33e9d60e767ffafe7a8b5dbc291b8cb609667bbac376c2L44-L46)
* [`tools/AutoTuner/test/resume_check.py`](diffhunk://#diff-018940b904a40ee28b33e9d60e767ffafe7a8b5dbc291b8cb609667bbac376c2L90-R127): Introduced the `check_trial_times` method to check the modification times of trial iterations, improving the robustness of the `test_tune_resume` test.