### PR TITLE
flow: update mock-array params and aes-block metrics in order to honor macro thresholds

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -24,7 +24,7 @@
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1561,
+        "value": 1866,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -152.45,
+        "value": -243.45,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -18.47,
+        "value": -43.48,
         "compare": ">="
     }
 }

--- a/flow/designs/asap7/mock-array/config.mk
+++ b/flow/designs/asap7/mock-array/config.mk
@@ -26,6 +26,10 @@ export DIE_AREA  = $(shell \
 export MACRO_PLACE_HALO = 0 2.16
 export RTLMP_BOUNDARY_WT = 0
 export RTLMP_FLOW ?= 1
+export RTLMP_MAX_INST = 250
+export RTLMP_MIN_INST = 50
+export RTLMP_MAX_MACRO = 64
+export RTLMP_MIN_MACRO = 8
 
 export BLOCKS                ?= Element
 


### PR DESCRIPTION
Updates asap7/mock-array MPL parameters allowing the proper use of macro thresholds in the design.

Also updates failing rules on asap7/aes-block.
designs/asap7/aes-block/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__design__instance__count__hold_buffer     |     1331 |     1866 | Failing  |
| finish__timing__setup__ws                     |  -152.45 |  -243.45 | Failing  |
| finish__timing__wns_percent_delay             |   -18.47 |   -43.48 | Failing  |

Should be merged alongside OR [#7619](https://github.com/The-OpenROAD-Project/OpenROAD/pull/7619)