### PR TITLE
asap7 cva6 - switch to use SLVT library for CTS

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -88,10 +88,10 @@ export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_64x256.lib \
 
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
 
-export CORE_UTILIZATION       = 40
+export CORE_UTILIZATION       = 50
 export CORE_MARGIN            = 2
 export MACRO_HALO             = 5
-export PLACE_DENSITY          = 0.50
+export PLACE_DENSITY          = 0.64
 
 # a smoketest for this option, there are a
 # few last gasp iterations
@@ -101,3 +101,7 @@ export SKIP_LAST_GASP ?= 1
 export SYNTH_MINIMUM_KEEP_SIZE ?= 40000
 
 export SYNTH_HDL_FRONTEND = slang
+
+export ASAP7_USE_VT = RVT LVT SLVT
+
+export CTS_LIB_NAME = asap7sc7p5t_INVBUF_SLVT_FF_nldm_211120

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 19930.01,
+        "value": 19725.15,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 23688,
+        "value": 20743,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 152015,
+        "value": 137118,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 13219,
+        "value": 11923,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 13219,
+        "value": 11923,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1332082,
+        "value": 1124948,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -147.23,
+        "value": -68.36,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 23925,
+        "value": 20933,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 6609,
+        "value": 5962,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -16.08,
+        "value": -10.27,
         "compare": ">="
     }
 }


### PR DESCRIPTION
WNS/TNS: -3.368

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 19930.01 | 19725.15 | Tighten  |
| placeopt__design__instance__area              |    23688 |    20743 | Tighten  |
| placeopt__design__instance__count__stdcell    |   152015 |   137118 | Tighten  |
| cts__design__instance__count__setup_buffer    |    13219 |    11923 | Tighten  |
| cts__design__instance__count__hold_buffer     |    13219 |    11923 | Tighten  |
| detailedroute__route__wirelength              |  1332082 |  1124948 | Tighten  |
| finish__timing__setup__ws                     |  -147.23 |   -68.36 | Tighten  |
| finish__design__instance__area                |    23925 |    20933 | Tighten  |
| finish__timing__drv__setup_violation_count    |     6609 |     5962 | Tighten  |
| finish__timing__wns_percent_delay             |   -16.08 |   -10.27 | Tighten  |
