### PR TITLE
synth: more consistent naming

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -286,12 +286,12 @@ do-yosys: $(DONT_USE_SC_LIB)
 
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies $(DONT_USE_SC_LIB)
-	$(SCRIPTS_DIR)/synth.sh $(SCRIPTS_DIR)/synth_canonicalize.tcl $(LOG_DIR)/1_1_yosys_canonicalize.log
+	$(SCRIPTS_DIR)/synth.sh $(SCRIPTS_DIR)/synth_canonicalize.tcl $(LOG_DIR)/1_0_yosys_canonicalize.log
 
-$(RESULTS_DIR)/1_synth.rtlil: $(YOSYS_DEPENDENCIES)
+$(RESULTS_DIR)/1_0_yosys_canonicalize.rtlil: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
-$(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_synth.rtlil
+$(RESULTS_DIR)/1_1_yosys.v: $(RESULTS_DIR)/1_0_yosys_canonicalize.rtlil
 	$(UNSET_AND_MAKE) do-yosys
 
 .PHONY: do-synth

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -1,5 +1,5 @@
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
-read_checkpoint $::env(RESULTS_DIR)/1_synth.rtlil
+read_checkpoint $::env(RESULTS_DIR)/1_0_yosys_canonicalize.rtlil
 
 hierarchy -check -top $::env(DESIGN_NAME)
 

--- a/flow/scripts/synth_canonicalize.tcl
+++ b/flow/scripts/synth_canonicalize.tcl
@@ -10,4 +10,4 @@ hierarchy -check -top $::env(DESIGN_NAME)
 # Get rid of unused modules
 opt_clean -purge
 # The hash of this file will not change if files not part of synthesis do not change
-write_rtlil $::env(RESULTS_DIR)/1_synth.rtlil
+write_rtlil $::env(RESULTS_DIR)/1_0_yosys_canonicalize.rtlil


### PR DESCRIPTION
I'm not keen on changing 1_1_yosys stem as I don't know what tools that rely on that name, like metrics, but canonicalization happens before 1_1_yosys, so the compromise is to create 1_0_yosys_canonicalize stem.