### PR TITLE
ihp-sg13g2: Prepare Multi Corner Analysis

### DIFF
--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/config.mk
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/config.mk
@@ -3,7 +3,7 @@ export DESIGN_NICKNAME = i2c-gpio-expander
 export PLATFORM = ihp-sg13g2
 
 export VERILOG_FILES = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/$(DESIGN_NAME).v \
-                       $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/I2cGpioExpander.v 
+                       $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/I2cGpioExpander.v
 export SDC_FILE = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 
 export SEAL_GDS = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/sealring.gds.gz
@@ -15,6 +15,8 @@ export MAX_ROUTING_LAYER = TopMetal2
 
 export TNS_END_PERCENT = 100
 export PLACE_DENSITY = 0.75
+
+export CORNERS = slow fast
 
 export FOOTPRINT_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/pad.tcl
 export PDN_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/pdn.tcl

--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -11,6 +11,8 @@ ifdef FOOTPRINT_TCL
 ifdef LOAD_ADDITIONAL_FILES
   export ADDITIONAL_LEFS += $(PLATFORM_DIR)/lef/sg13g2_io.lef \
                             $(PLATFORM_DIR)/lef/bondpad_70x70.lef
+  export ADDITIONAL_SLOW_LIBS = $(ADDITIONAL_LIBS) $(PLATFORM_DIR)/lib/sg13g2_io_slow_1p08V_3p0V_125C.lib
+  export ADDITIONAL_FAST_LIBS = $(ADDITIONAL_LIBS) $(PLATFORM_DIR)/lib/sg13g2_io_fast_1p32V_3p6V_m40C.lib
   export ADDITIONAL_LIBS += $(PLATFORM_DIR)/lib/sg13g2_io_typ_1p2V_3p3V_25C.lib
   export ADDITIONAL_GDS += $(PLATFORM_DIR)/gds/sg13g2_io.gds \
                            $(PLATFORM_DIR)/gds/bondpad_70x70.gds
@@ -19,6 +21,10 @@ endif
 export TECH_LEF ?= $(PLATFORM_DIR)/lef/sg13g2_tech.lef
 export SC_LEF ?= $(PLATFORM_DIR)/lef/sg13g2_stdcell.lef
 
+export SLOW_LIB_FILES ?= $(PLATFORM_DIR)/lib/sg13g2_stdcell_slow_1p08V_125C.lib \
+                         $(ADDITIONAL_SLOW_LIBS)
+export FAST_LIB_FILES ?= $(PLATFORM_DIR)/lib/sg13g2_stdcell_fast_1p32V_m40C.lib \
+                         $(ADDITIONAL_FAST_LIBS)
 export LIB_FILES ?= $(PLATFORM_DIR)/lib/sg13g2_stdcell_typ_1p20V_25C.lib \
                     $(ADDITIONAL_LIBS)
 export GDS_FILES ?= $(PLATFORM_DIR)/gds/sg13g2_stdcell.gds \


### PR DESCRIPTION
Define the libraries for the slow and fast corner. Not enabled by default. Simply add `export CONRNERS = slow fast` to the config.mk file.