### PR TITLE
bazel: remove broken comment with common bazel knowledge

### DIFF
--- a/flow/MODULE.bazel
+++ b/flow/MODULE.bazel
@@ -15,17 +15,6 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/bazel-orfs.git",
 )
 
-# Read: https://github.com/The-OpenROAD-Project/bazel-orfs?tab=readme-ov-file#usage
-#
-# TL;DR
-#
-# 1. uncomment below
-# 2. comment git_override() above
-#
-#local_path_override(
-#   module_name = "bazel-orfs", path = "../bazel-orfs"
-#)
-
 bazel_dep(name = "rules_python", version = "0.31.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")


### PR DESCRIPTION
It should have been ../../bazel-orfs, I thought about correcting the comment, but then again local_path_override() is common Bazel knowledge and doesn't belong in MODULE.bazel. Anyone hacking bazel-orfs would know this anyway.