### PR TITLE
added support for AutoTuner to stop after a specified stage

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -541,7 +541,8 @@ clean_cts:
 route: $(RESULTS_DIR)/5_route.odb \
        $(RESULTS_DIR)/5_route.sdc
 
-.PHONY: grt
+.PHONY: grt globalroute
+globalroute: grt
 grt: $(RESULTS_DIR)/5_1_grt.odb
 
 # ==============================================================================


### PR DESCRIPTION
Added support for --stop_stage argument to tell the AutoTuner to stop after a specified stage (e.g. globalroute).

Updated metrics extraction to take this into account by:

- Using the stop stage instead of "finish" for most of the metrics
- Ignoring the detailed route metrics if we stop before "route" (or else the run gets flagged as an error)
- Updated the metrics/evaluate code to pass back the die area, so that we can view it in TensorBoard.

Added a Makefile entry to map the "globalroute" target to "grt", since the metrics keyword is "globalroute". That way we can use the same stage name as the lookup key in the metrics.json.

@luarss , @vvbandeira FYI.