### PR TITLE
bump metrics for public ci

### DIFF
--- a/flow/designs/asap7/swerv_wrapper/rules-base.json
+++ b/flow/designs/asap7/swerv_wrapper/rules-base.json
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 654,
+        "value": 950,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/nangate45/black_parrot/rules-base.json
+++ b/flow/designs/nangate45/black_parrot/rules-base.json
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 8824146,
+        "value": 10420028,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 4296,
+        "value": 3810,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.62,
+        "value": -3.56,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 252,
+        "value": 106,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {


### PR DESCRIPTION
designs/sky130hd/microwatt/rules-base.json updates:
[WARNING] Multiple clocks not supported. Will use first clock: ext_clk: 15.0000.
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |     4296 |     3810 | Tighten  |
| finish__timing__setup__ws                     |    -2.62 |    -3.56 | Failing  |
| finish__timing__drv__hold_violation_count     |      252 |      106 | Tighten  |

designs/asap7/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__hold_violation_count     |      654 |      950 | Failing  |

designs/nangate45/black_parrot/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__route__wirelength              |  8824146 | 10420028 | Failing  |