### PR TITLE
nangate45/swerv_wrapper: decrease routing layer adjustment

### DIFF
--- a/flow/designs/nangate45/swerv_wrapper/fastroute.tcl
+++ b/flow/designs/nangate45/swerv_wrapper/fastroute.tcl
@@ -1,4 +1,4 @@
-set_global_routing_layer_adjustment metal2-metal3 0.25
-set_global_routing_layer_adjustment metal4-$::env(MAX_ROUTING_LAYER) 0.15
+set_global_routing_layer_adjustment metal2-metal3 0.20
+set_global_routing_layer_adjustment metal4-$::env(MAX_ROUTING_LAYER) 0.10
 
 set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)


### PR DESCRIPTION
For [#6967](https://github.com/The-OpenROAD-Project/OpenROAD/pull/6967)

This should solve the high congestion during  global routing in `ngt45/swerv_wrapper`.