### PR TITLE
Allow user to specify a custom hierarchy separator for the synthesis `flatten` pass

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -187,6 +187,7 @@ configuration file.
 | <a name="SYNTH_GUT"></a>SYNTH_GUT| Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.| | |
 | <a name="SYNTH_HDL_FRONTEND"></a>SYNTH_HDL_FRONTEND| Select an alternative language frontend to ingest the design. Available option is "slang". If the variable is empty, design is read with the Yosys read_verilog command.| | |
 | <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| 0| |
+| <a name="SYNTH_HIER_SEPARATOR"></a>SYNTH_HIER_SEPARATOR| Separator used for the synthesis flatten stage.| .| |
 | <a name="SYNTH_KEEP_MODULES"></a>SYNTH_KEEP_MODULES| Mark modules to keep from getting removed in flattening.| | |
 | <a name="SYNTH_MEMORY_MAX_BITS"></a>SYNTH_MEMORY_MAX_BITS| Maximum number of bits for memory synthesis.| 4096| |
 | <a name="SYNTH_MINIMUM_KEEP_SIZE"></a>SYNTH_MINIMUM_KEEP_SIZE| For hierarchical synthesis, we keep modules of larger area than given by this variable and flatten smaller modules. The area unit used is the size of a basic nand2 gate from the platform's standard cell library. The default value is platform specific.| 0| |
@@ -430,6 +431,7 @@ configuration file.
 - [SET_RC_TCL](#SET_RC_TCL)
 - [SLEW_MARGIN](#SLEW_MARGIN)
 - [SYNTH_ARGS](#SYNTH_ARGS)
+- [SYNTH_HIER_SEPARATOR](#SYNTH_HIER_SEPARATOR)
 - [TAP_CELL_NAME](#TAP_CELL_NAME)
 - [TECH_LEF](#TECH_LEF)
 - [USE_FILL](#USE_FILL)

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -17,6 +17,10 @@ if {[env_var_exists_and_non_empty SYNTH_KEEP_MODULES]} {
   }
 }
 
+if {[env_var_exists_and_non_empty SYNTH_HIER_SEPARATOR]} {
+  scratchpad -set flatten.separator $::env(SYNTH_HIER_SEPARATOR)
+}
+
 set synth_full_args $::env(SYNTH_ARGS)
 if {[env_var_exists_and_non_empty SYNTH_OPERATIONS_ARGS]} {
   set synth_full_args [concat $synth_full_args $::env(SYNTH_OPERATIONS_ARGS)]

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -677,6 +677,10 @@ SYNTH_ARGS:
   description: |
     Optional synthesis variables for yosys.
   default: -flatten
+SYNTH_HIER_SEPARATOR:
+  description: |
+    Separator used for the synthesis flatten stage.
+  default: .
 VERILOG_TOP_PARAMS:
   description: |
     Apply toplevel params (if exist).


### PR DESCRIPTION
This PR adds ability to specify a custom hierarchy separator which will be used for the `flatten` pass during synthesis.