### PR TITLE
generate-docs: stable order

### DIFF
--- a/flow/scripts/generate-variables-docs.py
+++ b/flow/scripts/generate-variables-docs.py
@@ -17,10 +17,10 @@ with open(yaml_path, "r") as file:
 preferred_order = ["synth", "floorplan", "place", "cts", "grt", "route", "final"]
 stages = {stage for value in data.values() for stage in value.get("stages", [])}
 # convert set of stages to stages in a list in the preferred order, but
-# list all stages
-stages = [stage for stage in preferred_order if stage in stages] + [
-    stage for stage in stages if stage not in preferred_order
-]
+# list all stages and sort the rest for a stable order
+stages = [stage for stage in preferred_order if stage in stages] + sorted(
+    [stage for stage in stages if stage not in preferred_order]
+)
 
 markdown_table = ""
 


### PR DESCRIPTION
an ordering was dependent on set of dictionary keys from yaml parsing of a dictionary.

We want a stable ordering and that is a lot of
implementation detail to base that stable ordering feature on, so sort to make it clear in the code
that we have a stable order.