### PR TITLE
open: better logging

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -41,7 +41,7 @@ proc read_timing {input_file} {
   if {$design_stage >= 6 && [file exist $::env(RESULTS_DIR)/6_final.spef]} {
     log_cmd read_spef $::env(RESULTS_DIR)/6_final.spef
   } elseif {$design_stage >= 5} {
-    if { [grt::have_routes] } {
+    if { [log_cmd grt::have_routes] } {
       log_cmd estimate_parasitics -global_routing
     } else {
       puts "No global routing results available, skipping estimate_parasitics"
@@ -51,10 +51,8 @@ proc read_timing {input_file} {
     log_cmd estimate_parasitics -placement
   }
 
-  puts -nonewline "Populating timing paths..."
   # Warm up OpenSTA, so clicking on timing related buttons reacts faster
-  set _tmp [find_timing_paths]
-  puts "OK"
+  set _tmp [log_cmd find_timing_paths]
 }
 
 if {[ord::openroad_gui_compiled]} {

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -3,13 +3,14 @@ proc log_cmd {cmd args} {
   set log_cmd "$cmd[join [lmap arg $args {format " %s" [expr {[string match {* *} $arg] ? "\"$arg\"" : "$arg"}]}] ""]"
   puts $log_cmd
   set start [clock seconds]
-  $cmd {*}$args
+  set result [$cmd {*}$args]
   set time [expr {[clock seconds] - $start}]
   if {$time >= 5} {
     # Ideally we'd use a single line, but the command can output text
     # and we don't want to mix it with the log, so output the time it took afterwards.
     puts "Took $time seconds: $log_cmd"
   }
+  return $result
 }
 
 proc fast_route {} {


### PR DESCRIPTION
log_cmd accounts for pretty much all time to open a desig now

All but 10 seconds accounted for by [log_cmd](https://github.com/The-OpenROAD-Project/OpenROAD/issues/7100):

```
OpenROAD v2.0-20670-g4939290b5 
Features included (+) or not (-): +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
read_db results/asap7/BoomTile/base/5_1_grt.odb
Took 8 seconds: read_db results/asap7/BoomTile/base/5_1_grt.odb
GUI_TIMING=1 reading timing, takes a little while for large designs...
read_sdc /home/oyvind/OpenROAD-flow-scripts/foo/results/asap7/BoomTile/base/5_1_grt.sdc
Took 10 seconds: read_sdc /home/oyvind/OpenROAD-flow-scripts/foo/results/asap7/BoomTile/base/5_1_grt.sdc
grt::have_routes
Took 48 seconds: grt::have_routes
No global routing results available, skipping estimate_parasitics
Load .//reports/asap7/BoomTile/base/congestion.rpt for details
find_timing_paths
Took 71 seconds: find_timing_paths

real	2m27,613s
user	2m23,664s
sys	0m3,944s
```
