### PR TITLE
[AutoTuner] fast smoke test

### DIFF
--- a/flow/test/test_fast_autotuner.sh
+++ b/flow/test/test_fast_autotuner.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+# run the commands in ORFS root dir
+echo "[INFO FLW-0029] Installing dependencies in virtual environment."
+cd ../
+./tools/AutoTuner/installer.sh
+. ./tools/AutoTuner/setup.sh
+
+echo "Running Autotuner fast smoke test"
+python3 -m unittest tools.AutoTuner.test.fast_smoke_test.FastSmokeTest.test

--- a/flow/test/test_helper.sh
+++ b/flow/test/test_helper.sh
@@ -76,6 +76,13 @@ if [ $ret -eq 0 ] && grep -q 'power:' <(echo $TARGETS); then
   $__make power 2>&1 | tee -a "$LOG_FILE"
   ret=$(( ret + $? ))
 fi
+
+# Fast AT Smoke Tests
+if [ "${DESIGN_NAME}" = "gcd" ] && [ "${PLATFORM}" = "asap7" ]; then
+  echo "Start fast autotuner smoke test"
+  ./test/test_fast_autotuner.sh
+  ret=$(( ret + $? ))
+fi
 set -x
 
 # Run Autotuner CI specifically for gcd on selected platforms.

--- a/tools/AutoTuner/test/fast_smoke_test.py
+++ b/tools/AutoTuner/test/fast_smoke_test.py
@@ -35,7 +35,7 @@
 import unittest
 import subprocess
 import os
-from .autotuner_test_utils import AutoTunerTestUtils
+from .autotuner_test_utils import AutoTunerTestUtils, accepted_rc
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -75,15 +75,15 @@ class FastSmokeTest(unittest.TestCase):
         if not (self.platform and self.design):
             raise unittest.SkipTest("Platform and design have to be defined")
 
-        tune_process = subprocess.Popen(self.tune_command, shell=True)
-        sweep_process = subprocess.Popen(self.sweep_command, shell=True)
+        # Run tune command
+        tune_result = subprocess.run(self.tune_command, shell=True)
+        tune_successful = tune_result.returncode in accepted_rc
+        self.assertTrue(tune_successful)
 
-        tune_returncode = tune_process.wait()
-        sweep_returncode = sweep_process.wait()
-
-        self.assertEqual(tune_returncode, 0, "Tune command failed")
-        self.assertEqual(sweep_returncode, 0, "Sweep command failed")
-
+        # Run sweep command
+        sweep_result = subprocess.run(self.sweep_command, shell=True)
+        sweep_successful = sweep_result.returncode in accepted_rc
+        self.assertTrue(sweep_successful)
 
 
 if __name__ == "__main__":

--- a/tools/AutoTuner/test/fast_smoke_test.py
+++ b/tools/AutoTuner/test/fast_smoke_test.py
@@ -67,8 +67,7 @@ class FastSmokeTest(unittest.TestCase):
 
         # Sweep command
         # limit jobs because ray.get() does not terminate if jobs > number of samples
-        core = os.cpu_count()
-        self.jobs = 4 if core >= 4 else core
+        self.jobs = 1
         self.sweep_command = (
             f"{self.exec}"
             f" --design {self.design}"

--- a/tools/AutoTuner/test/fast_smoke_test.py
+++ b/tools/AutoTuner/test/fast_smoke_test.py
@@ -54,6 +54,8 @@ class FastSmokeTest(unittest.TestCase):
             "./files/fast-at-sweep.json",
         )
         self.exec = AutoTunerTestUtils.get_exec_cmd()
+
+        # Tune command
         self.tune_command = (
             f"{self.exec}"
             f" --design {self.design}"
@@ -62,12 +64,18 @@ class FastSmokeTest(unittest.TestCase):
             f" --config {self.tune_config}"
             f" tune --samples 1"
         )
+
+        # Sweep command
+        # limit jobs because ray.get() does not terminate if jobs > number of samples
+        core = os.cpu_count()
+        self.jobs = 4 if core >= 4 else core
         self.sweep_command = (
             f"{self.exec}"
             f" --design {self.design}"
             f" --platform {self.platform}"
             f" --experiment fast-smke-test-sweep"
             f" --config {self.sweep_config}"
+            f" --jobs {self.jobs}"
             f" sweep"
         )
 

--- a/tools/AutoTuner/test/fast_smoke_test.py
+++ b/tools/AutoTuner/test/fast_smoke_test.py
@@ -1,0 +1,90 @@
+#############################################################################
+##
+## Copyright (c) 2024, Precision Innovations Inc.
+## All rights reserved.
+##
+## BSD 3-Clause License
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of source code must retain the above copyright notice, this
+##   list of conditions and the following disclaimer.
+##
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+##
+## * Neither the name of the copyright holder nor the names of its
+##   contributors may be used to endorse or promote products derived from
+##   this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+## LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+## CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+## SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+## INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+###############################################################################
+
+import unittest
+import subprocess
+import os
+from .autotuner_test_utils import AutoTunerTestUtils
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+class FastSmokeTest(unittest.TestCase):
+    platform = "asap7"
+    design = "gcd"
+
+    def setUp(self):
+        self.tune_config = os.path.join(
+            cur_dir,
+            f"../../../flow/designs/{self.platform}/{self.design}/autotuner.json",
+        )
+        self.sweep_config = os.path.join(
+            cur_dir,
+            "./files/fast-at-sweep.json",
+        )
+        self.exec = AutoTunerTestUtils.get_exec_cmd()
+        self.tune_command = (
+            f"{self.exec}"
+            f" --design {self.design}"
+            f" --platform {self.platform}"
+            f" --experiment fast-smoke-test-tune"
+            f" --config {self.tune_config}"
+            f" tune --samples 1"
+        )
+        self.sweep_command = (
+            f"{self.exec}"
+            f" --design {self.design}"
+            f" --platform {self.platform}"
+            f" --experiment fast-smke-test-sweep"
+            f" --config {self.sweep_config}"
+            f" sweep"
+        )
+
+    def test(self):
+        if not (self.platform and self.design):
+            raise unittest.SkipTest("Platform and design have to be defined")
+
+        tune_process = subprocess.Popen(self.tune_command, shell=True)
+        sweep_process = subprocess.Popen(self.sweep_command, shell=True)
+
+        tune_returncode = tune_process.wait()
+        sweep_returncode = sweep_process.wait()
+
+        self.assertEqual(tune_returncode, 0, "Tune command failed")
+        self.assertEqual(sweep_returncode, 0, "Sweep command failed")
+
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/AutoTuner/test/files/fast-at-sweep.json
+++ b/tools/AutoTuner/test/files/fast-at-sweep.json
@@ -1,0 +1,10 @@
+{
+    "CTS_CLUSTER_SIZE": {
+        "type": "int",
+        "minmax": [
+            50,
+            51
+        ],
+        "step": 1
+    }
+}


### PR DESCRIPTION
Note - this PR is meant to run without `autotuner` tag to show that the small smoke tests can still run without

### New Testing Feature: Fast Autotuner Smoke Test

* **Test Script Addition**:
  - Added `test_fast_autotuner.sh` to automate the setup and execution of the "Fast Autotuner Smoke Test" using a virtual environment.

* **Integration into Test Helper**:
  - Modified `test_helper.sh` to trigger the "Fast Autotuner Smoke Test" for the `gcd` design on the `asap7` platform.

* **Unit Test Implementation**:
  - Added `fast_smoke_test.py` to define a unit test for the autotuner, including commands for tuning and sweeping configurations. This ensures the autotuner operates correctly with minimal samples.

* **Configuration File**:
  - Introduced `fast-at-sweep.json`, a configuration file for the autotuner, specifying a parameter sweep for `CTS_CLUSTER_SIZE` with a small range for quick testing.