### PR TITLE
updated asap7 platform config.mk to support multi vt

### DIFF
--- a/flow/designs/asap7/jpeg_lvt/config.mk
+++ b/flow/designs/asap7/jpeg_lvt/config.mk
@@ -8,15 +8,6 @@ export VERILOG_INCLUDE_DIRS   = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/include
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/jpeg_encoder15_7nm.sdc
 export ABC_AREA               = 1
 
-export ADDITIONAL_LIBS        = $(LIB_DIR)/asap7sc7p5t_AO_LVT_FF_nldm_211120.lib.gz \
-                                 $(LIB_DIR)/asap7sc7p5t_INVBUF_LVT_FF_nldm_220122.lib.gz \
-			         $(LIB_DIR)/asap7sc7p5t_OA_LVT_FF_nldm_211120.lib.gz \
-			         $(LIB_DIR)/asap7sc7p5t_SIMPLE_LVT_FF_nldm_211120.lib.gz \
-			         $(LIB_DIR)/asap7sc7p5t_SEQ_LVT_FF_nldm_220123.lib 
-
-export ADDITIONAL_GDS  = $(PLATFORM_DIR)/gds/asap7sc7p5t_28_L_220121a.gds
-export ADDITIONAL_LEFS  = $(PLATFORM_DIR)/lef/asap7sc7p5t_28_L_1x_220121a.lef
-
 export CORE_UTILIZATION       = 30
 export CORE_ASPECT_RATIO      = 1
 export CORE_MARGIN            = 2
@@ -24,4 +15,7 @@ export PLACE_DENSITY          = 0.60
 
 export TNS_END_PERCENT        = 100
 export RECOVER_POWER          = 100
+
+export ASAP7_USE_VT           = LVT
+
 

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -80,93 +80,113 @@ export KLAYOUT_DRC_FILE = $(PLATFORM_DIR)/drc/asap7.lydrc
 # OpenRCX extRules
 export RCX_RULES               = $(PLATFORM_DIR)/rcx_patterns.rules
 
-# XS - defining function for using LVT
-ifeq ($(ASAP7_USE_VT), LVT)
-   export VT_TAG = L
-else ifeq ($(ASAP7_USE_VT), SLVT)
-   export VT_TAG = SL
-else
-   # Default to RVT
-   export VT_TAG = R
-endif
+# PLACEHOLDER gets replaced with the appropriate VT tag in the following templates
+export BC_NLDM_DFF_LIB_FILE_T    = $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_FF_nldm_220123.lib
+export BC_CCS_DFF_LIB_FILE_T     = $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_FF_ccs_220123.lib
+export WC_NLDM_DFF_LIB_FILE_T    = $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_SS_nldm_220123.lib
+export TC_NLDM_DFF_LIB_FILE_T    = $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_TT_nldm_220123.lib
+export BC_NLDM_LIB_FILES_T       = $(LIB_DIR)/asap7sc7p5t_AO_PLACEHOLDERVT_FF_nldm_211120.lib.gz \
+			           $(LIB_DIR)/asap7sc7p5t_INVBUF_PLACEHOLDERVT_FF_nldm_220122.lib.gz \
+			           $(LIB_DIR)/asap7sc7p5t_OA_PLACEHOLDERVT_FF_nldm_211120.lib.gz \
+			           $(LIB_DIR)/asap7sc7p5t_SIMPLE_PLACEHOLDERVT_FF_nldm_211120.lib.gz \
+			           $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_FF_nldm_220123.lib
+export BC_CCS_LIB_FILES_T        = $(LIB_DIR)/asap7sc7p5t_AO_PLACEHOLDERVT_FF_ccs_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_INVBUF_PLACEHOLDERVT_FF_ccs_220122.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_OA_PLACEHOLDERVT_FF_ccs_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_SIMPLE_PLACEHOLDERVT_FF_ccs_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_FF_ccs_220123.lib
+export WC_NLDM_LIB_FILES_T       = $(LIB_DIR)/asap7sc7p5t_AO_PLACEHOLDERVT_SS_nldm_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_INVBUF_PLACEHOLDERVT_SS_nldm_220122.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_OA_PLACEHOLDERVT_SS_nldm_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_SS_nldm_220123.lib \
+				   $(LIB_DIR)/asap7sc7p5t_SIMPLE_PLACEHOLDERVT_SS_nldm_211120.lib.gz
+export TC_NLDM_LIB_FILES_T       = $(LIB_DIR)/asap7sc7p5t_AO_PLACEHOLDERVT_TT_nldm_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_INVBUF_PLACEHOLDERVT_TT_nldm_220122.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_OA_PLACEHOLDERVT_TT_nldm_211120.lib.gz \
+				   $(LIB_DIR)/asap7sc7p5t_SEQ_PLACEHOLDERVT_TT_nldm_220123.lib \
+				   $(LIB_DIR)/asap7sc7p5t_SIMPLE_PLACEHOLDERVT_TT_nldm_211120.lib.gz
+export FILL_CELLS_T              = FILLERxp5_ASAP7_75t_ \
+                                   FILLER_ASAP7_75t_ \
+                                   DECAPx1_ASAP7_75t_ \
+                                   DECAPx2_ASAP7_75t_ \
+                                   DECAPx4_ASAP7_75t_ \
+                                   DECAPx6_ASAP7_75t_ \
+                                   DECAPx10_ASAP7_75t_
 
+# Default to RVT if unset
+export VT_LIST = $(if $(strip $(ASAP7_USE_VT)), $(ASAP7_USE_VT), RVT)
+
+# # The first VT in the ASAP7_USE_VT list is the primary VT. The others get added to OTHER_VT
+export PRIMARY_VT = $(word 1, $(VT_LIST))
+export PRIMARY_VT_TAG = $(strip $(patsubst %VT, %, $(PRIMARY_VT)))
+export OTHER_VT = $(wordlist 2, $(words $(VT_LIST)), $(VT_LIST))
+
+## Set cells based on the primary VT first
 # Set the TIEHI/TIELO cells
 # These are used in yosys synthesis to avoid logical 1/0's in the netlist
-export TIEHI_CELL_AND_PORT     ?= TIEHIx1_ASAP7_75t_$(VT_TAG) H
-export TIELO_CELL_AND_PORT     ?= TIELOx1_ASAP7_75t_$(VT_TAG) L
+export TIEHI_CELL_AND_PORT     ?= TIEHIx1_ASAP7_75t_$(PRIMARY_VT_TAG) H
+export TIELO_CELL_AND_PORT     ?= TIELOx1_ASAP7_75t_$(PRIMARY_VT_TAG) L
 
 # Used in synthesis
-export MIN_BUF_CELL_AND_PORTS  ?= BUFx2_ASAP7_75t_$(VT_TAG) A Y
+export MIN_BUF_CELL_AND_PORTS  ?= BUFx2_ASAP7_75t_$(PRIMARY_VT_TAG) A Y
 
-export HOLD_BUF_CELL           ?= BUFx2_ASAP7_75t_$(VT_TAG)
+export HOLD_BUF_CELL           ?= BUFx2_ASAP7_75t_$(PRIMARY_VT_TAG)
 
-export ABC_DRIVER_CELL         ?= BUFx2_ASAP7_75t_$(VT_TAG)
+export ABC_DRIVER_CELL         ?= BUFx2_ASAP7_75t_$(PRIMARY_VT_TAG)
 
 # Fill cells used in fill cell insertion
-export FILL_CELLS              ?= FILLERxp5_ASAP7_75t_$(VT_TAG) \
-                                  FILLER_ASAP7_75t_$(VT_TAG) \
-                                  DECAPx1_ASAP7_75t_$(VT_TAG) \
-                                  DECAPx2_ASAP7_75t_$(VT_TAG) \
-                                  DECAPx4_ASAP7_75t_$(VT_TAG) \
-                                  DECAPx6_ASAP7_75t_$(VT_TAG) \
-                                  DECAPx10_ASAP7_75t_$(VT_TAG)
+export FILL_CELLS              ?= $(addsuffix $(PRIMARY_VT_TAG), $(FILL_CELLS_T))
 
-export TAP_CELL_NAME	       ?= TAPCELL_ASAP7_75t_$(VT_TAG)
+export TAP_CELL_NAME	       ?= TAPCELL_ASAP7_75t_$(PRIMARY_VT_TAG)
 
 # GDS_FILES has to be = vs. ?= because GDS_FILES gets set in the ORFS Makefile
-export GDS_FILES               = $(PLATFORM_DIR)/gds/asap7sc7p5t_28_$(VT_TAG)_220121a.gds \
-			         $(ADDITIONAL_GDS)
+export GDS_FILES               = $(PLATFORM_DIR)/gds/asap7sc7p5t_28_$(PRIMARY_VT_TAG)_220121a.gds
 
-export SC_LEF                  ?= $(PLATFORM_DIR)/lef/asap7sc7p5t_28_$(VT_TAG)_1x_220121a.lef
+export SC_LEF                  ?= $(PLATFORM_DIR)/lef/asap7sc7p5t_28_$(PRIMARY_VT_TAG)_1x_220121a.lef
 
 # Yosys mapping files
-export LATCH_MAP_FILE          ?= $(PLATFORM_DIR)/yoSys/cells_latch_$(VT_TAG).v
-export CLKGATE_MAP_FILE        ?= $(PLATFORM_DIR)/yoSys/cells_clkgate_$(VT_TAG).v
-export ADDER_MAP_FILE          ?= $(PLATFORM_DIR)/yoSys/cells_adders_$(VT_TAG).v
+export LATCH_MAP_FILE          ?= $(PLATFORM_DIR)/yoSys/cells_latch_$(PRIMARY_VT_TAG).v
+export CLKGATE_MAP_FILE        ?= $(PLATFORM_DIR)/yoSys/cells_clkgate_$(PRIMARY_VT_TAG).v
+export ADDER_MAP_FILE          ?= $(PLATFORM_DIR)/yoSys/cells_adders_$(PRIMARY_VT_TAG).v
 
-export BC_NLDM_DFF_LIB_FILE    ?= $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_FF_nldm_220123.lib
-
-export BC_NLDM_LIB_FILES       ?= $(LIB_DIR)/asap7sc7p5t_AO_$(VT_TAG)VT_FF_nldm_211120.lib.gz \
-			          $(LIB_DIR)/asap7sc7p5t_INVBUF_$(VT_TAG)VT_FF_nldm_220122.lib.gz \
-			          $(LIB_DIR)/asap7sc7p5t_OA_$(VT_TAG)VT_FF_nldm_211120.lib.gz \
-			          $(LIB_DIR)/asap7sc7p5t_SIMPLE_$(VT_TAG)VT_FF_nldm_211120.lib.gz \
-			          $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_FF_nldm_220123.lib
-
-export BC_CCS_LIB_FILES        ?= $(LIB_DIR)/asap7sc7p5t_AO_$(VT_TAG)VT_FF_ccs_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_INVBUF_$(VT_TAG)VT_FF_ccs_220122.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_OA_$(VT_TAG)VT_FF_ccs_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_SIMPLE_$(VT_TAG)VT_FF_ccs_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_FF_ccs_220123.lib \
+export BC_NLDM_DFF_LIB_FILE    ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(BC_NLDM_DFF_LIB_FILE_T))
+export BC_NLDM_LIB_FILES       ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(BC_NLDM_LIB_FILES_T))
+export BC_CCS_LIB_FILES        ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(BC_CCS_LIB_FILES_T)) \
 				  $(BC_ADDITIONAL_LIBS)
+export BC_CCS_DFF_LIB_FILE     ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(BC_CCS_DFF_LIB_FILE_T))
 
-export BC_CCS_DFF_LIB_FILE     ?= $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_FF_ccs_220123.lib
+export WC_NLDM_DFF_LIB_FILE    ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(WC_NLDM_DFF_LIB_FILE_T))
+export WC_NLDM_LIB_FILES       ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(WC_NLDM_LIB_FILES_T))
 
-export WC_NLDM_DFF_LIB_FILE    ?= $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_SS_nldm_220123.lib
-
-export WC_NLDM_LIB_FILES       ?= $(LIB_DIR)/asap7sc7p5t_AO_$(VT_TAG)VT_SS_nldm_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_INVBUF_$(VT_TAG)VT_SS_nldm_220122.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_OA_$(VT_TAG)VT_SS_nldm_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_SS_nldm_220123.lib \
-				  $(LIB_DIR)/asap7sc7p5t_SIMPLE_$(VT_TAG)VT_SS_nldm_211120.lib.gz
-
-export TC_NLDM_DFF_LIB_FILE    ?= $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_TT_nldm_220123.lib
-
-export TC_NLDM_LIB_FILES       ?= $(LIB_DIR)/asap7sc7p5t_AO_$(VT_TAG)VT_TT_nldm_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_INVBUF_$(VT_TAG)VT_TT_nldm_220122.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_OA_$(VT_TAG)VT_TT_nldm_211120.lib.gz \
-				  $(LIB_DIR)/asap7sc7p5t_SEQ_$(VT_TAG)VT_TT_nldm_220123.lib \
-				  $(LIB_DIR)/asap7sc7p5t_SIMPLE_$(VT_TAG)VT_TT_nldm_211120.lib.gz
+export TC_NLDM_DFF_LIB_FILE    ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(TC_NLDM_DFF_LIB_FILE_T))
+export TC_NLDM_LIB_FILES       ?= $(subst PLACEHOLDER,$(PRIMARY_VT_TAG),$(TC_NLDM_LIB_FILES_T))
 
 ifeq ($(CLUSTER_FLOPS),1)
    # Add the multi-bit FF for clustering.  These are single corner libraries.
-   export ADDITIONAL_LIBS      += $(LIB_DIR)/asap7sc7p5t_DFFHQNH2V2X_$(VT_TAG)VT_TT_nldm_FAKE.lib \
-                                  $(LIB_DIR)/asap7sc7p5t_DFFHQNV2X_$(VT_TAG)VT_TT_nldm_FAKE.lib
+   export ADDITIONAL_LIBS      += $(LIB_DIR)/asap7sc7p5t_DFFHQNH2V2X_$(PRIMARY_VT_TAG)VT_TT_nldm_FAKE.lib \
+                                  $(LIB_DIR)/asap7sc7p5t_DFFHQNV2X_$(PRIMARY_VT_TAG)VT_TT_nldm_FAKE.lib
 
    export ADDITIONAL_LEFS      += $(PLATFORM_DIR)/lef/asap7sc7p5t_DFFHQNH2V2X.lef \
                                   $(PLATFORM_DIR)/lef/asap7sc7p5t_DFFHQNV2X.lef
    export ADDITIONAL_SITES     += asap7sc7p5t_pg
    export GDS_ALLOW_EMPTY      ?= DFFHQN[VH][24].*
 endif
+
+### Add additional files to the variables based on the OTHER_VT list
+$(foreach vt_type,$(OTHER_VT),\
+  $(eval OTHER_VT_TAG = $(strip $(patsubst %VT, %, $(vt_type)))) \
+  $(eval ADDITIONAL_LEFS += $(PLATFORM_DIR)/lef/asap7sc7p5t_28_$(OTHER_VT_TAG)_1x_220121a.lef) \
+  $(eval BC_NLDM_DFF_LIB_FILE += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(BC_NLDM_DFF_LIB_FILE_T))) \
+  $(eval BC_CCS_DFF_LIB_FILE += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(BC_CCS_DFF_LIB_FILE_T))) \
+  $(eval WC_NLDM_DFF_LIB_FILE += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(WC_NLDM_DFF_LIB_FILE_T))) \
+  $(eval TC_NLDM_DFF_LIB_FILE += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(TC_NLDM_DFF_LIB_FILE_T))) \
+  $(eval BC_NLDM_LIB_FILES += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(BC_NLDM_LIB_FILES_T))) \
+  $(eval BC_CCS_LIB_FILES += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(BC_CCS_LIB_FILES_T))) \
+  $(eval WC_NLDM_LIB_FILES += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(WC_NLDM_LIB_FILES_T))) \
+  $(eval TC_NLDM_LIB_FILES += $(subst PLACEHOLDER,$(OTHER_VT_TAG),$(TC_NLDM_LIB_FILES_T))) \
+  $(eval GDS_FILES += $(PLATFORM_DIR)/gds/asap7sc7p5t_28_$(OTHER_VT_TAG)_220121a.gds) \
+  $(eval FILL_CELLS += $(addsuffix $(PRIMARY_VT_TAG), $(FILL_CELLS_T))) \
+)
 
 # Dont use SC library based on CORNER selection
 #
@@ -176,6 +196,7 @@ endif
 export CORNER ?= BC
 export LIB_FILES             += $($(CORNER)_$(LIB_MODEL)_LIB_FILES)
 export LIB_FILES             += $(ADDITIONAL_LIBS)
+export GDS_FILES             += $(ADDITIONAL_GDS)
 export DB_FILES              += $(realpath $($(CORNER)_DB_FILES))
 export TEMPERATURE            = $($(CORNER)_TEMPERATURE)
 export VOLTAGE                = $($(CORNER)_VOLTAGE)

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_AO_LVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_AO_LVT_TT_201020.v
@@ -1,0 +1,3627 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_AO_LVT_TT_201020 created by Liberate 18.1.0.293 on Sat Nov 28 03:36:02 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module A2O1A1Ixp33_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module A2O1A1O1Ixp25_ASAP7_75t_L (Y, A1, A2, B, C, D);
+	output Y;
+	input A1, A2, B, C, D;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, D__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	and (int_fwire_0, C__bar, D__bar);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar, D__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar, D__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO211x2_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO21x1_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO21x2_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO221x1_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO221x2_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO222x2_ASAP7_75t_L (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2);
+	and (int_fwire_2, A1, A2);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO22x1_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO22x2_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO31x2_ASAP7_75t_L (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2, A3);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO322x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO32x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO32x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO331x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO331x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO332x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO332x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO333x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2, C3);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO333x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2, C3);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO33x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3) | (A2 & A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3) | (A1 & A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3) | (A1 & A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3) | (~A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3) | (~A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2) | (~A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI211x1_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI211xp5_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21x1_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21xp33_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21xp5_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI221x1_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar, C__bar);
+	and (int_fwire_3, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2) | (~A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI221xp5_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar, C__bar);
+	and (int_fwire_3, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI222xp33_ASAP7_75t_L (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C1__bar, C2__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7;
+
+	not (C2__bar, C2);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A2__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_3, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_6, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_7, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C1 & ~C2) | (A2 & ~B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C1 & ~C2) | (A1 & ~B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22x1_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22xp33_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22xp5_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI311xp33_ASAP7_75t_L (Y, A1, A2, A3, B, C);
+	output Y;
+	input A1, A2, A3, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar, C__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~C) | (~A1 & ~A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B) | (~A1 & ~A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI31xp33_ASAP7_75t_L (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3) | (~A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI31xp67_ASAP7_75t_L (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3) | (~A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI321xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, C);
+	output Y;
+	input A1, A2, A3, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A3__bar, B1__bar, C__bar);
+	not (A2__bar, A2);
+	and (int_fwire_2, A2__bar, B2__bar, C__bar);
+	and (int_fwire_3, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar, C__bar);
+	and (int_fwire_5, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C) | (~A1 & ~A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C) | (~A1 & ~A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2) | (~A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2) | (~A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2) | (~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI322xp5_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C1__bar;
+	wire C2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3, int_fwire_4;
+	wire int_fwire_5, int_fwire_6, int_fwire_7;
+	wire int_fwire_8, int_fwire_9, int_fwire_10;
+	wire int_fwire_11;
+
+	not (C2__bar, C2);
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_3, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_4, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_6, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_7, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_8, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_9, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_10, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_11, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C1 & C2) | (~A1 & ~A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI32xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+	wire int_fwire_4, int_fwire_5;
+
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A3__bar, B1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_2, A2__bar, B2__bar);
+	and (int_fwire_3, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar);
+	and (int_fwire_5, A1__bar, B1__bar);
+	or (Y, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2) | (~A1 & ~A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1) | (~A1 & ~A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI331xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3, int_fwire_4;
+	wire int_fwire_5, int_fwire_6, int_fwire_7;
+	wire int_fwire_8;
+
+	not (C1__bar, C1);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_1, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_3, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_4, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_5, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_6, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_7, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_8, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI332xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+	wire int_fwire_4, int_fwire_5, int_fwire_6;
+	wire int_fwire_7, int_fwire_8, int_fwire_9;
+	wire int_fwire_10, int_fwire_11, int_fwire_12;
+	wire int_fwire_13, int_fwire_14, int_fwire_15;
+	wire int_fwire_16, int_fwire_17;
+
+	not (C2__bar, C2);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_2, A3__bar, B2__bar, C2__bar);
+	and (int_fwire_3, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_4, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_5, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_6, A2__bar, B3__bar, C2__bar);
+	and (int_fwire_7, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_8, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_9, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_10, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_11, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_12, A1__bar, B3__bar, C2__bar);
+	and (int_fwire_13, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_14, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_15, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_16, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_17, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI333xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, C3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	not (C3__bar, C3);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C3__bar);
+	not (C2__bar, C2);
+	and (int_fwire_1, A3__bar, B3__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_2, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_3, A3__bar, B2__bar, C3__bar);
+	and (int_fwire_4, A3__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_6, A3__bar, B1__bar, C3__bar);
+	and (int_fwire_7, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_8, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_9, A2__bar, B3__bar, C3__bar);
+	and (int_fwire_10, A2__bar, B3__bar, C2__bar);
+	and (int_fwire_11, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_12, A2__bar, B2__bar, C3__bar);
+	and (int_fwire_13, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_14, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_15, A2__bar, B1__bar, C3__bar);
+	and (int_fwire_16, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_17, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_18, A1__bar, B3__bar, C3__bar);
+	and (int_fwire_19, A1__bar, B3__bar, C2__bar);
+	and (int_fwire_20, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_21, A1__bar, B2__bar, C3__bar);
+	and (int_fwire_22, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_23, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_24, A1__bar, B1__bar, C3__bar);
+	and (int_fwire_25, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_26, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI33xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar);
+	not (B2__bar, B2);
+	and (int_fwire_1, A3__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_3, A2__bar, B3__bar);
+	and (int_fwire_4, A2__bar, B2__bar);
+	and (int_fwire_5, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_6, A1__bar, B3__bar);
+	and (int_fwire_7, A1__bar, B2__bar);
+	and (int_fwire_8, A1__bar, B1__bar);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3) | (A2 & A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3) | (A1 & A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3) | (A1 & A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3) | (~A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3) | (~A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2) | (~A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_AO_SLVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_AO_SLVT_TT_201020.v
@@ -1,0 +1,3627 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_AO_SLVT_TT_201020 created by Liberate 18.1.0.293 on Sat Nov 28 03:36:02 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module A2O1A1Ixp33_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module A2O1A1O1Ixp25_ASAP7_75t_SL (Y, A1, A2, B, C, D);
+	output Y;
+	input A1, A2, B, C, D;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, D__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	and (int_fwire_0, C__bar, D__bar);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar, D__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar, D__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO211x2_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO21x1_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO21x2_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO221x1_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO221x2_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO222x2_ASAP7_75t_SL (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2);
+	and (int_fwire_2, A1, A2);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO22x1_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO22x2_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO31x2_ASAP7_75t_SL (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire int_fwire_0;
+
+	and (int_fwire_0, A1, A2, A3);
+	or (Y, int_fwire_0, B);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO322x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO32x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO32x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO331x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO331x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0, C);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO332x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO332x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO333x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2, C3);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO333x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, C1, C2, C3);
+	and (int_fwire_1, B1, B2, B3);
+	and (int_fwire_2, A1, A2, A3);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AO33x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, B1, B2, B3);
+	and (int_fwire_1, A1, A2, A3);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3) | (A2 & A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3) | (A1 & A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3) | (A1 & A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3) | (~A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3) | (~A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2) | (~A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI211x1_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI211xp5_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21x1_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21xp33_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI21xp5_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+		if ((~A1 & ~A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI221x1_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar, C__bar);
+	and (int_fwire_3, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2) | (~A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI221xp5_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar, C__bar);
+	and (int_fwire_3, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI222xp33_ASAP7_75t_SL (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C1__bar, C2__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7;
+
+	not (C2__bar, C2);
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A2__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_3, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_6, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_7, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2 & ~C1 & ~C2) | (A2 & ~B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2 & ~C1 & ~C2) | (A1 & ~B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22x1_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22xp33_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI22xp5_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3;
+
+	not (B2__bar, B2);
+	not (A2__bar, A2);
+	and (int_fwire_0, A2__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B2__bar);
+	and (int_fwire_3, A1__bar, B1__bar);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI311xp33_ASAP7_75t_SL (Y, A1, A2, A3, B, C);
+	output Y;
+	input A1, A2, A3, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, C__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar, C__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar, C__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~C) | (~A1 & ~A2 & A3 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~C))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B) | (~A1 & ~A2 & A3 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI31xp33_ASAP7_75t_SL (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3) | (~A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI31xp67_ASAP7_75t_SL (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B__bar);
+	not (A2__bar, A2);
+	and (int_fwire_1, A2__bar, B__bar);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3) | (~A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI321xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, C);
+	output Y;
+	input A1, A2, A3, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar, C__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A3__bar, B1__bar, C__bar);
+	not (A2__bar, A2);
+	and (int_fwire_2, A2__bar, B2__bar, C__bar);
+	and (int_fwire_3, A2__bar, B1__bar, C__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar, C__bar);
+	and (int_fwire_5, A1__bar, B1__bar, C__bar);
+	or (Y, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C) | (~A1 & ~A2 & A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C) | (~A1 & ~A2 & A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2) | (~A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2) | (~A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2) | (~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI322xp5_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C1__bar;
+	wire C2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3, int_fwire_4;
+	wire int_fwire_5, int_fwire_6, int_fwire_7;
+	wire int_fwire_8, int_fwire_9, int_fwire_10;
+	wire int_fwire_11;
+
+	not (C2__bar, C2);
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_3, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_4, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_6, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_7, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_8, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_9, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_10, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_11, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C1 & C2) | (~A1 & ~A2 & A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI32xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+	wire int_fwire_4, int_fwire_5;
+
+	not (B2__bar, B2);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_1, A3__bar, B1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_2, A2__bar, B2__bar);
+	and (int_fwire_3, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_4, A1__bar, B2__bar);
+	and (int_fwire_5, A1__bar, B1__bar);
+	or (Y, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2) | (~A1 & ~A2 & A3 & B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1) | (~A1 & ~A2 & A3 & B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI331xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2, int_fwire_3, int_fwire_4;
+	wire int_fwire_5, int_fwire_6, int_fwire_7;
+	wire int_fwire_8;
+
+	not (C1__bar, C1);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_1, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_3, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_4, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_5, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_6, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_7, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_8, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI332xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2, int_fwire_3;
+	wire int_fwire_4, int_fwire_5, int_fwire_6;
+	wire int_fwire_7, int_fwire_8, int_fwire_9;
+	wire int_fwire_10, int_fwire_11, int_fwire_12;
+	wire int_fwire_13, int_fwire_14, int_fwire_15;
+	wire int_fwire_16, int_fwire_17;
+
+	not (C2__bar, C2);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_1, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_2, A3__bar, B2__bar, C2__bar);
+	and (int_fwire_3, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_4, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_5, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_6, A2__bar, B3__bar, C2__bar);
+	and (int_fwire_7, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_8, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_9, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_10, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_11, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_12, A1__bar, B3__bar, C2__bar);
+	and (int_fwire_13, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_14, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_15, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_16, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_17, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI333xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, C3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	not (C3__bar, C3);
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar, C3__bar);
+	not (C2__bar, C2);
+	and (int_fwire_1, A3__bar, B3__bar, C2__bar);
+	not (C1__bar, C1);
+	and (int_fwire_2, A3__bar, B3__bar, C1__bar);
+	not (B2__bar, B2);
+	and (int_fwire_3, A3__bar, B2__bar, C3__bar);
+	and (int_fwire_4, A3__bar, B2__bar, C2__bar);
+	and (int_fwire_5, A3__bar, B2__bar, C1__bar);
+	not (B1__bar, B1);
+	and (int_fwire_6, A3__bar, B1__bar, C3__bar);
+	and (int_fwire_7, A3__bar, B1__bar, C2__bar);
+	and (int_fwire_8, A3__bar, B1__bar, C1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_9, A2__bar, B3__bar, C3__bar);
+	and (int_fwire_10, A2__bar, B3__bar, C2__bar);
+	and (int_fwire_11, A2__bar, B3__bar, C1__bar);
+	and (int_fwire_12, A2__bar, B2__bar, C3__bar);
+	and (int_fwire_13, A2__bar, B2__bar, C2__bar);
+	and (int_fwire_14, A2__bar, B2__bar, C1__bar);
+	and (int_fwire_15, A2__bar, B1__bar, C3__bar);
+	and (int_fwire_16, A2__bar, B1__bar, C2__bar);
+	and (int_fwire_17, A2__bar, B1__bar, C1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_18, A1__bar, B3__bar, C3__bar);
+	and (int_fwire_19, A1__bar, B3__bar, C2__bar);
+	and (int_fwire_20, A1__bar, B3__bar, C1__bar);
+	and (int_fwire_21, A1__bar, B2__bar, C3__bar);
+	and (int_fwire_22, A1__bar, B2__bar, C2__bar);
+	and (int_fwire_23, A1__bar, B2__bar, C1__bar);
+	and (int_fwire_24, A1__bar, B1__bar, C3__bar);
+	and (int_fwire_25, A1__bar, B1__bar, C2__bar);
+	and (int_fwire_26, A1__bar, B1__bar, C1__bar);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3 & ~C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3 & ~C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3 & ~C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C2 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C2 & C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C3) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~B3 & C1 & C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AOI33xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	not (B3__bar, B3);
+	not (A3__bar, A3);
+	and (int_fwire_0, A3__bar, B3__bar);
+	not (B2__bar, B2);
+	and (int_fwire_1, A3__bar, B2__bar);
+	not (B1__bar, B1);
+	and (int_fwire_2, A3__bar, B1__bar);
+	not (A2__bar, A2);
+	and (int_fwire_3, A2__bar, B3__bar);
+	and (int_fwire_4, A2__bar, B2__bar);
+	and (int_fwire_5, A2__bar, B1__bar);
+	not (A1__bar, A1);
+	and (int_fwire_6, A1__bar, B3__bar);
+	and (int_fwire_7, A1__bar, B2__bar);
+	and (int_fwire_8, A1__bar, B1__bar);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((A2 & A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & B2 & ~B3) | (A2 & A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((A2 & A3 & ~B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((A1 & A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & B2 & ~B3) | (A1 & A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((A1 & A3 & ~B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~B3) | (A1 & A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B2 & B3) | (~A1 & A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B2 & B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B3) | (~A1 & A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2) | (~A1 & A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & ~A3 & B1 & B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_INVBUF_LVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_INVBUF_LVT_TT_201020.v
@@ -1,0 +1,663 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_INVBUF_LVT_TT_201020 created by Liberate 18.1.0.293 on Mon Dec  7 13:57:05 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx10_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx12_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx12f_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx16f_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx24_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx2_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx3_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx4_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx4f_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx5_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx6f_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module BUFx8_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx10_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx11_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx12_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx14_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx16_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx20_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx5p33_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx6p67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx8_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module CKINVDCx9p33_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB1xp67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB2xp67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB3xp67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB4xp67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx11_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx13_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx1_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx2_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx3_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx4_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx5_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx6_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx8_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVxp33_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVxp67_ASAP7_75t_L (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_INVBUF_SLVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_INVBUF_SLVT_TT_201020.v
@@ -1,6 +1,6 @@
 // BSD 3-Clause License
 // 
-// Copyright 2021 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
 // University
 // 
 // Redistribution and use in source and binary forms, with or without
@@ -29,12 +29,12 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
-// Verilog for library /home/anolas19/Liberate/Verilog/asap7sc6T_INVBUF_RVT_FF_210905 created by Liberate 18.1.0.293 on Thu Sep 16 23:50:24 MST 2021 for SDF version 2.1
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_INVBUF_SLVT_TT_201020 created by Liberate 18.1.0.293 on Mon Dec  7 13:57:05 MST 2020 for SDF version 2.1
 
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx10_ASAP7_6t_R (Y, A);
+module BUFx10_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -51,7 +51,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx12_ASAP7_6t_R (Y, A);
+module BUFx12_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -68,7 +68,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx12q_ASAP7_6t_R (Y, A);
+module BUFx12f_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -85,7 +85,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx16q_ASAP7_6t_R (Y, A);
+module BUFx16f_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -102,7 +102,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx24_ASAP7_6t_R (Y, A);
+module BUFx24_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -119,7 +119,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx2_ASAP7_6t_R (Y, A);
+module BUFx2_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -136,7 +136,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx3_ASAP7_6t_R (Y, A);
+module BUFx3_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -153,7 +153,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx4_ASAP7_6t_R (Y, A);
+module BUFx4_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -170,7 +170,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx4q_ASAP7_6t_R (Y, A);
+module BUFx4f_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -187,7 +187,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx5_ASAP7_6t_R (Y, A);
+module BUFx5_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -204,7 +204,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx6q_ASAP7_6t_R (Y, A);
+module BUFx6f_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -221,7 +221,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module BUFx8_ASAP7_6t_R (Y, A);
+module BUFx8_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -238,75 +238,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module HB1x1_ASAP7_6t_R (Y, A);
-	output Y;
-	input A;
-
-	// Function
-	buf (Y, A);
-
-	// Timing
-	specify
-		(A => Y) = 0;
-	endspecify
-endmodule
-`endcelldefine
-
-// type:  
-`timescale 1ns/10ps
-`celldefine
-module HB2x1_ASAP7_6t_R (Y, A);
-	output Y;
-	input A;
-
-	// Function
-	buf (Y, A);
-
-	// Timing
-	specify
-		(A => Y) = 0;
-	endspecify
-endmodule
-`endcelldefine
-
-// type:  
-`timescale 1ns/10ps
-`celldefine
-module HB3x1_ASAP7_6t_R (Y, A);
-	output Y;
-	input A;
-
-	// Function
-	buf (Y, A);
-
-	// Timing
-	specify
-		(A => Y) = 0;
-	endspecify
-endmodule
-`endcelldefine
-
-// type:  
-`timescale 1ns/10ps
-`celldefine
-module HB4x1_ASAP7_6t_R (Y, A);
-	output Y;
-	input A;
-
-	// Function
-	buf (Y, A);
-
-	// Timing
-	specify
-		(A => Y) = 0;
-	endspecify
-endmodule
-`endcelldefine
-
-// type:  
-`timescale 1ns/10ps
-`celldefine
-module INVx11_ASAP7_6t_R (Y, A);
+module CKINVDCx10_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -323,7 +255,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx13_ASAP7_6t_R (Y, A);
+module CKINVDCx11_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -340,7 +272,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx1_ASAP7_6t_R (Y, A);
+module CKINVDCx12_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -357,7 +289,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx2_ASAP7_6t_R (Y, A);
+module CKINVDCx14_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -374,7 +306,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx3_ASAP7_6t_R (Y, A);
+module CKINVDCx16_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -391,7 +323,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx4_ASAP7_6t_R (Y, A);
+module CKINVDCx20_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -408,7 +340,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx5_ASAP7_6t_R (Y, A);
+module CKINVDCx5p33_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -425,7 +357,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx6_ASAP7_6t_R (Y, A);
+module CKINVDCx6p67_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -442,7 +374,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVx8_ASAP7_6t_R (Y, A);
+module CKINVDCx8_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -459,7 +391,7 @@ endmodule
 // type:  
 `timescale 1ns/10ps
 `celldefine
-module INVxp5_ASAP7_6t_R (Y, A);
+module CKINVDCx9p33_ASAP7_75t_SL (Y, A);
 	output Y;
 	input A;
 
@@ -472,4 +404,261 @@ module INVxp5_ASAP7_6t_R (Y, A);
 	endspecify
 endmodule
 `endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB1xp67_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB2xp67_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB3xp67_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HB4xp67_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	buf (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx11_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx13_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx1_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx2_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx3_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx4_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx5_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx6_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVx8_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVxp33_ASAP7_75t_SL (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module INVxp67_ASAP7_75t_SL
+ (Y, A);
+	output Y;
+	input A;
+
+	// Function
+	not (Y, A);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
 

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_OA_LVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_OA_LVT_TT_201020.v
@@ -1,0 +1,5243 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_OA_LVT_TT_201020 created by Liberate 18.1.0.293 on Sat Nov 28 13:55:21 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module O2A1O1Ixp33_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module O2A1O1Ixp5_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A2 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA211x2_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, A2, B, C);
+	and (int_fwire_1, A1, B, C);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & A2 & B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA21x2_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, A2, B);
+	and (int_fwire_1, A1, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA221x2_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3;
+
+	and (int_fwire_0, A2, B2, C);
+	and (int_fwire_1, A2, B1, C);
+	and (int_fwire_2, A1, B2, C);
+	and (int_fwire_3, A1, B1, C);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2) | (~A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA222x2_ASAP7_75t_L (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7;
+
+	and (int_fwire_0, A2, B2, C2);
+	and (int_fwire_1, A2, B2, C1);
+	and (int_fwire_2, A2, B1, C2);
+	and (int_fwire_3, A2, B1, C1);
+	and (int_fwire_4, A1, B2, C2);
+	and (int_fwire_5, A1, B2, C1);
+	and (int_fwire_6, A1, B1, C2);
+	and (int_fwire_7, A1, B1, C1);
+	or (Y, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & C1 & ~C2) | (~A2 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & ~C2) | (~A1 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA22x2_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3;
+
+	and (int_fwire_0, A2, B2);
+	and (int_fwire_1, A2, B1);
+	and (int_fwire_2, A1, B2);
+	and (int_fwire_3, A1, B1);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA31x2_ASAP7_75t_L (Y, A1, A2, A3, B1);
+	output Y;
+	input A1, A2, A3, B1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, A3, B1);
+	and (int_fwire_1, A2, B1);
+	and (int_fwire_2, A1, B1);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3) | (~A1 & A2 & A3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA331x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3, C1);
+	and (int_fwire_1, A3, B2, C1);
+	and (int_fwire_2, A3, B1, C1);
+	and (int_fwire_3, A2, B3, C1);
+	and (int_fwire_4, A2, B2, C1);
+	and (int_fwire_5, A2, B1, C1);
+	and (int_fwire_6, A1, B3, C1);
+	and (int_fwire_7, A1, B2, C1);
+	and (int_fwire_8, A1, B1, C1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA331x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3, C1);
+	and (int_fwire_1, A3, B2, C1);
+	and (int_fwire_2, A3, B1, C1);
+	and (int_fwire_3, A2, B3, C1);
+	and (int_fwire_4, A2, B2, C1);
+	and (int_fwire_5, A2, B1, C1);
+	and (int_fwire_6, A1, B3, C1);
+	and (int_fwire_7, A1, B2, C1);
+	and (int_fwire_8, A1, B1, C1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA332x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+
+	and (int_fwire_0, A3, B3, C2);
+	and (int_fwire_1, A3, B3, C1);
+	and (int_fwire_2, A3, B2, C2);
+	and (int_fwire_3, A3, B2, C1);
+	and (int_fwire_4, A3, B1, C2);
+	and (int_fwire_5, A3, B1, C1);
+	and (int_fwire_6, A2, B3, C2);
+	and (int_fwire_7, A2, B3, C1);
+	and (int_fwire_8, A2, B2, C2);
+	and (int_fwire_9, A2, B2, C1);
+	and (int_fwire_10, A2, B1, C2);
+	and (int_fwire_11, A2, B1, C1);
+	and (int_fwire_12, A1, B3, C2);
+	and (int_fwire_13, A1, B3, C1);
+	and (int_fwire_14, A1, B2, C2);
+	and (int_fwire_15, A1, B2, C1);
+	and (int_fwire_16, A1, B1, C2);
+	and (int_fwire_17, A1, B1, C1);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA332x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+
+	and (int_fwire_0, A3, B3, C2);
+	and (int_fwire_1, A3, B3, C1);
+	and (int_fwire_2, A3, B2, C2);
+	and (int_fwire_3, A3, B2, C1);
+	and (int_fwire_4, A3, B1, C2);
+	and (int_fwire_5, A3, B1, C1);
+	and (int_fwire_6, A2, B3, C2);
+	and (int_fwire_7, A2, B3, C1);
+	and (int_fwire_8, A2, B2, C2);
+	and (int_fwire_9, A2, B2, C1);
+	and (int_fwire_10, A2, B1, C2);
+	and (int_fwire_11, A2, B1, C1);
+	and (int_fwire_12, A1, B3, C2);
+	and (int_fwire_13, A1, B3, C1);
+	and (int_fwire_14, A1, B2, C2);
+	and (int_fwire_15, A1, B2, C1);
+	and (int_fwire_16, A1, B1, C2);
+	and (int_fwire_17, A1, B1, C1);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA333x1_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	and (int_fwire_0, A3, B3, C3);
+	and (int_fwire_1, A3, B3, C2);
+	and (int_fwire_2, A3, B3, C1);
+	and (int_fwire_3, A3, B2, C3);
+	and (int_fwire_4, A3, B2, C2);
+	and (int_fwire_5, A3, B2, C1);
+	and (int_fwire_6, A3, B1, C3);
+	and (int_fwire_7, A3, B1, C2);
+	and (int_fwire_8, A3, B1, C1);
+	and (int_fwire_9, A2, B3, C3);
+	and (int_fwire_10, A2, B3, C2);
+	and (int_fwire_11, A2, B3, C1);
+	and (int_fwire_12, A2, B2, C3);
+	and (int_fwire_13, A2, B2, C2);
+	and (int_fwire_14, A2, B2, C1);
+	and (int_fwire_15, A2, B1, C3);
+	and (int_fwire_16, A2, B1, C2);
+	and (int_fwire_17, A2, B1, C1);
+	and (int_fwire_18, A1, B3, C3);
+	and (int_fwire_19, A1, B3, C2);
+	and (int_fwire_20, A1, B3, C1);
+	and (int_fwire_21, A1, B2, C3);
+	and (int_fwire_22, A1, B2, C2);
+	and (int_fwire_23, A1, B2, C1);
+	and (int_fwire_24, A1, B1, C3);
+	and (int_fwire_25, A1, B1, C2);
+	and (int_fwire_26, A1, B1, C1);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA333x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	and (int_fwire_0, A3, B3, C3);
+	and (int_fwire_1, A3, B3, C2);
+	and (int_fwire_2, A3, B3, C1);
+	and (int_fwire_3, A3, B2, C3);
+	and (int_fwire_4, A3, B2, C2);
+	and (int_fwire_5, A3, B2, C1);
+	and (int_fwire_6, A3, B1, C3);
+	and (int_fwire_7, A3, B1, C2);
+	and (int_fwire_8, A3, B1, C1);
+	and (int_fwire_9, A2, B3, C3);
+	and (int_fwire_10, A2, B3, C2);
+	and (int_fwire_11, A2, B3, C1);
+	and (int_fwire_12, A2, B2, C3);
+	and (int_fwire_13, A2, B2, C2);
+	and (int_fwire_14, A2, B2, C1);
+	and (int_fwire_15, A2, B1, C3);
+	and (int_fwire_16, A2, B1, C2);
+	and (int_fwire_17, A2, B1, C1);
+	and (int_fwire_18, A1, B3, C3);
+	and (int_fwire_19, A1, B3, C2);
+	and (int_fwire_20, A1, B3, C1);
+	and (int_fwire_21, A1, B2, C3);
+	and (int_fwire_22, A1, B2, C2);
+	and (int_fwire_23, A1, B2, C1);
+	and (int_fwire_24, A1, B1, C3);
+	and (int_fwire_25, A1, B1, C2);
+	and (int_fwire_26, A1, B1, C1);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA33x2_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3);
+	and (int_fwire_1, A3, B2);
+	and (int_fwire_2, A3, B1);
+	and (int_fwire_3, A2, B3);
+	and (int_fwire_4, A2, B2);
+	and (int_fwire_5, A2, B1);
+	and (int_fwire_6, A1, B3);
+	and (int_fwire_7, A1, B2);
+	and (int_fwire_8, A1, B1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & B3) | (~A2 & ~A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & B3) | (~A1 & ~A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & B3) | (~A1 & ~A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B2 & ~B3) | (~A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2) | (~A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI211xp5_ASAP7_75t_L (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & A2 & B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21x1_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21xp33_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21xp5_ASAP7_75t_L (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI221xp5_ASAP7_75t_L (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI222xp33_ASAP7_75t_L (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C1__bar, C2__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & C1 & ~C2) | (~A2 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & ~C2) | (~A1 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22x1_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22xp33_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22xp5_ASAP7_75t_L (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI311xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, C1);
+	output Y;
+	input A1, A2, A3, B1, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, C1__bar, int_fwire_0;
+
+	not (C1__bar, C1);
+	not (B1__bar, B1);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B1__bar, C1__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & C1) | (A1 & ~A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1) | (A1 & ~A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI31xp33_ASAP7_75t_L (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3) | (A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI31xp67_ASAP7_75t_L (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3) | (A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI321xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, C);
+	output Y;
+	input A1, A2, A3, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C) | (A1 & ~A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C) | (A1 & ~A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2) | (A1 & ~A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2) | (A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2) | (A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI322xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C1__bar;
+	wire C2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI32xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2) | (A1 & ~A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1) | (A1 & ~A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI331xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, int_fwire_0, int_fwire_1;
+
+	not (C1__bar, C1);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0, C1__bar);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI332xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI333xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, C3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C3__bar, C3);
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar, C3__bar);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI33xp33_ASAP7_75t_L (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3) | (~A2 & ~A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3) | (~A1 & ~A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3) | (~A1 & ~A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B2 & ~B3) | (~A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2) | (~A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_OA_SLVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_OA_SLVT_TT_201020.v
@@ -1,0 +1,5243 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_OA_SLVT_TT_201020 created by Liberate 18.1.0.293 on Sat Nov 28 13:55:21 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module O2A1O1Ixp33_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module O2A1O1Ixp5_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, C__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~C))
+			(B => Y) = 0;
+		if ((A2 & ~B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & ~B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA211x2_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, A2, B, C);
+	and (int_fwire_1, A1, B, C);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & A2 & B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA21x2_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire int_fwire_0, int_fwire_1;
+
+	and (int_fwire_0, A2, B);
+	and (int_fwire_1, A1, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA221x2_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3;
+
+	and (int_fwire_0, A2, B2, C);
+	and (int_fwire_1, A2, B1, C);
+	and (int_fwire_2, A1, B2, C);
+	and (int_fwire_3, A1, B1, C);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2) | (~A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA222x2_ASAP7_75t_SL (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7;
+
+	and (int_fwire_0, A2, B2, C2);
+	and (int_fwire_1, A2, B2, C1);
+	and (int_fwire_2, A2, B1, C2);
+	and (int_fwire_3, A2, B1, C1);
+	and (int_fwire_4, A1, B2, C2);
+	and (int_fwire_5, A1, B2, C1);
+	and (int_fwire_6, A1, B1, C2);
+	and (int_fwire_7, A1, B1, C1);
+	or (Y, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & C1 & ~C2) | (~A2 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & ~C2) | (~A1 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA22x2_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3;
+
+	and (int_fwire_0, A2, B2);
+	and (int_fwire_1, A2, B1);
+	and (int_fwire_2, A1, B2);
+	and (int_fwire_3, A1, B1);
+	or (Y, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA31x2_ASAP7_75t_SL (Y, A1, A2, A3, B1);
+	output Y;
+	input A1, A2, A3, B1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, A3, B1);
+	and (int_fwire_1, A2, B1);
+	and (int_fwire_2, A1, B1);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3) | (~A1 & A2 & A3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA331x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3, C1);
+	and (int_fwire_1, A3, B2, C1);
+	and (int_fwire_2, A3, B1, C1);
+	and (int_fwire_3, A2, B3, C1);
+	and (int_fwire_4, A2, B2, C1);
+	and (int_fwire_5, A2, B1, C1);
+	and (int_fwire_6, A1, B3, C1);
+	and (int_fwire_7, A1, B2, C1);
+	and (int_fwire_8, A1, B1, C1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA331x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3, C1);
+	and (int_fwire_1, A3, B2, C1);
+	and (int_fwire_2, A3, B1, C1);
+	and (int_fwire_3, A2, B3, C1);
+	and (int_fwire_4, A2, B2, C1);
+	and (int_fwire_5, A2, B1, C1);
+	and (int_fwire_6, A1, B3, C1);
+	and (int_fwire_7, A1, B2, C1);
+	and (int_fwire_8, A1, B1, C1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA332x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+
+	and (int_fwire_0, A3, B3, C2);
+	and (int_fwire_1, A3, B3, C1);
+	and (int_fwire_2, A3, B2, C2);
+	and (int_fwire_3, A3, B2, C1);
+	and (int_fwire_4, A3, B1, C2);
+	and (int_fwire_5, A3, B1, C1);
+	and (int_fwire_6, A2, B3, C2);
+	and (int_fwire_7, A2, B3, C1);
+	and (int_fwire_8, A2, B2, C2);
+	and (int_fwire_9, A2, B2, C1);
+	and (int_fwire_10, A2, B1, C2);
+	and (int_fwire_11, A2, B1, C1);
+	and (int_fwire_12, A1, B3, C2);
+	and (int_fwire_13, A1, B3, C1);
+	and (int_fwire_14, A1, B2, C2);
+	and (int_fwire_15, A1, B2, C1);
+	and (int_fwire_16, A1, B1, C2);
+	and (int_fwire_17, A1, B1, C1);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA332x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+
+	and (int_fwire_0, A3, B3, C2);
+	and (int_fwire_1, A3, B3, C1);
+	and (int_fwire_2, A3, B2, C2);
+	and (int_fwire_3, A3, B2, C1);
+	and (int_fwire_4, A3, B1, C2);
+	and (int_fwire_5, A3, B1, C1);
+	and (int_fwire_6, A2, B3, C2);
+	and (int_fwire_7, A2, B3, C1);
+	and (int_fwire_8, A2, B2, C2);
+	and (int_fwire_9, A2, B2, C1);
+	and (int_fwire_10, A2, B1, C2);
+	and (int_fwire_11, A2, B1, C1);
+	and (int_fwire_12, A1, B3, C2);
+	and (int_fwire_13, A1, B3, C1);
+	and (int_fwire_14, A1, B2, C2);
+	and (int_fwire_15, A1, B2, C1);
+	and (int_fwire_16, A1, B1, C2);
+	and (int_fwire_17, A1, B1, C1);
+	or (Y, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA333x1_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	and (int_fwire_0, A3, B3, C3);
+	and (int_fwire_1, A3, B3, C2);
+	and (int_fwire_2, A3, B3, C1);
+	and (int_fwire_3, A3, B2, C3);
+	and (int_fwire_4, A3, B2, C2);
+	and (int_fwire_5, A3, B2, C1);
+	and (int_fwire_6, A3, B1, C3);
+	and (int_fwire_7, A3, B1, C2);
+	and (int_fwire_8, A3, B1, C1);
+	and (int_fwire_9, A2, B3, C3);
+	and (int_fwire_10, A2, B3, C2);
+	and (int_fwire_11, A2, B3, C1);
+	and (int_fwire_12, A2, B2, C3);
+	and (int_fwire_13, A2, B2, C2);
+	and (int_fwire_14, A2, B2, C1);
+	and (int_fwire_15, A2, B1, C3);
+	and (int_fwire_16, A2, B1, C2);
+	and (int_fwire_17, A2, B1, C1);
+	and (int_fwire_18, A1, B3, C3);
+	and (int_fwire_19, A1, B3, C2);
+	and (int_fwire_20, A1, B3, C1);
+	and (int_fwire_21, A1, B2, C3);
+	and (int_fwire_22, A1, B2, C2);
+	and (int_fwire_23, A1, B2, C1);
+	and (int_fwire_24, A1, B1, C3);
+	and (int_fwire_25, A1, B1, C2);
+	and (int_fwire_26, A1, B1, C1);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA333x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+	wire int_fwire_9, int_fwire_10, int_fwire_11;
+	wire int_fwire_12, int_fwire_13, int_fwire_14;
+	wire int_fwire_15, int_fwire_16, int_fwire_17;
+	wire int_fwire_18, int_fwire_19, int_fwire_20;
+	wire int_fwire_21, int_fwire_22, int_fwire_23;
+	wire int_fwire_24, int_fwire_25, int_fwire_26;
+
+	and (int_fwire_0, A3, B3, C3);
+	and (int_fwire_1, A3, B3, C2);
+	and (int_fwire_2, A3, B3, C1);
+	and (int_fwire_3, A3, B2, C3);
+	and (int_fwire_4, A3, B2, C2);
+	and (int_fwire_5, A3, B2, C1);
+	and (int_fwire_6, A3, B1, C3);
+	and (int_fwire_7, A3, B1, C2);
+	and (int_fwire_8, A3, B1, C1);
+	and (int_fwire_9, A2, B3, C3);
+	and (int_fwire_10, A2, B3, C2);
+	and (int_fwire_11, A2, B3, C1);
+	and (int_fwire_12, A2, B2, C3);
+	and (int_fwire_13, A2, B2, C2);
+	and (int_fwire_14, A2, B2, C1);
+	and (int_fwire_15, A2, B1, C3);
+	and (int_fwire_16, A2, B1, C2);
+	and (int_fwire_17, A2, B1, C1);
+	and (int_fwire_18, A1, B3, C3);
+	and (int_fwire_19, A1, B3, C2);
+	and (int_fwire_20, A1, B3, C1);
+	and (int_fwire_21, A1, B2, C3);
+	and (int_fwire_22, A1, B2, C2);
+	and (int_fwire_23, A1, B2, C1);
+	and (int_fwire_24, A1, B1, C3);
+	and (int_fwire_25, A1, B1, C2);
+	and (int_fwire_26, A1, B1, C1);
+	or (Y, int_fwire_26, int_fwire_25, int_fwire_24, int_fwire_23, int_fwire_22, int_fwire_21, int_fwire_20, int_fwire_19, int_fwire_18, int_fwire_17, int_fwire_16, int_fwire_15, int_fwire_14, int_fwire_13, int_fwire_12, int_fwire_11, int_fwire_10, int_fwire_9, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OA33x2_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6, int_fwire_7, int_fwire_8;
+
+	and (int_fwire_0, A3, B3);
+	and (int_fwire_1, A3, B2);
+	and (int_fwire_2, A3, B1);
+	and (int_fwire_3, A2, B3);
+	and (int_fwire_4, A2, B2);
+	and (int_fwire_5, A2, B1);
+	and (int_fwire_6, A1, B3);
+	and (int_fwire_7, A1, B2);
+	and (int_fwire_8, A1, B1);
+	or (Y, int_fwire_8, int_fwire_7, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & B3) | (~A2 & ~A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & B3) | (~A1 & ~A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & B3) | (~A1 & ~A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B2 & ~B3) | (~A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2) | (~A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI211xp5_ASAP7_75t_SL (Y, A1, A2, B, C);
+	output Y;
+	input A1, A2, B, C;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire C__bar, int_fwire_0;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & C))
+			(B => Y) = 0;
+		if ((~A1 & A2 & C))
+			(B => Y) = 0;
+		if ((A1 & A2 & B))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21x1_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21xp33_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI21xp5_ASAP7_75t_SL (Y, A1, A2, B);
+	output Y;
+	input A1, A2, B;
+
+	// Function
+	wire A1__bar, A2__bar, B__bar;
+	wire int_fwire_0;
+
+	not (B__bar, B);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		if ((A1 & A2))
+			(B => Y) = 0;
+		if ((A1 & ~A2))
+			(B => Y) = 0;
+		if ((~A1 & A2))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI221xp5_ASAP7_75t_SL (Y, A1, A2, B1, B2, C);
+	output Y;
+	input A1, A2, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI222xp33_ASAP7_75t_SL (Y, A1, A2, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, C1__bar, C2__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & C1 & ~C2) | (~A2 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & C1 & ~C2) | (~A1 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22x1_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22xp33_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI22xp5_ASAP7_75t_SL (Y, A1, A2, B1, B2);
+	output Y;
+	input A1, A2, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, B1__bar;
+	wire B2__bar, int_fwire_0, int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI311xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, C1);
+	output Y;
+	input A1, A2, A3, B1, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, C1__bar, int_fwire_0;
+
+	not (C1__bar, C1);
+	not (B1__bar, B1);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B1__bar, C1__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & C1) | (A1 & ~A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1) | (A1 & ~A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI31xp33_ASAP7_75t_SL (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3) | (A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI31xp67_ASAP7_75t_SL (Y, A1, A2, A3, B);
+	output Y;
+	input A1, A2, A3, B;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B__bar, int_fwire_0;
+
+	not (B__bar, B);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_0, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_0, B__bar);
+
+	// Timing
+	specify
+		(A1 => Y) = 0;
+		(A2 => Y) = 0;
+		(A3 => Y) = 0;
+		if ((A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & A2 & ~A3) | (A1 & ~A2 & A3))
+			(B => Y) = 0;
+		if ((A1 & ~A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & A3))
+			(B => Y) = 0;
+		if ((~A1 & A2 & ~A3))
+			(B => Y) = 0;
+		if ((~A1 & ~A2 & A3))
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI321xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, C);
+	output Y;
+	input A1, A2, A3, B1, B2, C;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (C__bar, C);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0, C__bar);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C) | (A1 & ~A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C) | (A1 & ~A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2) | (A1 & ~A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2) | (A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2) | (A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2))
+			(C => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2))
+			(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI322xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, C1__bar;
+	wire C2__bar, int_fwire_0, int_fwire_1;
+	wire int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI32xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2);
+	output Y;
+	input A1, A2, A3, B1, B2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2) | (A1 & ~A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1) | (A1 & ~A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1))
+			(B2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI331xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, int_fwire_0, int_fwire_1;
+
+	not (C1__bar, C1);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0, C1__bar);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3) | (A1 & A2 & A3 & B1 & ~B2 & B3) | (A1 & A2 & ~A3 & B1 & B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3) | (~A1 & A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3))
+			(C1 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI332xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, int_fwire_0;
+	wire int_fwire_1, int_fwire_2;
+
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1) | (A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1) | (~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1))
+			(C2 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI333xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3, C1, C2, C3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3, C1, C2, C3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire C1__bar, C2__bar, C3__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C3__bar, C3);
+	not (C2__bar, C2);
+	not (C1__bar, C1);
+	and (int_fwire_0, C1__bar, C2__bar, C3__bar);
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_1, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_2, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3 & ~C1 & ~C2 & C3) | (~A1 & ~A2 & B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & C1 & ~C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & C1 & ~C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & C2 & ~C3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3 & ~C1 & ~C2 & C3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & C1 & ~C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & C2 & ~C3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3 & ~C1 & ~C2 & C3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & C1 & ~C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & C2 & ~C3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3 & ~C1 & ~C2 & C3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & C2 & ~C3) | (~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & C1 & ~C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & C2 & ~C3))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & ~C1 & ~C2 & C3))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C2 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C2 & ~C3))
+			(C1 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C3) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C3))
+			(C2 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2) | (A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (A1 & ~A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & A2 & ~A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & B2 & ~B3 & ~C1 & ~C2) | (~A1 & ~A2 & A3 & B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & B1 & ~B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & B2 & ~B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2 & B3 & ~C1 & ~C2))
+			(C3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OAI33xp33_ASAP7_75t_SL (Y, A1, A2, A3, B1, B2, B3);
+	output Y;
+	input A1, A2, A3, B1, B2, B3;
+
+	// Function
+	wire A1__bar, A2__bar, A3__bar;
+	wire B1__bar, B2__bar, B3__bar;
+	wire int_fwire_0, int_fwire_1;
+
+	not (B3__bar, B3);
+	not (B2__bar, B2);
+	not (B1__bar, B1);
+	and (int_fwire_0, B1__bar, B2__bar, B3__bar);
+	not (A3__bar, A3);
+	not (A2__bar, A2);
+	not (A1__bar, A1);
+	and (int_fwire_1, A1__bar, A2__bar, A3__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if ((~A2 & ~A3 & B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & B2 & ~B3) | (~A2 & ~A3 & B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & B1 & ~B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & B2 & ~B3))
+			(A1 => Y) = 0;
+		if ((~A2 & ~A3 & ~B1 & ~B2 & B3))
+			(A1 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & B2 & ~B3) | (~A1 & ~A3 & B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & B1 & ~B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & B2 & ~B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A3 & ~B1 & ~B2 & B3))
+			(A2 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & B2 & ~B3) | (~A1 & ~A2 & B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & B1 & ~B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & B2 & ~B3))
+			(A3 => Y) = 0;
+		if ((~A1 & ~A2 & ~B1 & ~B2 & B3))
+			(A3 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B2 & ~B3) | (~A1 & A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B2 & ~B3))
+			(B1 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B3) | (~A1 & A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B3))
+			(B2 => Y) = 0;
+		if ((A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & A3 & ~B1 & ~B2) | (~A1 & A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((A1 & ~A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & A2 & ~A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+		if ((~A1 & ~A2 & A3 & ~B1 & ~B2))
+			(B3 => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SEQ_LVT_TT_220101.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SEQ_LVT_TT_220101.v
@@ -1,0 +1,1173 @@
+// BSD 3-Clause License
+// 
+// Copyright 2022 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/anolas19/Liberate/Verilog/asap7sc7p5t_SEQ_LVT_TT_211229_pex created by Liberate 18.1.0.293 on Fri Dec 31 22:59:44 MST 2021 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFASRHQNx1_ASAP7_75t_L (QN, D, RESETN, SETN, CLK);
+	output QN;
+	input D, RESETN, SETN, CLK;
+	reg notifier;
+	wire delayed_D, delayed_LESETN, delayed_SETN, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, int_fwire_r;
+	wire int_fwire_s, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_s, delayed_LESETN);
+	not (int_fwire_r, delayed_SETN);
+	//altos_dff_sr_err (xcr_0, delayed_CLK, int_fwire_d, int_fwire_s, int_fwire_r);
+	// altos_dff_sr_0 (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, int_fwire_s, int_fwire_r, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, adacond8;
+	wire CLK__bar, D__bar;
+
+
+	// Additional timing gates
+	and (adacond0, RESETN, SETN);
+	and (adacond1, D, SETN);
+	and (adacond2, CLK, SETN);
+	not (CLK__bar, CLK);
+	and (adacond3, CLK__bar, SETN);
+	not (D__bar, D);
+	and (adacond4, D__bar, RESETN);
+	and (adacond5, CLK, RESETN);
+	and (adacond6, CLK__bar, RESETN);
+	and (adacond7, D, RESETN, SETN);
+	and (adacond8, D__bar, RESETN, SETN);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx1_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx2_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx3_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQx4_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ, xcr_0;
+
+	//altos_dff_err (xcr_0, delayed_CLK, delayed_D);
+	//altos_dff (int_fwire_IQ, notifier, delayed_CLK, delayed_D, xcr_0);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx1_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx2_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx3_ASAP7_75t_L (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQx4_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, xcr_0;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, delayed_D);
+	//altos_dff (int_fwire_IQ, notifier, int_fwire_clk, delayed_D, xcr_0);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx1_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx2_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx3_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx1_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx2_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx3_ASAP7_75t_L (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx1_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx2_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx2p67DC_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx3_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx4DC_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx4_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx5_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx5p33DC_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx6p67DC_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx8DC_ASAP7_75t_L (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx1_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx2_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx3_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx4_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx1_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx2_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx3_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx4_ASAP7_75t_L (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SEQ_SLVT_TT_220101.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SEQ_SLVT_TT_220101.v
@@ -1,0 +1,1173 @@
+// BSD 3-Clause License
+// 
+// Copyright 2022 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/anolas19/Liberate/Verilog/asap7sc7p5t_SEQ_SLVT_TT_211229_pex created by Liberate 18.1.0.293 on Fri Dec 31 22:59:44 MST 2021 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFASRHQNx1_ASAP7_75t_SL (QN, D, RESETN, SETN, CLK);
+	output QN;
+	input D, RESETN, SETN, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SLESETN, delayed_SETN, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, int_fwire_r;
+	wire int_fwire_s, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_s, delayed_SLESETN);
+	not (int_fwire_r, delayed_SETN);
+	//altos_dff_sr_err (xcr_0, delayed_CLK, int_fwire_d, int_fwire_s, int_fwire_r);
+	// altos_dff_sr_0 (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, int_fwire_s, int_fwire_r, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, adacond8;
+	wire CLK__bar, D__bar;
+
+
+	// Additional timing gates
+	and (adacond0, RESETN, SETN);
+	and (adacond1, D, SETN);
+	and (adacond2, CLK, SETN);
+	not (CLK__bar, CLK);
+	and (adacond3, CLK__bar, SETN);
+	not (D__bar, D);
+	and (adacond4, D__bar, RESETN);
+	and (adacond5, CLK, RESETN);
+	and (adacond6, CLK__bar, RESETN);
+	and (adacond7, D, RESETN, SETN);
+	and (adacond8, D__bar, RESETN, SETN);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx1_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx2_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQNx3_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFHQx4_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ, xcr_0;
+
+	//altos_dff_err (xcr_0, delayed_CLK, delayed_D);
+	//altos_dff (int_fwire_IQ, notifier, delayed_CLK, delayed_D, xcr_0);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx1_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx2_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQNx3_ASAP7_75t_SL (QN, D, CLK);
+	output QN;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (int_fwire_d, delayed_D);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DFFLQx4_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, xcr_0;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, delayed_D);
+	//altos_dff (int_fwire_IQ, notifier, int_fwire_clk, delayed_D, xcr_0);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx1_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx2_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DHLx3_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_IQ;
+
+	//altos_latch (int_fwire_IQ, notifier, delayed_CLK, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx1_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx2_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module DLLx3_ASAP7_75t_SL (Q, D, CLK);
+	output Q;
+	input D, CLK;
+	reg notifier;
+	wire delayed_D, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ;
+
+	not (int_fwire_clk, delayed_CLK);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, delayed_D);
+	buf (Q, int_fwire_IQ);
+
+	// Timing
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx1_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx2_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx2p67DC_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx3_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx4DC_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx4_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx5_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx5p33DC_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx6p67DC_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module ICGx8DC_ASAP7_75t_SL (GCLK, ENA, SE, CLK);
+	output GCLK;
+	input ENA, SE, CLK;
+	reg notifier;
+	wire delayed_ENA, delayed_SE, delayed_CLK;
+
+	// Function
+	wire int_fwire_clk, int_fwire_IQ, int_fwire_test;
+
+	not (int_fwire_clk, delayed_CLK);
+	or (int_fwire_test, delayed_ENA, delayed_SE);
+	//altos_latch (int_fwire_IQ, notifier, int_fwire_clk, int_fwire_test);
+	and (GCLK, delayed_CLK, int_fwire_IQ);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, ENA__bar;
+	wire int_twire_0, SE__bar;
+
+
+	// Additional timing gates
+	not (ENA__bar, ENA);
+	and (int_twire_0, ENA__bar, SE);
+	or (adacond0, ENA, int_twire_0);
+	not (SE__bar, SE);
+	and (adacond1, ENA__bar, SE__bar);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx1_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx2_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx3_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFHx4_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_d, int_fwire_IQN, xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	//altos_dff_err (xcr_0, delayed_CLK, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, delayed_CLK, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx1_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx2_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx3_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module SDFLx4_ASAP7_75t_SL (QN, D, SE, SI, CLK);
+	output QN;
+	input D, SE, SI, CLK;
+	reg notifier;
+	wire delayed_D, delayed_SE, delayed_SI, delayed_CLK;
+
+	// Function
+	wire delayed_D__bar, delayed_SE__bar, delayed_SI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_clk, int_fwire_d, int_fwire_IQN;
+	wire xcr_0;
+
+	not (delayed_SI__bar, delayed_SI);
+	and (int_fwire_0, delayed_SE, delayed_SI__bar);
+	not (delayed_D__bar, delayed_D);
+	and (int_fwire_1, delayed_D__bar, delayed_SI__bar);
+	not (delayed_SE__bar, delayed_SE);
+	and (int_fwire_2, delayed_D__bar, delayed_SE__bar);
+	or (int_fwire_d, int_fwire_2, int_fwire_1, int_fwire_0);
+	not (int_fwire_clk, delayed_CLK);
+	//altos_dff_err (xcr_0, int_fwire_clk, int_fwire_d);
+	//altos_dff (int_fwire_IQN, notifier, int_fwire_clk, int_fwire_d, xcr_0);
+	buf (QN, int_fwire_IQN);
+
+	// Timing
+
+	// Additional timing wires
+	wire adacond0, adacond1, adacond2;
+	wire adacond3, adacond4, adacond5;
+	wire adacond6, adacond7, D__bar;
+	wire int_twire_0, int_twire_1, int_twire_2;
+	wire int_twire_3, int_twire_4, int_twire_5;
+	wire SE__bar, SI__bar;
+
+
+	// Additional timing gates
+	not (SE__bar, SE);
+	and (adacond0, SE__bar, SI);
+	not (SI__bar, SI);
+	and (adacond1, SE__bar, SI__bar);
+	and (adacond2, D, SI__bar);
+	not (D__bar, D);
+	and (adacond3, D__bar, SI);
+	and (adacond4, D, SE);
+	and (adacond5, D__bar, SE);
+	and (int_twire_0, D__bar, SE, SI);
+	and (int_twire_1, D, SE__bar);
+	and (int_twire_2, D, SE, SI);
+	or (adacond6, int_twire_2, int_twire_1, int_twire_0);
+	and (int_twire_3, D__bar, SE__bar);
+	and (int_twire_4, D__bar, SE, SI__bar);
+	and (int_twire_5, D, SE, SI__bar);
+	or (adacond7, int_twire_5, int_twire_4, int_twire_3);
+
+endmodule
+`endcelldefine

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SIMPLE_LVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SIMPLE_LVT_TT_201020.v
@@ -1,0 +1,1303 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_SIMPLE_LVT_TT_201020 created by Liberate 18.1.0.293 on Fri Nov 27 12:35:46 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x4_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x6_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x1_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x2_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x4_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND4x1_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	and (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND4x2_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	and (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND5x1_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	and (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND5x2_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	and (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module FAx1_ASAP7_75t_L (CON, SN, A, B, CI);
+	output CON, SN;
+	input A, B, CI;
+
+	// Function
+	wire A__bar, B__bar, CI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6;
+
+	not (CI__bar, CI);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, CI__bar);
+	not (A__bar, A);
+	and (int_fwire_1, A__bar, CI__bar);
+	and (int_fwire_2, A__bar, B__bar);
+	or (CON, int_fwire_2, int_fwire_1, int_fwire_0);
+	and (int_fwire_3, A__bar, B__bar, CI__bar);
+	and (int_fwire_4, A__bar, B, CI);
+	and (int_fwire_5, A, B__bar, CI);
+	and (int_fwire_6, A, B, CI__bar);
+	or (SN, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HAxp5_ASAP7_75t_L (CON, SN, A, B);
+	output CON, SN;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (CON, A__bar, B__bar);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (SN, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A => CON) = 0;
+		(B => CON) = 0;
+		if (B)
+			(A => SN) = 0;
+		if (~B)
+			(A => SN) = 0;
+		if (A)
+			(B => SN) = 0;
+		if (~A)
+			(B => SN) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJIxp5_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A__bar, A);
+	and (int_fwire_1, A__bar, C__bar);
+	and (int_fwire_2, A__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJx2_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, B, C);
+	and (int_fwire_1, A, C);
+	and (int_fwire_2, A, B);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJx3_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, B, C);
+	and (int_fwire_1, A, C);
+	and (int_fwire_2, A, B);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x1_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x1p5_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp33_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp5_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp67_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3x1_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3x2_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3xp33_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND4xp25_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND4xp75_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND5xp2_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar, E__bar;
+
+	not (E__bar, E);
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar, E__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x1_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x1p5_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2xp33_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2xp67_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3x1_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3x2_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3xp33_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR4xp25_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR4xp75_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR5xp2_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar, E__bar;
+
+	not (E__bar, E);
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar, E__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x4_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x6_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x1_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x2_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x4_ASAP7_75t_L (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR4x1_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	or (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR4x2_ASAP7_75t_L (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	or (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR5x1_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	or (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR5x2_ASAP7_75t_L (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	or (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module TIEHIx1_ASAP7_75t_L (H);
+	output H;
+
+	// Function
+	buf (H, 1'b1);
+
+	// Timing
+	specify
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module TIELOx1_ASAP7_75t_L (L);
+	output L;
+
+	// Function
+	buf (L, 1'b0);
+
+	// Timing
+	specify
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2x1_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2xp5_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2x1_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2x2_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2xp5_ASAP7_75t_L (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine

--- a/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SIMPLE_SLVT_TT_201020.v
+++ b/flow/platforms/asap7/work_around_yosys/asap7sc7p5t_SIMPLE_SLVT_TT_201020.v
@@ -1,0 +1,1303 @@
+// BSD 3-Clause License
+// 
+// Copyright 2020 Lawrence T. Clark, Vinay Vashishtha, or Arizona State
+// University
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+// 
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+// 
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from this
+// software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Verilog for library /home/ltclark/ASAP7/LIB2/Liberate_2/Verilog/asap7sc7p5t_SIMPLE_SLVT_TT_201020 created by Liberate 18.1.0.293 on Fri Nov 27 12:35:46 MST 2020 for SDF version 2.1
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x4_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND2x6_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	and (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x1_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x2_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND3x4_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	and (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND4x1_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	and (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND4x2_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	and (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND5x1_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	and (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module AND5x2_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	and (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module FAx1_ASAP7_75t_SL (CON, SN, A, B, CI);
+	output CON, SN;
+	input A, B, CI;
+
+	// Function
+	wire A__bar, B__bar, CI__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+	wire int_fwire_3, int_fwire_4, int_fwire_5;
+	wire int_fwire_6;
+
+	not (CI__bar, CI);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, CI__bar);
+	not (A__bar, A);
+	and (int_fwire_1, A__bar, CI__bar);
+	and (int_fwire_2, A__bar, B__bar);
+	or (CON, int_fwire_2, int_fwire_1, int_fwire_0);
+	and (int_fwire_3, A__bar, B__bar, CI__bar);
+	and (int_fwire_4, A__bar, B, CI);
+	and (int_fwire_5, A, B__bar, CI);
+	and (int_fwire_6, A, B, CI__bar);
+	or (SN, int_fwire_6, int_fwire_5, int_fwire_4, int_fwire_3);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module HAxp5_ASAP7_75t_SL (CON, SN, A, B);
+	output CON, SN;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (CON, A__bar, B__bar);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (SN, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		(A => CON) = 0;
+		(B => CON) = 0;
+		if (B)
+			(A => SN) = 0;
+		if (~B)
+			(A => SN) = 0;
+		if (A)
+			(B => SN) = 0;
+		if (~A)
+			(B => SN) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJIxp5_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	and (int_fwire_0, B__bar, C__bar);
+	not (A__bar, A);
+	and (int_fwire_1, A__bar, C__bar);
+	and (int_fwire_2, A__bar, B__bar);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJx2_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, B, C);
+	and (int_fwire_1, A, C);
+	and (int_fwire_2, A, B);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module MAJx3_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire int_fwire_0, int_fwire_1, int_fwire_2;
+
+	and (int_fwire_0, B, C);
+	and (int_fwire_1, A, C);
+	and (int_fwire_2, A, B);
+	or (Y, int_fwire_2, int_fwire_1, int_fwire_0);
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x1_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x1p5_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp33_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp5_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND2xp67_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3x1_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3x2_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND3xp33_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND4xp25_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND4xp75_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NAND5xp2_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar, E__bar;
+
+	not (E__bar, E);
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	or (Y, A__bar, B__bar, C__bar, D__bar, E__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x1_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x1p5_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2xp33_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR2xp67_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3x1_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3x2_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR3xp33_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR4xp25_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR4xp75_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar;
+
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module NOR5xp2_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	wire A__bar, B__bar, C__bar;
+	wire D__bar, E__bar;
+
+	not (E__bar, E);
+	not (D__bar, D);
+	not (C__bar, C);
+	not (B__bar, B);
+	not (A__bar, A);
+	and (Y, A__bar, B__bar, C__bar, D__bar, E__bar);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x4_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR2x6_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	or (Y, A, B);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x1_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x2_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR3x4_ASAP7_75t_SL (Y, A, B, C);
+	output Y;
+	input A, B, C;
+
+	// Function
+	or (Y, A, B, C);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR4x1_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	or (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR4x2_ASAP7_75t_SL (Y, A, B, C, D);
+	output Y;
+	input A, B, C, D;
+
+	// Function
+	or (Y, A, B, C, D);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR5x1_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	or (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module OR5x2_ASAP7_75t_SL (Y, A, B, C, D, E);
+	output Y;
+	input A, B, C, D, E;
+
+	// Function
+	or (Y, A, B, C, D, E);
+
+	// Timing
+	specify
+		(A => Y) = 0;
+		(B => Y) = 0;
+		(C => Y) = 0;
+		(D => Y) = 0;
+		(E => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module TIEHIx1_ASAP7_75t_SL (H);
+	output H;
+
+	// Function
+	buf (H, 1'b1);
+
+	// Timing
+	specify
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module TIELOx1_ASAP7_75t_SL (L);
+	output L;
+
+	// Function
+	buf (L, 1'b0);
+
+	// Timing
+	specify
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2x1_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XNOR2xp5_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (B__bar, B);
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B__bar);
+	and (int_fwire_1, A, B);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (B)
+			(A => Y) = 0;
+		if (~B)
+			(A => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2x1_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2x2_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine
+
+// type:  
+`timescale 1ns/10ps
+`celldefine
+module XOR2xp5_ASAP7_75t_SL (Y, A, B);
+	output Y;
+	input A, B;
+
+	// Function
+	wire A__bar, B__bar, int_fwire_0;
+	wire int_fwire_1;
+
+	not (A__bar, A);
+	and (int_fwire_0, A__bar, B);
+	not (B__bar, B);
+	and (int_fwire_1, A, B__bar);
+	or (Y, int_fwire_1, int_fwire_0);
+
+	// Timing
+	specify
+		if (~B)
+			(A => Y) = 0;
+		if (B)
+			(A => Y) = 0;
+		if (~A)
+			(B => Y) = 0;
+		if (A)
+			(B => Y) = 0;
+	endspecify
+endmodule
+`endcelldefine


### PR DESCRIPTION
- Updated jpeg_lvt to leverage ASAP7_USE_VT instead of manually adding the LVT asap7 lib files - more in line with aes_lvt and ethmac_lvt
- Extended ASAP7_USE_VT to support one or more Vt's.
- Default remains a single Vt (RVT)
- The first Vt specified is treated as the primary Vt and is used to set the tie hi/tie lo and other cells
- The other Vts are treated as secondary and their Lib, LEF, GDS, and fill cells are added to the appropriate lists
- Note that designs that use CCS will not be able to use multi-Vt unless we add the LVT and SLVT CCS files to the repo