### PR TITLE
dependencies: missed a spot when adding PYTHON_EXE dependency injection

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -52,7 +52,7 @@ if {![env_var_equals SYNTH_HIERARCHICAL 1]} {
 
 json -o $::env(RESULTS_DIR)/mem.json
 # Run report and check here so as to fail early if this synthesis run is doomed
-exec -- python3 $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
+exec -- $::env(PYTHON_EXE) $::env(SCRIPTS_DIR)/mem_dump.py --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
 
 if {![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS]} {
   synth -top $::env(DESIGN_NAME) -run fine: {*}$synth_full_args


### PR DESCRIPTION
Found by inspection, not because something failed. Should be this way for consistency and to minimize surprise.