### PR TITLE
bazel: fix local openroad usage gaffe

### DIFF
--- a/flow/MODULE.bazel
+++ b/flow/MODULE.bazel
@@ -53,7 +53,7 @@ visibility = ["//visibility:public"],
 )
 filegroup(
     name = "all",
-    data = glob(["**/*"]),
+    data = glob(["openroad.runfiles/**/*"]),
     visibility = ["//visibility:public"],
 )
 """,


### PR DESCRIPTION
Reduce glob enormously for openroad to limit to runfiles