### PR TITLE
reduced clock period and die size for asap7 cva6

### DIFF
--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -88,10 +88,10 @@ export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_64x256.lib \
 
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
 
-export CORE_UTILIZATION       = 50
+export CORE_UTILIZATION       = 70
 export CORE_MARGIN            = 2
-export MACRO_HALO             = 5
-export PLACE_DENSITY          = 0.64
+export MACRO_PLACE_HALO       = 3 3
+export PLACE_DENSITY          = 0.73
 
 # a smoketest for this option, there are a
 # few last gasp iterations

--- a/flow/designs/asap7/cva6/constraint.sdc
+++ b/flow/designs/asap7/cva6/constraint.sdc
@@ -3,7 +3,7 @@
 set clk_name main_clk
 set clk_port clk_i
 set clk_ports_list [list $clk_port]
-set clk_period 1300
+set clk_period 1200
 set input_delay 0.46
 set output_delay 0.11
 create_clock [get_ports $clk_port] -name $clk_name -period $clk_period

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 20743,
+        "value": 20690,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 137118,
+        "value": 136421,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 11923,
+        "value": 11863,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 11923,
+        "value": 11863,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1124948,
+        "value": 1074578,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -68.36,
+        "value": -139.89,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 20933,
+        "value": 20850,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 5962,
+        "value": 5931,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -10.27,
+        "value": -10.0,
         "compare": ">="
     }
 }


### PR DESCRIPTION
Reducing clock period to get back to negative slack and reduced die size. Also reduced the halo size

Updated run time is still about an hour.

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__count__stdcell    |   136483 |   136421 | Tighten  |
| cts__design__instance__count__setup_buffer    |    11868 |    11863 | Tighten  |
| cts__design__instance__count__hold_buffer     |    11868 |    11863 | Tighten  |
| finish__timing__setup__ws                     |   -55.89 |  -139.89 | Failing  |
| finish__timing__drv__setup_violation_count    |     5934 |     5931 | Tighten  |
