### PR TITLE
inject macro definitions during compilation time

### DIFF
--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -15,12 +15,23 @@ COPY --link build_openroad.sh build_openroad.sh
 
 FROM orfs-base AS orfs-builder-base
 
+# Inject compiler wrapper scripts that append the macros
+RUN mkdir -p /usr/local/bin/wrapped-cc && \
+    echo '#!/bin/sh' > /usr/local/bin/wrapped-cc/gcc && \
+    echo 'exec /usr/bin/gcc -D__TIME__="\"0\"" -D__DATE__="\"0\"" -D__TIMESTAMP__="\"0\"" -Wno-builtin-macro-redefined "$@"' >> /usr/local/bin/wrapped-cc/gcc && \
+    chmod +x /usr/local/bin/wrapped-cc/gcc && \
+    ln -s /usr/local/bin/wrapped-cc/gcc /usr/local/bin/wrapped-cc/cc && \
+    echo '#!/bin/sh' > /usr/local/bin/wrapped-cc/g++ && \
+    echo 'exec /usr/bin/g++ -D__TIME__="\"0\"" -D__DATE__="\"0\"" -D__TIMESTAMP__="\"0\"" -Wno-builtin-macro-redefined "$@"' >> /usr/local/bin/wrapped-cc/g++ && \
+    chmod +x /usr/local/bin/wrapped-cc/g++
+
+# Prepend wrapper directory to PATH so they override system compilers
+ENV PATH="/usr/local/bin/wrapped-cc:$PATH"
+
 COPY --link tools tools
 ARG numThreads=$(nproc)
 
 RUN echo "" > tools/yosys/abc/.gitcommit && \
-  env CFLAGS="-Wno-builtin-macro-redefined" \
-  CXXFLAGS="-Wno-builtin-macro-redefined" \
   ./build_openroad.sh --no_init --local --threads ${numThreads}
 
 FROM orfs-base

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -15,8 +15,18 @@ COPY InstallerOpenROAD.sh \
 ARG options=""
 ARG constantBuildDir="-constant-build-dir"
 
-ENV CFLAGS="-Wno-builtin-macro-redefined"
-ENV CXXFLAGS="-Wno-builtin-macro-redefined"
+# add compiler wrapper scripts
+# inject the macro definitions during compilation only
+RUN mkdir -p /usr/local/bin/wrapped-cc && \
+    echo '#!/bin/sh' > /usr/local/bin/wrapped-cc/gcc && \
+    echo 'exec /usr/bin/gcc -D__TIME__="\"0\"" -D__DATE__="\"0\"" -D__TIMESTAMP__="\"0\"" -Wno-builtin-macro-redefined "$@"' >> /usr/local/bin/wrapped-cc/gcc && \
+    chmod +x /usr/local/bin/wrapped-cc/gcc && \
+    ln -s /usr/local/bin/wrapped-cc/gcc /usr/local/bin/wrapped-cc/cc && \
+    echo '#!/bin/sh' > /usr/local/bin/wrapped-cc/g++ && \
+    echo 'exec /usr/bin/g++ -D__TIME__="\"0\"" -D__DATE__="\"0\"" -D__TIMESTAMP__="\"0\"" -Wno-builtin-macro-redefined "$@"' >> /usr/local/bin/wrapped-cc/g++ && \
+    chmod +x /usr/local/bin/wrapped-cc/g++
+
+ENV PATH="/usr/local/bin/wrapped-cc:$PATH"
 
 RUN ./DependencyInstaller.sh -base $options $constantBuildDir \
     && ./DependencyInstaller.sh -common $options $constantBuildDir \


### PR DESCRIPTION
I've found this strategy to set the __TIME__, __DATE__ and __TIMESTAMP__ as constants without breaking Yosys build, and also without breaking the check for the C++14 support (the error that was happening with verilator).

I've tested it and I can see that what the C++ compiler sees is the constant "0", so I believe it will restore the behavior of having constant date/time in the binary.