### PR TITLE
Work around yosys-slang not building without `.git`

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -247,7 +247,8 @@ __local_build()
         ${NICE} make install -C tools/yosys -j "${PROC}" ${YOSYS_ARGS}
 
         echo "[INFO FLW-0030] Compiling yosys-slang."
-        ${NICE} make install -C tools/yosys-slang -j "${PROC}" YOSYS_PREFIX="${INSTALL_PATH}/yosys/bin/"
+        # CMAKE_FLAGS added to work around yosys-slang#141 (unable to build outside of git checkout)
+        ${NICE} make install -C tools/yosys-slang -j "${PROC}" YOSYS_PREFIX="${INSTALL_PATH}/yosys/bin/" CMAKE_FLAGS="-DYOSYS_SLANG_REVISION=unknown -DSLANG_REVISION=unknown"
 
         echo "[INFO FLW-0018] Compiling OpenROAD."
         eval ${NICE} ./tools/OpenROAD/etc/Build.sh -dir="$DIR/tools/OpenROAD/build" -threads=${PROC} -cmake=\'${OPENROAD_APP_ARGS}\'


### PR DESCRIPTION
Addresses the following from the build of Docker image:

```
17:55:26  #22 299.6 fatal: not a git repository: /OpenROAD-flow-scripts/tools/yosys-slang/../../.git/modules/tools/yosys-slang
17:55:26  #22 299.6 CMake Error at cmake/GitRevision.cmake:4 (execute_process):
17:55:26  #22 299.6   execute_process failed command indexes:
17:55:26  #22 299.6
17:55:26  #22 299.6     1: "Child return code: 128"
```