### PR TITLE
make: make vars/issue fix

### DIFF
--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -22,7 +22,7 @@ while read -r VAR; do
         # they are invalid in shell
         continue
     fi
-    name="${VAR%=*}"
+    name="${VAR%%=*}"
     value="${VAR#*=}"
     if [[ "${name}" =~ ^[[:digit:]] ]] ; then
         # skip if the name starts with a number


### PR DESCRIPTION
The name of the variable is what comes before the first, not the last '=' char

Fixes make DESIGN_CONFIG=designs/asap7/mock-array/config.mk vars, for instance, because MAKEFLAGS is not excluded from vars.sh generated.