### PR TITLE
[AutoTuner] Fix metadata.json regression

### DIFF
--- a/tools/AutoTuner/test/smoke_test_algo_eval.py
+++ b/tools/AutoTuner/test/smoke_test_algo_eval.py
@@ -35,6 +35,7 @@
 import unittest
 import subprocess
 import os
+import shutil
 from .autotuner_test_utils import AutoTunerTestUtils, accepted_rc
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
@@ -66,6 +67,9 @@ class BaseAlgoEvalSmokeTest(unittest.TestCase):
             f" --reference {self.reference}"
             for a, e in self.matrix
         ]
+        # Make a file copy of the original metadata.json
+        self.metadata = os.path.join(cur_dir, f"{design_path}/metadata.json")
+        shutil.copyfile(self.metadata, self.metadata + ".orig")
 
     def make_base(self):
         commands = [
@@ -87,6 +91,10 @@ class BaseAlgoEvalSmokeTest(unittest.TestCase):
             out = subprocess.run(command, shell=True)
             successful = out.returncode in accepted_rc
             self.assertTrue(successful)
+
+        # On successful run, restore the metadata.json file
+        shutil.copyfile(self.metadata + ".orig", self.metadata)
+        os.remove(self.metadata + ".orig")
 
 
 class asap7AlgoEvalSmokeTest(BaseAlgoEvalSmokeTest):

--- a/tools/AutoTuner/test/smoke_test_algo_eval.py
+++ b/tools/AutoTuner/test/smoke_test_algo_eval.py
@@ -48,6 +48,7 @@ class BaseAlgoEvalSmokeTest(unittest.TestCase):
 
     def setUp(self):
         design_path = f"../../../flow/designs/{self.platform}/{self.design}"
+        report_path = f"../../../flow/reports/{self.platform}/{self.design}"
         self.config = os.path.join(cur_dir, f"{design_path}/autotuner.json")
         self.experiment = f"smoke-test-algo-eval-{self.platform}"
         self.reference = os.path.join(cur_dir, f"{design_path}/metadata-base-at.json")
@@ -68,7 +69,7 @@ class BaseAlgoEvalSmokeTest(unittest.TestCase):
             for a, e in self.matrix
         ]
         # Make a file copy of the original metadata.json
-        self.metadata = os.path.join(cur_dir, f"{design_path}/metadata.json")
+        self.metadata = os.path.join(cur_dir, f"{report_path}/metadata.json")
         shutil.copyfile(self.metadata, self.metadata + ".orig")
 
     def make_base(self):


### PR DESCRIPTION
This pull request updates the `BaseAlgoEvalSmokeTest` class in `tools/AutoTuner/test/smoke_test_algo_eval.py` to introduce the concept of a `flow_variant` for better configurability and reuse. The changes primarily focus on refactoring the `setUp` method and related commands to use this new variable.

### Refactoring for `flow_variant` integration:

* Introduced a new class variable `flow_variant` with the default value `"smoke-test-algo-eval"` to represent the flow variant. (`[tools/AutoTuner/test/smoke_test_algo_eval.pyR47-R55](diffhunk://#diff-63a772b287b174f31b4335be42c7e910f197140112906da7b1bb169517dfacf8R47-R55)`)
* Updated the `setUp` method to use `flow_variant` in constructing the `experiment` name and the `reference` file path, improving flexibility and consistency. (`[tools/AutoTuner/test/smoke_test_algo_eval.pyR47-R55](diffhunk://#diff-63a772b287b174f31b4335be42c7e910f197140112906da7b1bb169517dfacf8R47-R55)`)
* Refactored the `make_base` method to include `FLOW_VARIANT` in all `make` commands, ensuring that the flow variant is explicitly passed to the build system. (`[tools/AutoTuner/test/smoke_test_algo_eval.pyL71-R79](diffhunk://#diff-63a772b287b174f31b4335be42c7e910f197140112906da7b1bb169517dfacf8L71-R79)`)