### PR TITLE
update public metrics

### DIFF
--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 0,
+        "value": 2,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -44,7 +44,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 51,
+        "value": 32,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 3606,
+        "value": 5426,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,7 +40,7 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 9,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {

--- a/flow/designs/sky130hs/ibex/rules-base.json
+++ b/flow/designs/sky130hs/ibex/rules-base.json
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 12,
+        "value": 30,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 911447,
+        "value": 908310,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {


### PR DESCRIPTION
designs/ihp-sg13g2/ibex/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |        0 |        2 | Failing  |
| detailedroute__antenna_diodes_count           |       51 |       32 | Tighten  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |     3606 |     5426 | Failing  |
| detailedroute__antenna__violating__nets       |        9 |        0 | Tighten  |

designs/sky130hs/ibex/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       12 |       30 | Failing  |
| detailedroute__route__wirelength              |   911447 |   908310 | Tighten  |