### PR TITLE
make: silently suppress warnings in read_liberty.tcl

### DIFF
--- a/flow/platforms/asap7/liberty_suppressions.tcl
+++ b/flow/platforms/asap7/liberty_suppressions.tcl
@@ -1,4 +1,4 @@
 # To remove [WARNING STA-1212] from the logs for ASAP7.
 # /OpenROAD-flow-scripts/flow/platforms/asap7/lib/asap7sc7p5t_SIMPLE_RVT_TT_nldm_211120.lib.gz line 13178, timing group from output port.
 # Added following suppress_message
-log_cmd suppress_message STA 1212
+suppress_message STA 1212

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -3,12 +3,6 @@ source $::env(SCRIPTS_DIR)/util.tcl
 source $::env(SCRIPTS_DIR)/report_metrics.tcl
 
 proc load_design { design_file sdc_file } {
-  # Source platform-related Tcl command (initially for suppressing Liberty
-  # warnings
-  if { [env_var_exists_and_non_empty PLATFORM_TCL] } {
-    log_cmd source $::env(PLATFORM_TCL)
-  }
-
   # Read liberty files
   source $::env(SCRIPTS_DIR)/read_liberty.tcl
 

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -3,7 +3,8 @@ source $::env(SCRIPTS_DIR)/util.tcl
 source $::env(SCRIPTS_DIR)/report_metrics.tcl
 
 proc load_design { design_file sdc_file } {
-  # Read liberty files
+  source_env_var_if_exists PLATFORM_TCL
+
   source $::env(SCRIPTS_DIR)/read_liberty.tcl
 
   # Read design files

--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -1,10 +1,10 @@
 source $::env(SCRIPTS_DIR)/util.tcl
-# Read liberty files
+
+source_env_var_if_exists PLATFORM_TCL
+
 source $::env(SCRIPTS_DIR)/read_liberty.tcl
 
-# Read def
 if { [env_var_exists_and_non_empty DEF_FILE] } {
-  # Read lef
   log_cmd read_lef $::env(TECH_LEF)
   log_cmd read_lef $::env(SC_LEF)
   if { [env_var_exists_and_non_empty ADDITIONAL_LEFS] } {

--- a/flow/scripts/read_liberty.tcl
+++ b/flow/scripts/read_liberty.tcl
@@ -1,3 +1,9 @@
+# Source platform-related Tcl command (initially for suppressing Liberty
+# warnings
+if { [env_var_exists_and_non_empty PLATFORM_TCL] } {
+  source $::env(PLATFORM_TCL)
+}
+
 #Read Liberty
 if { [env_var_exists_and_non_empty CORNERS] } {
   # corners

--- a/flow/scripts/read_liberty.tcl
+++ b/flow/scripts/read_liberty.tcl
@@ -1,9 +1,3 @@
-# Source platform-related Tcl command (initially for suppressing Liberty
-# warnings
-if { [env_var_exists_and_non_empty PLATFORM_TCL] } {
-  source $::env(PLATFORM_TCL)
-}
-
 #Read Liberty
 if { [env_var_exists_and_non_empty CORNERS] } {
   # corners

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -205,3 +205,9 @@ proc place_density_with_lb_addon { } {
   }
   return $place_density
 }
+
+proc source_env_var_if_exists { env_var } {
+  if { [env_var_exists_and_non_empty $env_var] } {
+    source $::env($env_var)
+  }
+}


### PR DESCRIPTION
This fixes  and `make gui_open` and also `make floorplan`

Reduce log spam: don't log command that suppresses warning