### PR TITLE
synth: remove extract_fa

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tools/yosys"]
 	path = tools/yosys
-	url = ../../The-OpenROAD-Project/yosys.git
+	url = https://github.com/YosysHQ/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
 	url = ../OpenROAD.git

--- a/flow/platforms/asap7/yoSys/cells_adders_L.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_L.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/asap7/yoSys/cells_adders_L.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_L.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/asap7/yoSys/cells_adders_R.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_R.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/asap7/yoSys/cells_adders_R.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_R.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/asap7/yoSys/cells_adders_SL.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_SL.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/asap7/yoSys/cells_adders_SL.v
+++ b/flow/platforms/asap7/yoSys/cells_adders_SL.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/gf180/cells_adders.v
+++ b/flow/platforms/gf180/cells_adders.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/gf180/cells_adders.v
+++ b/flow/platforms/gf180/cells_adders.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/nangate45/cells_adders.v
+++ b/flow/platforms/nangate45/cells_adders.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/nangate45/cells_adders.v
+++ b/flow/platforms/nangate45/cells_adders.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/sky130hd/cells_adders_hd.v
+++ b/flow/platforms/sky130hd/cells_adders_hd.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/sky130hd/cells_adders_hd.v
+++ b/flow/platforms/sky130hd/cells_adders_hd.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/platforms/sky130hs/cells_adders_hs.v
+++ b/flow/platforms/sky130hs/cells_adders_hs.v
@@ -1,6 +1,6 @@
 
 (* techmap_celltype = "$fa" *)
-module _tech_fa (A, B, C, X, Y);
+module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)
     input [WIDTH-1 : 0] A, B, C;

--- a/flow/platforms/sky130hs/cells_adders_hs.v
+++ b/flow/platforms/sky130hs/cells_adders_hs.v
@@ -1,5 +1,5 @@
 
-(* techmap_celltype = "$fa" *)
+(* abc9_box, lib_whitebox, techmap_celltype = "$fa" *)
 module _80_tech_fa (A, B, C, X, Y);
   parameter WIDTH = 1;
   (* force_downto *)

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -72,11 +72,10 @@ opt -purge
 
 # Technology mapping of adders
 if {[env_var_exists_and_non_empty ADDER_MAP_FILE]} {
-  # extract the full adders
-  extract_fa
-  # map full adders
+  # default map all but full adders
+  techmap -dont_map \$fa
+  # custom map full adders
   techmap -map $::env(ADDER_MAP_FILE)
-  techmap
   # Quick optimization
   opt -fast -purge
 }

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -22,7 +22,13 @@ set synth_full_args $::env(SYNTH_ARGS)
 if {[env_var_exists_and_non_empty SYNTH_OPERATIONS_ARGS]} {
   set synth_full_args [concat $synth_full_args $::env(SYNTH_OPERATIONS_ARGS)]
 } else {
+  # Coarse LCU -> Kogge-Stone
   set synth_full_args [concat $synth_full_args "-extra-map $::env(FLOW_HOME)/platforms/common/lcu_kogge_stone.v"]
+
+  if {[env_var_exists_and_non_empty ADDER_MAP_FILE]} {
+    # Coarse FA -> PDK FA
+    set synth_full_args [concat $synth_full_args "-extra-map $::env(ADDER_MAP_FILE)"]
+  }
 }
 
 if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
@@ -69,16 +75,6 @@ renames -wire
 
 # Optimize the design
 opt -purge
-
-# Technology mapping of adders
-if {[env_var_exists_and_non_empty ADDER_MAP_FILE]} {
-  # default map all but full adders
-  techmap -dont_map \$fa
-  # custom map full adders
-  techmap -map $::env(ADDER_MAP_FILE)
-  # Quick optimization
-  opt -fast -purge
-}
 
 # Technology mapping of latches
 if {[env_var_exists_and_non_empty LATCH_MAP_FILE]} {


### PR DESCRIPTION
This draft showcases a possible usage of Yosys without relying on `extract_fa` by using the default techmap file change from https://github.com/YosysHQ/yosys/pull/4997/

cc @QuantamHD @maliberty @mikesinouye