### PR TITLE
[AutoTuner] add Dockerfile

### DIFF
--- a/tools/AutoTuner/.dockerignore
+++ b/tools/AutoTuner/.dockerignore
@@ -1,0 +1,8 @@
+**/*.venv
+**/__pycache__
+**/*.egg-info
+**/*.env
+**/*test
+**/*.json
+autotuner_env
+*.log

--- a/tools/AutoTuner/.gitignore
+++ b/tools/AutoTuner/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 # Autotuner env
 autotuner_env
 .env
+
+# Log files
+docker-build.log

--- a/tools/AutoTuner/Dockerfile
+++ b/tools/AutoTuner/Dockerfile
@@ -1,0 +1,25 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE:-openroad/orfs:latest}
+
+# Set workdir
+WORKDIR /OpenROAD-flow-scripts/tools/AutoTuner
+
+# Replace pre-existing AT files with local copy
+RUN rm -rf /OpenROAD-flow-scripts/tools/AutoTuner
+
+# Create venv
+RUN python3 -m venv .venv
+ENV PATH="/OpenROAD-flow-scripts/tools/AutoTuner/.venv:${PATH}"
+
+# Copy only requirements first for better caching of pip install
+COPY requirements.txt .
+
+# Upgrade pip and install Python dependencies
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements.txt
+
+# Copy full source after installing dependencies
+COPY . .
+
+# Install package in editable mode
+RUN pip3 install --no-cache-dir -e .

--- a/tools/AutoTuner/Makefile
+++ b/tools/AutoTuner/Makefile
@@ -1,0 +1,28 @@
+include .env
+export
+
+BASE_TAG=$(shell cd ../../ && ./etc/DockerTag.sh -dev)
+ORFS_IMAGE := openroad/orfs:latest
+ORFS_AUTOTUNER_IMAGE := orfs-autotuner
+
+.PHONY: clean
+clean:
+	@echo "Cleaning up old images"
+	@docker rmi ${ORFS_AUTOTUNER_IMAGE}:latest || true
+
+.PHONY: docker
+docker: clean
+	@echo "Building docker image..."
+	@docker build -t ${ORFS_AUTOTUNER_IMAGE}:latest -f Dockerfile --build-arg BASE_IMAGE=${ORFS_IMAGE} . | tee docker-build.log
+	@docker tag ${ORFS_AUTOTUNER_IMAGE}:latest ${ORFS_AUTOTUNER_IMAGE}:$(BASE_TAG)
+
+.PHONY: upload
+upload: docker
+	@echo "Uploading docker image..."
+	@docker login -u $(DOCKERHUB_USERNAME) -p $(DOCKERHUB_PASSWORD)
+	@echo "Base image: $(BASE_TAG)"
+	@docker tag ${ORFS_AUTOTUNER_IMAGE}:latest ${DOCKERHUB_USERNAME}/${ORFS_AUTOTUNER_IMAGE}:$(BASE_TAG)
+	@docker tag ${ORFS_AUTOTUNER_IMAGE}:latest ${DOCKERHUB_USERNAME}/${ORFS_AUTOTUNER_IMAGE}:latest
+	@docker push ${DOCKERHUB_USERNAME}/${ORFS_AUTOTUNER_IMAGE}:$(BASE_TAG)
+	@docker push ${DOCKERHUB_USERNAME}/${ORFS_AUTOTUNER_IMAGE}:latest
+	@docker logout


### PR DESCRIPTION
This pull request introduces several updates to improve the Docker-based workflow and environment setup for the `AutoTuner` tool. Key changes include adding a Dockerfile for building a containerized environment, updating `.dockerignore` and `.gitignore` for better file management, and creating a `Makefile` to streamline Docker image building and uploading.

### Docker Environment Setup:
* Added a new `Dockerfile` to define the containerized environment for `AutoTuner`, including steps to set up a Python virtual environment, install dependencies, and copy the source code.

### File Management:
* Updated `.dockerignore` to exclude unnecessary files and directories such as `.venv`, `__pycache__`, `*.log`, and test files from the Docker build context.
* Updated `.gitignore` to include log files such as `docker-build.log`.

### Build Automation:
* Added a `Makefile` to automate Docker image building, cleaning, and uploading, including support for tagging images and pushing them to Docker Hub.