### PR TITLE
make: introduce PYTHON_EXE dependency injection

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -204,7 +204,7 @@ versions.txt:
 .SECONDEXPANSION:
 $(DONT_USE_LIBS): $$(filter %$$(@F) %$$(@F).gz,$(LIB_FILES))
 	@mkdir -p $(OBJECTS_DIR)/lib
-	$(UTILS_DIR)/preprocessLib.py -i $^ -o $@
+	$(PYTHON_EXE) $(UTILS_DIR)/preprocessLib.py -i $^ -o $@
 
 $(OBJECTS_DIR)/lib/merged.lib: $(DONT_USE_LIBS)
 	$(UTILS_DIR)/mergeLib.pl $(PLATFORM)_merged $(DONT_USE_LIBS) > $@
@@ -271,9 +271,9 @@ do-synth-report:
 .PHONY: memory
 memory:
 	if [ -f $(RESULTS_DIR)/mem_hierarchical.json ]; then \
-		python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem_hierarchical.json; \
+		$(PYTHON_EXE) $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem_hierarchical.json; \
 	fi
-	python3 $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
+	$(PYTHON_EXE) $(SCRIPTS_DIR)/mem_dump.py $(RESULTS_DIR)/mem.json
 
 # ==============================================================================
 
@@ -619,12 +619,12 @@ finish: $(LOG_DIR)/6_report.log \
 
 .PHONY: elapsed
 elapsed:
-	-@$(UTILS_DIR)/genElapsedTime.py -d $(BLOCK_LOG_FOLDERS) $(LOG_DIR)
+	-@$(PYTHON_EXE) $(UTILS_DIR)/genElapsedTime.py -d $(BLOCK_LOG_FOLDERS) $(LOG_DIR)
 
 # Useful when working with macros, see elapsed time for all macros in platform
 .PHONY: elapsed-all
 elapsed-all:
-	@$(UTILS_DIR)/genElapsedTime.py -d $(shell find $(WORK_HOME)/logs/$(PLATFORM)/*/*/ -type d)
+	@$(PYTHON_EXE) $(UTILS_DIR)/genElapsedTime.py -d $(shell find $(WORK_HOME)/logs/$(PLATFORM)/*/*/ -type d)
 
 $(eval $(call do-step,6_1_fill,$(RESULTS_DIR)/5_route.odb $(RESULTS_DIR)/5_route.sdc $(FILL_CONFIG),density_fill))
 

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -41,7 +41,7 @@ include $(PLATFORM_DIR)/config.mk
 
 # __SPACE__ is a workaround for whitespace hell in "foreach"; there
 # is no way to escape space in defaults.py and get "foreach" to work.
-$(foreach line,$(shell $(SCRIPTS_DIR)/defaults.py),$(eval export $(subst __SPACE__, ,$(line))))
+$(foreach line,$(shell $(PYTHON_EXE) $(SCRIPTS_DIR)/defaults.py),$(eval export $(subst __SPACE__, ,$(line))))
 
 export LOG_DIR     = $(WORK_HOME)/logs/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_VARIANT)
 export OBJECTS_DIR = $(WORK_HOME)/objects/$(PLATFORM)/$(DESIGN_NICKNAME)/$(FLOW_VARIANT)
@@ -70,6 +70,8 @@ export NUM_CORES
 
 #-------------------------------------------------------------------------------
 # setup all commands used within this flow
+export PYTHON_EXE ?= $(shell command -v python3)
+
 export TIME_BIN   ?= env time
 TIME_CMD = $(TIME_BIN) -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.'
 TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -5,9 +5,9 @@ metadata: finish metadata-generate metadata-check
 
 .PHONY: metadata-generate
 metadata-generate:
-	@mkdir -p $(REPORTS_DIR)
-	@echo $(DESIGN_DIR) > $(REPORTS_DIR)/design-dir.txt
-	$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
+	mkdir -p $(REPORTS_DIR)
+	echo $(DESIGN_DIR) > $(REPORTS_DIR)/design-dir.txt
+	$(PYTHON_EXE) $(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
 	    -p $(PLATFORM) \
 	    -v $(FLOW_VARIANT) \
 	    --logs $(LOG_DIR) \
@@ -20,7 +20,7 @@ export RULES_JSON ?= $(DESIGN_DIR)/rules-$(FLOW_VARIANT).json
 
 .PHONY: metadata-check
 metadata-check:
-	@$(UTILS_DIR)/checkMetadata.py \
+	$(PYTHON_EXE) $(UTILS_DIR)/checkMetadata.py \
 	    -m $(REPORTS_DIR)/metadata.json \
 	    -r $(RULES_JSON) 2>&1 \
 	    | tee $(abspath $(REPORTS_DIR)/metadata-check.log)
@@ -40,8 +40,8 @@ update_metadata:
 
 .PHONY: do-update_rules
 do-update_rules:
-	@mkdir -p $(REPORTS_DIR)
-	$(UTILS_DIR)/genRuleFile.py \
+	mkdir -p $(REPORTS_DIR)
+	$(PYTHON_EXE) $(UTILS_DIR)/genRuleFile.py \
 	    --rules $(RULES_JSON) \
 	    --new-rules $(REPORTS_DIR)/rules.json \
 	    --reference $(REPORTS_DIR)/metadata.json \
@@ -59,7 +59,7 @@ update_rules: do-update_rules do-copy_update_rules
 
 .PHONY: do-update_rules_force
 do-update_rules_force:
-	@mkdir -p $(REPORTS_DIR)
+	mkdir -p $(REPORTS_DIR)
 	$(UTILS_DIR)/genRuleFile.py \
 	    --rules $(RULES_JSON) \
 	    --new-rules $(REPORTS_DIR)/rules.json \
@@ -74,7 +74,7 @@ update_rules_force: do-update_rules_force
 
 .PHONY: update_metadata_autotuner
 update_metadata_autotuner:
-	@$(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
+	$(PYTHON_EXE) $(UTILS_DIR)/genMetrics.py -d $(DESIGN_NICKNAME) \
 	    -p $(PLATFORM) \
 	    -v $(FLOW_VARIANT) \
 	    --logs $(LOG_DIR) \
@@ -93,7 +93,7 @@ $(RESULTS_DIR)/6_net_rc.csv:
 
 .PHONY: correlate_rc
 correlate_rc: $(RESULTS_DIR)/6_net_rc.csv
-	$(UTILS_DIR)/correlateRC.py $(RESULTS_DIR)/6_net_rc.csv
+	$(PYTHON_EXE) $(UTILS_DIR)/correlateRC.py $(RESULTS_DIR)/6_net_rc.csv
 
 # TODO Make always wants to redo designs with this rule, regardless of which variations are tried.
 #	$(MAKE) DESIGN_CONFIG=$$config write_net_rc; \
@@ -104,7 +104,7 @@ correlate_platform_rc:
 	  design=$$(basename $$(dirname $$config)); \
 	  make DESIGN_CONFIG=./$$config results/$(PLATFORM)/$$design/base/6_net_rc.csv; \
 	done
-	$(UTILS_DIR)/correlateRC.py $$(find results/$(PLATFORM)/*/base -name 6_net_rc.csv)
+	$(PYTHON_EXE) $(UTILS_DIR)/correlateRC.py $$(find results/$(PLATFORM)/*/base -name 6_net_rc.csv)
 
 # Run test using gnu parallel
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
This is consistent with OPENROAD_EXE, etc. and is useful to manage dependencies, e.g. when providing the python dependency from a venv instead of the system.

[Example](https://github.com/The-OpenROAD-Project/bazel-orfs/pull/344) use-case