### PR TITLE
[Autotuner] fix sweep log-saving directory

### DIFF
--- a/tools/AutoTuner/src/autotuner/distributed.py
+++ b/tools/AutoTuner/src/autotuner/distributed.py
@@ -565,9 +565,7 @@ def sweep():
         temp = dict()
         for value in parameter:
             temp.update(value)
-        queue.put(
-            [args, repo_dir, temp, LOCAL_DIR, SDC_ORIGINAL, FR_ORIGINAL, INSTALL_PATH]
-        )
+        queue.put([args, repo_dir, temp, SDC_ORIGINAL, FR_ORIGINAL, INSTALL_PATH])
     workers = [consumer.remote(queue) for _ in range(args.jobs)]
     print("[INFO TUN-0009] Waiting for results.")
     ray.get(workers)

--- a/tools/AutoTuner/src/autotuner/utils.py
+++ b/tools/AutoTuner/src/autotuner/utils.py
@@ -40,10 +40,10 @@ import re
 import yaml
 import subprocess
 import sys
+import uuid
+import time
 from multiprocessing import cpu_count
 from datetime import datetime
-from uuid import uuid4 as uuid
-from time import time
 
 import numpy as np
 import ray
@@ -624,15 +624,15 @@ def openroad_distributed(
     )
     if variant is None:
         variant = config.replace(" ", "_").replace("=", "_")
-    t = time()
+    t = time.time()
     metric_file = openroad(
         args=args,
         base_dir=repo_dir,
         parameters=config,
-        flow_variant=f"{uuid()}-{variant}",
+        flow_variant=f"{uuid.uuid4()}-{variant}" if variant else f"{uuid.uuid4()}",
         install_path=install_path,
     )
-    duration = time() - t
+    duration = time.time() - t
     return metric_file, duration
 
 


### PR DESCRIPTION
- Fixes a bug where an extraneous variable `LOCAL_DIR` was passed into the `consumer()` function via `openroad_distributed`. 
- Cleanup: do not use `None` in folder naming when `variant` is None.
- Uses `time.time()`, `uuid.uuid4()` for clarity.