### PR TITLE
update metrics for nangate45/swerv_wrapper

### DIFF
--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 6208106,
+        "value": 5912359,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.54,
+        "value": -0.69,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 678,
+        "value": 674,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {


### PR DESCRIPTION
designs/nangate45/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__route__wirelength              |  6208106 |  5912359 | Tighten  |
| finish__timing__setup__ws                     |    -0.54 |    -0.69 | Failing  |
| finish__timing__drv__hold_violation_count     |      678 |      674 | Tighten  |