### PR TITLE
include "-all" parameter to dependency installer description

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -232,7 +232,7 @@ _help() {
     cat <<EOF
 
 All arguments and flags are only applicable for OpenROAD dependencies
-Usage: $0
+Usage: $0 -all
                                 # Installs all of OpenROAD's dependencies no
                                 #     need to run -base or -common. Requires
                                 #     privileged access.

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -232,7 +232,7 @@ _help() {
     cat <<EOF
 
 All arguments and flags are only applicable for OpenROAD dependencies
-Usage: $0 -all
+Usage: $0 [-all|-base|-common] [-<ARGS>]
                                 # Installs all of OpenROAD's dependencies no
                                 #     need to run -base or -common. Requires
                                 #     privileged access.


### PR DESCRIPTION
If I run DependencyInstaller without any input flag it throws an error, so I believe this is the right description