### PR TITLE
[WIP] variables: DESIGN_DIR is overrideable

### DIFF
--- a/flow/designs/asap7/gcd/BUILD.bazel
+++ b/flow/designs/asap7/gcd/BUILD.bazel
@@ -21,7 +21,11 @@ orfs_sweep(
         "CORE_AREA": "1.08 1.08 15.12 15.12",
         "PLACE_DENSITY": "0.35",
     },
-    other_variants = {"base": {}},
+    other_variants = {"base": {
+        "sources": {
+            "RULES_JSON": [":rules-base.json"],
+        },
+    }},
     sources = {
         "SDC_FILE": [":constraint.sdc"],
     },

--- a/flow/util/genRuleFile.py
+++ b/flow/util/genRuleFile.py
@@ -11,36 +11,28 @@ import sys
 
 
 def gen_rule_file(
-    design_dir,
+    rules_file,
+    new_rules_file,
     update,
     tighten,
     failing,
     variant,
-    metrics=None,
+    metrics_file=None,
     metrics_to_consider=[],
 ):
 
-    golden_metrics = f"metadata-{variant}-ok.json"
-    if isinstance(metrics, str) and isfile(metrics):
-        with open(metrics, "r") as f:
-            metrics = json.load(f)
-    elif isfile(golden_metrics):
-        with open(golden_metrics, "r") as f:
-            metrics = json.load(f)
+    with open(metrics_file, "r") as f:
+        metrics = json.load(f)
     if not isinstance(metrics, dict):
-        print(f"[ERROR] Invalid format for reference metrics {design_dir}")
+        print(f"[ERROR] Invalid format for reference metrics {metrics_file}")
         sys.exit(1)
 
-    original_directory = getcwd()
-    chdir(design_dir)
-    rules_file = f"rules-{variant}.json"
     rules = dict()
-
     if isfile(rules_file):
         with open(rules_file, "r") as f:
             OLD_RULES = json.load(f)
     else:
-        print(f"[WARNING] Rules file not found {design_dir}")
+        print(f"[WARNING] No old rules file found {rules_file}")
         OLD_RULES = None
 
     # dict format
@@ -189,10 +181,7 @@ def gen_rule_file(
     change_str = ""
     for field, option in rules_dict.items():
         if field not in metrics.keys():
-            print(
-                f"[ERROR] Metric {field} not found in "
-                f"metrics file: {metrics_file} or golden metrics."
-            )
+            print(f"[ERROR] Metric {field} not found")
             sys.exit(1)
 
         if isinstance(metrics[field], str):
@@ -305,15 +294,12 @@ def gen_rule_file(
         rules[field] = dict(value=rule_value, compare=option["compare"])
 
     if len(change_str) > 0:
-        print(design_dir)
         print(format_str.format("Metric", "Old", "New", "Type"), end="")
         print(format_str.format("------", "---", "---", "----"), end="")
         print(change_str)
 
-    with open(rules_file, "w") as f:
+    with open(new_rules_file, "w") as f:
         json.dump(rules, f, indent=4)
-
-    chdir(original_directory)
 
 
 def comma_separated_list(value):
@@ -326,7 +312,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generates or updates rules file for CI."
     )
-    parser.add_argument("dir", help="Path to the design directory.")
     parser.add_argument(
         "-v", "--variant", default="base", help='Flow variant [default="base"].'
     )
@@ -359,6 +344,18 @@ if __name__ == "__main__":
         help="Reference metadata file.",
     )
     parser.add_argument(
+        "--rules",
+        type=str,
+        default=None,
+        help="Rules input file.",
+    )
+    parser.add_argument(
+        "--new-rules",
+        type=str,
+        default=None,
+        help="Rules input file.",
+    )
+    parser.add_argument(
         "-m",
         "--metrics",
         type=comma_separated_list,
@@ -376,7 +373,8 @@ if __name__ == "__main__":
         sys.exit(1)
 
     gen_rule_file(
-        args.dir,
+        args.rules,
+        args.new_rules,
         args.update,
         args.tighten,
         args.failing,

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -43,7 +43,10 @@ update_rules:
 
 .PHONY: update_rules_force
 update_rules_force:
-	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) --variant $(FLOW_VARIANT) --update
+	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) \
+	    --reference $(REPORTS_DIR)/metadata.json \
+		--variant $(FLOW_VARIANT) \
+		--update
 
 .PHONY: update_metadata_autotuner
 update_metadata_autotuner:

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -33,24 +33,37 @@ update_metadata:
 	cp -f $(REPORTS_DIR)/metadata.json \
 	      $(DESIGN_DIR)/metadata-$(FLOW_VARIANT)-ok.json
 
-.PHONY: update_rules
-update_rules:
+.PHONY: do-update_rules
+do-update_rules:
 	$(UTILS_DIR)/genRuleFile.py \
 	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
-	    --new-rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
+	    --new-rules $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
 		--reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--failing \
 		--tighten
 
-.PHONY: update_rules_force
-update_rules_force:
+.PHONY: do-copy_update_rules
+do-copy_update_rules:
+	cp -f $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
+	      $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
+
+.PHONY: update_rules
+update_rules: do-update_rules do-copy_update_rules
+
+.PHONY: do-update_rules_force
+do-update_rules_force:
 	$(UTILS_DIR)/genRuleFile.py \
 	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
 	    --new-rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
 	    --reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--update
+
+.PHONY: update_rules_force
+update_rules_force: do-update_rules_force
+	cp -f $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
+	      $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
 
 .PHONY: update_metadata_autotuner
 update_metadata_autotuner:

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -10,34 +10,33 @@ metadata-generate:
 	@$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
 		-p $(PLATFORM) \
 		-v $(FLOW_VARIANT) \
-		-o $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json 2>&1 \
-		| tee $(abspath $(REPORTS_DIR)/gen-metrics-$(FLOW_VARIANT)-generate.log)
+		-o $(REPORTS_DIR)/metadata.json 2>&1 \
+		| tee $(abspath $(REPORTS_DIR)/metadata-generate.log)
 
 .PHONY: metadata-check
 metadata-check:
 	@$(UTILS_DIR)/checkMetadata.py \
-		-m $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
+		-m $(REPORTS_DIR)/metadata.json \
 		-r $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json 2>&1 \
-		| tee $(abspath $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log)
+		| tee $(abspath $(REPORTS_DIR)/metadata-check.log)
 
 .PHONY: clean_metadata
 clean_metadata:
 	rm -f $(REPORTS_DIR)/design-dir.txt
-	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-*.log
-	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json
+	rm -f $(REPORTS_DIR)/metadata*.*
 
 .PHONY: update_ok
 update_ok: update_rules
 
 .PHONY: update_metadata
 update_metadata:
-	cp -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
+	cp -f $(REPORTS_DIR)/metadata.json \
 	      $(DESIGN_DIR)/metadata-$(FLOW_VARIANT)-ok.json
 
 .PHONY: update_rules
 update_rules:
 	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) \
-		--reference $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
+		--reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--failing \
 		--tighten

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -1,21 +1,29 @@
 # Utilities
 #===============================================================================
 .PHONY: metadata
-metadata: finish
+metadata: finish metadata-generate metadata-check
+
+.PHONY: metadata-generate
+metadata-generate:
+	@mkdir -p $(REPORTS_DIR)
 	@echo $(DESIGN_DIR) > $(REPORTS_DIR)/design-dir.txt
 	@$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
 		-p $(PLATFORM) \
 		-v $(FLOW_VARIANT) \
 		-o $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json 2>&1 \
-		| tee $(REPORTS_DIR)/gen-metrics-$(FLOW_VARIANT)-check.log
+		| tee $(abspath $(REPORTS_DIR)/gen-metrics-$(FLOW_VARIANT)-generate.log)
+
+.PHONY: metadata-check
+metadata-check:
 	@$(UTILS_DIR)/checkMetadata.py \
 		-m $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json \
 		-r $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json 2>&1 \
-		| tee $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log
+		| tee $(abspath $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log)
 
 .PHONY: clean_metadata
 clean_metadata:
-	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-check.log
+	rm -f $(REPORTS_DIR)/design-dir.txt
+	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT)-*.log
 	rm -f $(REPORTS_DIR)/metadata-$(FLOW_VARIANT).json
 
 .PHONY: update_ok

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -35,7 +35,9 @@ update_metadata:
 
 .PHONY: update_rules
 update_rules:
-	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) \
+	$(UTILS_DIR)/genRuleFile.py \
+	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
+	    --new-rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
 		--reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--failing \
@@ -43,7 +45,9 @@ update_rules:
 
 .PHONY: update_rules_force
 update_rules_force:
-	$(UTILS_DIR)/genRuleFile.py $(DESIGN_DIR) \
+	$(UTILS_DIR)/genRuleFile.py \
+	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
+	    --new-rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
 	    --reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--update

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -13,11 +13,13 @@ metadata-generate:
 		-o $(REPORTS_DIR)/metadata.json 2>&1 \
 		| tee $(abspath $(REPORTS_DIR)/metadata-generate.log)
 
+export RULES_JSON ?= $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
+
 .PHONY: metadata-check
 metadata-check:
 	@$(UTILS_DIR)/checkMetadata.py \
 		-m $(REPORTS_DIR)/metadata.json \
-		-r $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json 2>&1 \
+		-r $(RULES_JSON) 2>&1 \
 		| tee $(abspath $(REPORTS_DIR)/metadata-check.log)
 
 .PHONY: clean_metadata
@@ -36,7 +38,7 @@ update_metadata:
 .PHONY: do-update_rules
 do-update_rules:
 	$(UTILS_DIR)/genRuleFile.py \
-	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
+	    --rules $(RULES_JSON) \
 	    --new-rules $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
 		--reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
@@ -46,7 +48,7 @@ do-update_rules:
 .PHONY: do-copy_update_rules
 do-copy_update_rules:
 	cp -f $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
-	      $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
+	      $(RULES_JSON)
 
 .PHONY: update_rules
 update_rules: do-update_rules do-copy_update_rules
@@ -54,8 +56,8 @@ update_rules: do-update_rules do-copy_update_rules
 .PHONY: do-update_rules_force
 do-update_rules_force:
 	$(UTILS_DIR)/genRuleFile.py \
-	    --rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
-	    --new-rules $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json \
+	    --rules $(RULES_JSON) \
+	    --new-rules $(RULES_JSON) \
 	    --reference $(REPORTS_DIR)/metadata.json \
 		--variant $(FLOW_VARIANT) \
 		--update
@@ -63,7 +65,7 @@ do-update_rules_force:
 .PHONY: update_rules_force
 update_rules_force: do-update_rules_force
 	cp -f $(RESULTS_DIR)/rules-$(FLOW_VARIANT).json \
-	      $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
+	      $(RULES_JSON)
 
 .PHONY: update_metadata_autotuner
 update_metadata_autotuner:


### PR DESCRIPTION
Plus some driveby cleanup and making things a bit more consistent.

By default in Makefile DESIGN_DIR points to the DESIGN_CONFIG dir, but it can be useful to override it, w.r.t. rules.json and metadata.json support in bazel-orfs.