### PR TITLE
genMetrics: remove unreferenced brittle use-case

### DIFF
--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -6,7 +6,6 @@
 # -----------------------------------------------------------------------------
 
 import os
-from sys import exit
 from datetime import datetime, timedelta
 from collections import defaultdict
 from uuid import uuid4 as uuid
@@ -26,8 +25,7 @@ def parse_args():
     parser.add_argument(
         "--design",
         "-d",
-        required=False,
-        default="all_designs",
+        required=True,
         help="Design Name for metrics",
     )
     parser.add_argument(

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -51,17 +51,9 @@ def parse_args():
         "--output", "-o", required=False, default="metadata.json", help="Output file"
     )
     parser.add_argument("--hier", "-x", action="store_true", help="Hierarchical JSON")
-    parser.add_argument("--logs", help="Path to logs", default=None)
-    parser.add_argument(
-        "--reports",
-        help="Path to reports",
-        default=None,
-    )
-    parser.add_argument(
-        "--results",
-        help="Path to results",
-        default=None,
-    )
+    parser.add_argument("--logs", help="Path to logs")
+    parser.add_argument("--reports", help="Path to reports")
+    parser.add_argument("--results", help="Path to results")
     args = parser.parse_args()
 
     return args
@@ -378,75 +370,15 @@ def extract_metrics(
 
 args = parse_args()
 now = datetime.now()
-flow_variants = args.flowVariant.split()
-all_designs = True if args.design == "all_designs" else False
-designs = args.design.split()
-platforms = args.platform.split()
 
-if all_designs or len(designs) > 1 or len(flow_variants) > 1:
-    rootdir = "./logs"
-
-    all_df = pd.DataFrame()
-    all_d = []
-
-    cwd = os.getcwd()
-    for platform_it in os.scandir(rootdir):
-        if not platform_it.is_dir():
-            continue
-        plt = platform_it.name
-        if not plt in platforms:
-            continue
-        for design_it in os.scandir(platform_it.path):
-            if not design_it.is_dir():
-                continue
-            des = design_it.name
-            if not (all_designs or des in designs):
-                continue
-            for variant in flow_variants:
-                log_dir = os.path.join(cwd, "logs", plt, des, variant)
-                if not os.path.isdir(log_dir):
-                    continue
-                if not os.path.isfile(os.path.join(log_dir, "6_report.json")):
-                    print(
-                        f"Skip extracting metrics for {plt}, {des}, {variant} as run did not complete"
-                    )
-                    continue
-                print(f"Extract Metrics for {plt}, {des}, {variant}")
-                file = "/".join(["reports", plt, des, variant, "metrics.json"])
-                logPath = os.path.join(cwd, "logs", plt, des, variant)
-                rptPath = os.path.join(cwd, "reports", plt, des, variant)
-                resultPath = os.path.join(cwd, "results", plt, des, variant)
-                metrics, df = extract_metrics(
-                    cwd,
-                    plt,
-                    des,
-                    variant,
-                    file,
-                    args.hier,
-                    logPath,
-                    rptPath,
-                    resultPath,
-                )
-                all_d.append(metrics)
-                if all_df.shape[0] == 0:
-                    all_df = df
-                else:
-                    all_df = all_df.merge(df, on="Metrics", how="inner")
-
-    with open("metrics.json", "w") as outFile:
-        json.dump(all_d, outFile, indent=2)
-
-    with open("metrics.html", "w") as f:
-        f.write(all_df.to_html())
-else:
-    metrics_dict, metrics_df = extract_metrics(
-        os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"),
-        args.platform,
-        args.design,
-        args.flowVariant,
-        args.output,
-        args.hier,
-        args.logs,
-        args.reports,
-        args.results,
-    )
+metrics_dict, metrics_df = extract_metrics(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"),
+    args.platform,
+    args.design,
+    args.flowVariant,
+    args.output,
+    args.hier,
+    args.logs,
+    args.reports,
+    args.results,
+)


### PR DESCRIPTION
There is no reference to the use-case of genMetrics.py to scan all local designs, deleting it predicated on review confirmation that it is no longer in use.

genMetrics.py had code to scan designs, but this code would be brittle as it makes assumptions on layout. I ran it locally and it didn't look like it was maintained.