### PR TITLE
Obtain bash path through /usr/bin/env in flow scripts.

### DIFF
--- a/flow/platforms/sky130ram/Makefile
+++ b/flow/platforms/sky130ram/Makefile
@@ -66,7 +66,7 @@ endif
 # Verbosity
 OPTS += -v
 
-SHELL ?= /bin/bash
+SHELL ?= /usr/bin/env bash
 export SHELL
 export SHELLOPTS := pipefail
 

--- a/flow/scripts/escape.sh
+++ b/flow/scripts/escape.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 sed -e 's/ /\\ /g' -e 's/(/\\(/g' -e 's/|/\\|/g' -e 's/)/\\)/g'

--- a/flow/scripts/flow.sh
+++ b/flow/scripts/flow.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u -eo pipefail
 mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
 echo Running $2.tcl, stage $1

--- a/flow/scripts/klayout/src/gen_klayout_files.sh
+++ b/flow/scripts/klayout/src/gen_klayout_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Bash wrapper script to read PDK files and generate the KLayout layer
 # properties and technology file used the 6_final step of OpenROAD-flow-scripts

--- a/flow/scripts/synth.sh
+++ b/flow/scripts/synth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -u -eo pipefail
 mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
 eval "$TIME_CMD $YOSYS_EXE $YOSYS_FLAGS -c $1" 2>&1 | tee $(realpath $2)

--- a/flow/test/openroad.sh
+++ b/flow/test/openroad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 # HACK while we're waiting for OpenROAD to be switched to MODULE.bazel
 # OpenROAD has its own TCL library

--- a/flow/test/test_delta_debug.sh
+++ b/flow/test/test_delta_debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # deltaDebug.py integration smoke-test, run from ORFS/flow folder.
 #

--- a/flow/test/test_make_issue.sh
+++ b/flow/test/test_make_issue.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # make issue smoketest
 set -ue -o pipefail
 

--- a/flow/test/test_outoftree.sh
+++ b/flow/test/test_outoftree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # deltaDebug.py integration smoke-test, run from ORFS/flow folder.
 #

--- a/flow/util/open_plots.sh
+++ b/flow/util/open_plots.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 xdg-open $1


### PR DESCRIPTION
Unfortunately, not all systems have bash in /bin. One notable example is nixos. When entering a development shell in nixos, the current version of the scripts will fail complaining that "something is wrong at line 1". The issue is that there is no /bin/bash on NixOS or more generally on the system.