### PR TITLE
Re-worked ref_file_check.py to test specific error conditions

### DIFF
--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -27,7 +27,7 @@ python3 -m unittest tools.AutoTuner.test.smoke_test_algo_eval.${PLATFORM_WITHOUT
 
 if [ "$PLATFORM_WITHOUT_DASHES" == "asap7" ] && [ "$DESIGN_NAME" == "gcd" ]; then
   echo "Running Autotuner ref file test (only once)"
-  python3 -m unittest tools.AutoTuner.test.ref_file_check.RefFileCheck.test_files
+  python3 -m unittest tools.AutoTuner.test.ref_file_check.RefFileCheck
 
   echo "Running AutoTuner resume test (only once)"
   # Temporarily disable resume check test due to flakiness

--- a/tools/AutoTuner/test/ref_file_check.py
+++ b/tools/AutoTuner/test/ref_file_check.py
@@ -44,31 +44,66 @@ os.chdir(src_dir)
 
 
 class RefFileCheck(unittest.TestCase):
-    # only test 1 platform/design.
-    platform = "asap7"
-    design = "gcd"
+    """
+    Tests situations where a referenced file (SDC or FastRoute) is not
+    defined in the AutoTuner config
+    """
 
     def setUp(self):
-        configs = [
-            "../../test/files/no_sdc_ref.json",
-            "../../test/files/no_fr_ref.json",
-        ]
-        self.exec = AutoTunerTestUtils.get_exec_cmd()
-        self.commands = [
-            f"{self.exec}"
-            f" --design {self.design}"
-            f" --platform {self.platform}"
-            f" --config {c}"
-            f" tune --samples 1"
-            for c in configs
-        ]
+        self._cur_dir = os.path.dirname(os.path.abspath(__file__))
+        src_dir = os.path.join(self._cur_dir, "../src")
+        os.chdir(src_dir)
 
-    # Make this a test case
-    def test_files(self):
-        for c in self.commands:
-            out = subprocess.run(c, shell=True)
-            failed = out.returncode != 0
-            self.assertTrue(failed)
+        self._exec = AutoTunerTestUtils.get_exec_cmd()
+
+    def _execute_autotuner(self, platform, design, config_file, error_code=None):
+        full_path = os.path.abspath(os.path.join(self._cur_dir, config_file))
+
+        cmd = f"{self._exec} --design {design} --platform {platform} --config {full_path} tune --samples 1"
+
+        out = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+        failed = out.returncode != 0
+        self.assertTrue(failed, f"AT run with {config_file} passed")
+        if error_code:
+            self.assertTrue(
+                error_code in out.stdout,
+                f"Didn't find error code {error_code} in output '{out.stdout}'",
+            )
+
+    def test_asap_gcd_no_sdc(self):
+        """
+        Tests when SDC file is not defined, which is an error for all
+        platforms and designs
+        """
+
+        platform = "asap7"
+        design = "gcd"
+        config_file = "files/no_sdc_ref.json"
+        error_code = "[ERROR TUN-0020] No SDC reference"
+        self._execute_autotuner(platform, design, config_file, error_code)
+
+    def test_asap_gcd_no_fr(self):
+        """
+        Tests when FastRoute file is not defined, which is not an error for
+        asap platform. This test fails anyway
+        """
+
+        platform = "asap7"
+        design = "gcd"
+        config_file = "files/no_fr_ref.json"
+        self._execute_autotuner(platform, design, config_file)
+
+    def test_ihp_gcd_no_fr(self):
+        """
+        Tests when FastRoute file is not defined, which is not an error for
+        any non-asap7 platform.
+        """
+
+        platform = "ihp-sg13g2"
+        design = "gcd"
+        config_file = "files/no_fr_ref.json"
+        error_code = "[ERROR TUN-0021] No FastRoute Tcl"
+        self._execute_autotuner(platform, design, config_file, error_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previous version of ref_file_check.py checked to see if the AT run failed, but not the specific failure we are looking for. In this rev, I've split test_files() into specific test methods, so that we can check the type of failure.

Had to update the test_autotuner.sh script to call the test class in ref_file_check.py, so that all of the test methods get executed now.

Replacement for https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/2903