### PR TITLE
add grt configs for asap7

### DIFF
--- a/flow/designs/asap7/jpeg/rules-base.json
+++ b/flow/designs/asap7/jpeg/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 7117.21,
+        "value": 7008.24,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 7801,
+        "value": 7648,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 66869,
+        "value": 65384,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5815,
+        "value": 5686,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5815,
+        "value": 5686,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": 0.0,
+        "value": -54.68,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 7973,
+        "value": 7738,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 2907,
+        "value": 2843,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {

--- a/flow/designs/asap7/mock-alu/rules-base.json
+++ b/flow/designs/asap7/mock-alu/rules-base.json
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -515.34,
+        "value": -521.3,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -60,7 +60,7 @@
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 148,
+        "value": 116,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {

--- a/flow/designs/asap7/riscv32i-mock-sram/fakeram7_256x32/config.mk
+++ b/flow/designs/asap7/riscv32i-mock-sram/fakeram7_256x32/config.mk
@@ -11,6 +11,7 @@ export PLACE_DENSITY = 0.80
 # fakeram7 doesn't block off M5, so limit to M4 here.
 # However, PDN will use M5, so it is still added to blockages.
 export MAX_ROUTING_LAYER = M4
+export MIN_CLK_ROUTING_LAYER = M2
 
 export PLACE_PINS_ARGS = -min_distance 6 -min_distance_in_tracks
 export IO_CONSTRAINTS  = $(DESIGN_HOME)/asap7/riscv32i-mock-sram/fakeram7_256x32/io.tcl

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -63,8 +63,11 @@ export SET_RC_TCL              = $(PLATFORM_DIR)/setRC.tcl
 
 # Route options
 export MIN_ROUTING_LAYER       ?= M2
-#export MIN_CLOCK_ROUTING_LAYER = M4
+export MIN_CLK_ROUTING_LAYER   ?= M4
 export MAX_ROUTING_LAYER       ?= M7
+
+# Define fastRoute tcl
+export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 
 # KLayout technology file
 export KLAYOUT_TECH_FILE       = $(PLATFORM_DIR)/KLayout/asap7.lyt

--- a/flow/platforms/asap7/fastroute.tcl
+++ b/flow/platforms/asap7/fastroute.tcl
@@ -1,0 +1,3 @@
+set_global_routing_layer_adjustment $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) 0.25
+set_routing_layers -clock $::env(MIN_CLK_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
+set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)


### PR DESCRIPTION
designs/asap7/mock-alu/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| finish__timing__setup__ws                     |  -515.34 |   -521.3 | Failing  |
| finish__timing__drv__hold_violation_count     |      148 |      116 | Tighten  |

designs/asap7/jpeg/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        |  7117.21 |  7008.24 | Tighten  |
| placeopt__design__instance__area              |     7801 |     7648 | Tighten  |
| placeopt__design__instance__count__stdcell    |    66869 |    65384 | Tighten  |
| cts__design__instance__count__setup_buffer    |     5815 |     5686 | Tighten  |
| cts__design__instance__count__hold_buffer     |     5815 |     5686 | Tighten  |
| finish__timing__setup__ws                     |      0.0 |   -54.68 | Failing  |
| finish__design__instance__area                |     7973 |     7738 | Tighten  |
| finish__timing__drv__setup_violation_count    |     2907 |     2843 | Tighten  |