### PR TITLE
update klayout checksum for ubuntu 20.04

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -170,7 +170,7 @@ _installUbuntuPackages() {
         fi
         else
             if [[ $1 == 20.04 ]]; then
-                klayoutChecksum=15a26f74cf396d8a10b7985ed70ab135
+                klayoutChecksum=f78d41edf5bcfa5f1990bde1a9307e9e
             else
                 klayoutChecksum=54748a49e1ab53e14cf5bf95feb2f25a
             fi


### PR DESCRIPTION
Update KLayout 0.28.17 checksum for Ubuntu 20.04.

Checksum found in https://www.klayout.de/build.html
![image](https://github.com/user-attachments/assets/825f76be-59b8-46ec-b42f-b045f99e5d90)
