### PR TITLE
[Autotuner] Fix tensorboard hparam regression

### DIFF
--- a/tools/AutoTuner/requirements.txt
+++ b/tools/AutoTuner/requirements.txt
@@ -5,7 +5,7 @@ optuna==3.6.0
 pandas>=2.0,<=2.2.1
 bayesian-optimization==1.4.0
 colorama==0.4.6
-tensorboard>=2.14.0,<=2.16.2
+tensorboard>=2.17.0
 protobuf>=5.26.1
 SQLAlchemy==1.4.17
 urllib3>=1.26.17


### PR DESCRIPTION
- tensorboard < 2.16.2 used some old protobuf functions that were dropped in current protobuf, so a bump in version is needed.
fixes #3273 