### PR TITLE
Update metrics for MPL changes

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 4296,
+        "value": 3810,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.62,
+        "value": -3.56,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 252,
+        "value": 106,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {


### PR DESCRIPTION
For [#6689](https://github.com/The-OpenROAD-Project/OpenROAD/pull/6689)

sky130hd/uW:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |     4296 |     3810 | Tighten  |
| finish__timing__setup__ws                     |    -2.62 |    -3.56 | Failing  |
| finish__timing__drv__hold_violation_count     |      252 |      106 | Tighten  |