### PR TITLE
Update metrics for resizer refactor

### DIFF
--- a/flow/designs/nangate45/gcd/rules-base.json
+++ b/flow/designs/nangate45/gcd/rules-base.json
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 35,
+        "value": 43,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 76,
+        "value": 81,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/sky130hd/riscv32i/rules-base.json
+++ b/flow/designs/sky130hd/riscv32i/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 20,
+        "value": 36,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {


### PR DESCRIPTION
designs/nangate45/gcd/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__setup_violation_count    |       35 |       43 | Failing  |

designs/sky130hd/gcd/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__drv__setup_violation_count    |       76 |       81 | Failing  |

designs/sky130hd/riscv32i/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       20 |       36 | Failing  |