### PR TITLE
gitignore: fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,4 +99,7 @@ build
 metadata-base-at.json
 
 user.bazelrc
-bazel-*
+bazel-bin/
+bazel-out/
+bazel-flow/
+bazel-testlogs/

--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -2,5 +2,3 @@ settings.mk
 vars.sh
 vars.gdb
 vars.tcl
-user.bazelrc
-bazel-*


### PR DESCRIPTION
- goop to be cleaned out should be visible
- bazel project folder is git root cleanup

Speeds up local tools like grep.