### PR TITLE
update sky130hd/microwatt metrics

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -44,11 +44,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 2198,
+        "value": 3720,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.39,
+        "value": -2.11,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -20.12,
+        "value": -18.62,
         "compare": ">="
     }
 }


### PR DESCRIPTION
designs/sky130hd/microwatt/rules-base.json updates:
[WARNING] Multiple clocks not supported. Will use first clock: ext_clk: 15.0000.
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__antenna_diodes_count           |     2198 |     3720 | Failing  |
| finish__timing__setup__ws                     |    -2.39 |    -2.11 | Tighten  |
| finish__timing__wns_percent_delay             |   -20.12 |   -18.62 | Tighten  |