### PR TITLE
def2stream: log cleanup, terser and removed debug progress statements

### DIFF
--- a/flow/util/def2stream.py
+++ b/flow/util/def2stream.py
@@ -20,7 +20,6 @@ print("[INFO] Reporting cells prior to loading DEF ...")
 for i in main_layout.each_cell():
     print("[INFO] '{0}'".format(i.name))
 
-print("[INFO] Reading DEF ...")
 main_layout.read(in_def, layoutOptions)
 
 # Clear cells
@@ -28,35 +27,33 @@ top_cell_index = main_layout.cell(design_name).cell_index()
 
 # remove orphan cell BUT preserve cell with VIA_
 #  - KLayout is prepending VIA_ when reading DEF that instantiates LEF's via
-print("[INFO] Clearing cells...")
 for i in main_layout.each_cell():
     if i.cell_index() != top_cell_index:
         if not i.name.startswith("VIA_") and not i.name.endswith("_DEF_FILL"):
             i.clear()
 
 # Load in the gds to merge
-print("[INFO] Merging GDS/OAS files...")
 for fil in in_files.split():
     print("\t{0}".format(fil))
     main_layout.read(fil)
 
 # Copy the top level only to a new layout
-print("[INFO] Copying toplevel cell '{0}'".format(design_name))
 top_only_layout = pya.Layout()
 top_only_layout.dbu = main_layout.dbu
 top = top_only_layout.create_cell(design_name)
 top.copy_tree(main_layout.cell(design_name))
 
-print("[INFO] Checking for missing cell from GDS/OAS...")
 missing_cell = False
-regex = None
-if "GDS_ALLOW_EMPTY" in os.environ:
-    print("[INFO] Found GDS_ALLOW_EMPTY variable.")
-    regex = os.getenv("GDS_ALLOW_EMPTY")
+allow_empty = os.environ.get("GDS_ALLOW_EMPTY", "")
+regex = re.compile(allow_empty) if allow_empty else None
+
+if allow_empty:
+    print(f"[INFO] GDS_ALLOW_EMPTY={allow_empty}")
+
 for i in top_only_layout.each_cell():
     if i.is_empty():
         missing_cell = True
-        if regex is not None and re.match(regex, i.name):
+        if regex is not None and regex.match(i.name):
             print(
                 "[WARNING] LEF Cell '{0}' ignored. Matches GDS_ALLOW_EMPTY.".format(
                     i.name
@@ -72,7 +69,6 @@ for i in top_only_layout.each_cell():
 if not missing_cell:
     print("[INFO] All LEF cells have matching GDS/OAS cells")
 
-print("[INFO] Checking for orphan cell in the final layout...")
 orphan_cell = False
 for i in top_only_layout.each_cell():
     if i.name != design_name and i.parent_cells() == 0:
@@ -81,14 +77,12 @@ for i in top_only_layout.each_cell():
         errors += 1
 
 if not orphan_cell:
-    print("[INFO] No orphan cells")
+    print("[INFO] No orphan cells in the final layout")
 
 
 if seal_file:
     top_cell = top_only_layout.top_cell()
 
-    print("[INFO] Reading seal GDS/OAS file...")
-    print("\t{0}".format(seal_file))
     top_only_layout.read(seal_file)
 
     for cell in top_only_layout.top_cells():
@@ -101,7 +95,6 @@ if seal_file:
             top.insert(pya.CellInstArray(cell.cell_index(), pya.Trans()))
 
 # Write out the GDS
-print("[INFO] Writing out GDS/OAS '{0}'".format(out_file))
 top_only_layout.write(out_file)
 
 sys.exit(errors)


### PR DESCRIPTION
The code was distinguishing between empty and not set GDS_ALLOW_EMPTY which led to confusing logs in the common case.

New output:

```
[INFO] GDS_ALLOW_EMPTY=Element
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
```
