### PR TITLE
switched asap7 cva6 from die/core area to utilization with margin

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -79,10 +79,10 @@ export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x256.lib
 
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
 
-export DIE_AREA               = 0 0 350 350
-export CORE_AREA              = 1.08 1.08 340 340
+export CORE_UTILIZATION       = 40
+export CORE_MARGIN            = 2
+export MACRO_HALO             = 5
 export PLACE_DENSITY          = 0.50
-export MACRO_HALO             = 5 5
 
 # a smoketest for this option, there are a
 # few last gasp iterations

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 40692.1,
+        "value": 40631.65,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -12,7 +12,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 164118,
+        "value": 163049,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 14271,
+        "value": 14178,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 14271,
+        "value": 14178,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1618999,
+        "value": 1884562,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -56,15 +56,15 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 7136,
+        "value": 7089,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
-        "value": 105,
+        "value": 101,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -20.43,
+        "value": -20.3,
         "compare": ">="
     }
 }


### PR DESCRIPTION
Eventually, I'd like to be able to run cva6 using the AutoTuner and the core utilization approach is the only one that's currently supported.

## CI Could not Update Rules
[ERROR] asap7/aes-block: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/aes-mbff: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/aes: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/aes_lvt: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/ethmac: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/ethmac_lvt: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/gcd-ccs: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/gcd: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/jpeg_lvt: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/mock-alu: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/mock-array: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/riscv32i-mock-sram: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/riscv32i: No metrics found, please check the latest CI build for issues.
[ERROR] asap7/uart: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/aes-hybrid: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/aes: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/riscv32i: No metrics found, please check the latest CI build for issues.
[ERROR] gf180/uart-blocks: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/aes: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/gcd: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/i2c-gpio-expander: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/riscv32i: No metrics found, please check the latest CI build for issues.
[ERROR] ihp-sg13g2/spi: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/aes: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/ariane133: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/bp_be_top: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/bp_fe_top: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/bp_multi_top: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/dynamic_node: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/gcd: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/swerv: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/swerv_wrapper: No metrics found, please check the latest CI build for issues.
[ERROR] nangate45/tinyRocket: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/aes: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/chameleon: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/gcd: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/microwatt: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hd/riscv32i: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hs/aes: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hs/gcd: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hs/ibex: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hs/jpeg: No metrics found, please check the latest CI build for issues.
[ERROR] sky130hs/riscv32i: No metrics found, please check the latest CI build for issues.
