### PR TITLE
logging: log hash alongside elapsed to help find divergent/non-deterministic results

### DIFF
--- a/flow/test/test_genElapsedTime.py
+++ b/flow/test/test_genElapsedTime.py
@@ -30,7 +30,7 @@ class TestElapsedTime(unittest.TestCase):
         genElapsedTime.scan_logs(["--logDir", str(self.tmp_dir.name), "--noHeader"])
         # check if output is correct
         expected_output = (
-            self.tmp_dir.name + "\n1_test 5400 9440\nTotal 5400 9440\n"
+            self.tmp_dir.name + "\n1_test 5400 9440 N/A\nTotal 5400 9440\n"
         ).split()
         actual_output = mock_stdout.getvalue().split()
         self.assertEqual(actual_output, expected_output)
@@ -44,7 +44,7 @@ class TestElapsedTime(unittest.TestCase):
         # call the script with the test log file
         genElapsedTime.scan_logs(["--logDir", str(self.tmp_dir.name), "--noHeader"])
         expected_output = (
-            self.tmp_dir.name + "\n1_test 74 9440\nTotal 74 9440\n"
+            self.tmp_dir.name + "\n1_test 74 9440 N/A\nTotal 74 9440\n"
         ).split()
         actual_output = mock_stdout.getvalue().split()
         self.assertEqual(actual_output, expected_output)
@@ -61,7 +61,7 @@ class TestElapsedTime(unittest.TestCase):
         genElapsedTime.scan_logs(["--logDir", str(self.tmp_dir.name), "--noHeader"])
         # check if output is correct
         expected_output = (
-            self.tmp_dir.name + "\n1_test 744 9440 Total 744 9440"
+            self.tmp_dir.name + "\n1_test 744 9440 N/A Total 744 9440"
         ).split()
         actual_output = mock_stdout.getvalue().split()
         self.assertEqual(actual_output, expected_output)

--- a/flow/util/genElapsedTime.py
+++ b/flow/util/genElapsedTime.py
@@ -4,9 +4,10 @@
 # in the flow and prints it in a table
 # ---------------------------------------------------------------------------
 
+import argparse
+import hashlib
 import pathlib
 import os
-import argparse  # argument parsing
 import sys
 
 # Parse and validate arguments
@@ -61,15 +62,33 @@ def print_log_dir_times(logdir, args):
                         int(line.split("Peak memory: ")[1].split("KB")[0]) / 1024
                     )
 
+            # content hash for .odb file alongside .log file is useful to
+            # debug divergent results under what should be identical
+            # builds(such as local and CI builds)
+            odb_file = pathlib.Path(
+                str(f).replace("logs/", "results/").replace(".log", ".odb")
+            )
+            if odb_file.exists():
+                hasher = hashlib.sha1()
+                with open(odb_file, "rb") as odb_f:
+                    while chunk := odb_f.read(16 * 1024 * 1024):
+                        hasher.update(chunk)
+                odb_hash = hasher.hexdigest()
+            else:
+                odb_hash = "N/A"
+
             if not found:
                 print("No elapsed time found in", str(f), file=sys.stderr)
                 continue
 
         # Print the name of the step and the corresponding elapsed time
-        format_str = "%-25s %20s %14s"
+        format_str = "%-25s %10s %14s %20s"
         if elapsedTime is not None and peak_memory is not None:
             if first and not args.noHeader:
-                print(format_str % ("Log", "Elapsed seconds", "Peak Memory/MB"))
+                print(
+                    format_str
+                    % ("Log", "Elapsed/s", "Peak Memory/MB", "sha1sum .odb [0:20)")
+                )
                 first = False
             print(
                 format_str
@@ -77,13 +96,14 @@ def print_log_dir_times(logdir, args):
                     os.path.splitext(os.path.basename(str(f)))[0],
                     elapsedTime,
                     peak_memory,
+                    odb_hash[0:20],
                 )
             )
         totalElapsed += elapsedTime
         total_max_memory = max(total_max_memory, int(peak_memory))
 
     if totalElapsed != 0:
-        print(format_str % ("Total", totalElapsed, total_max_memory))
+        print(format_str % ("Total", totalElapsed, total_max_memory, ""))
 
 
 def scan_logs(args):


### PR DESCRIPTION
Example. A failed step could end up with log and no .odb file.

```
$ make elapsed
./logs/nangate45/gcd/base
Log                        Elapsed/s Peak Memory/MB  sha1sum .odb [0:20)
1_1_yosys                          0             43                  N/A
1_1_yosys_canonicalize             0             40                  N/A
2_1_floorplan                      0             98 50eac5062cd153c214bc
2_2_floorplan_macro                0             94 50eac5062cd153c214bc
2_3_floorplan_tapcell              0             94 ac3fe102c900185d2480
2_4_floorplan_pdn                  0             96 59b27705fdbd75c33f36
3_1_place_gp_skip_io               0             95 d6b4e2de32af97e51809
3_2_place_iop                      0             95 abe5f19e242458533155
3_3_place_gp                       1            211 1a7e366da16e932d2917
3_4_place_resized                  0            114 0171f43d6d2d17c772e9
3_5_place_dp                       0            100 79e4817b19df4b20222a
4_1_cts                            2            127 b342824a6e10d783e773
5_1_grt                            5            214 ba9e7089ccedd24d7e9f
5_2_route                         11           1215 f48628e592653b8c3c3f
5_3_fillcell                       0             97 f32e153bcd24ed0862d5
6_1_fill                           0             95 f32e153bcd24ed0862d5
6_1_merge                          1            376                  N/A
6_report                           1            250                  N/A
Total                             21           1215                     
```
