### PR TITLE
asap7: constraints.sdc max delay excludes clock latency

### DIFF
--- a/flow/designs/asap7/mock-array/rules-base.json
+++ b/flow/designs/asap7/mock-array/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 35273.33,
+        "value": 34554.19,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -48,7 +48,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -457.76,
+        "value": -89.95,
         "compare": ">="
     },
     "finish__design__instance__area": {
@@ -56,7 +56,7 @@
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 605,
+        "value": 536,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {
@@ -64,7 +64,7 @@
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {
-        "value": -111.1,
+        "value": -31.9,
         "compare": ">="
     }
 }

--- a/flow/platforms/asap7/constraints.sdc
+++ b/flow/platforms/asap7/constraints.sdc
@@ -74,11 +74,13 @@ set non_clk_inputs [all_inputs -no_clocks]
 # Optimization targets: overconstrain by default and
 # leave refinements to a more design specific constraints.sdc file.
 #
-# Minimum time for io-io, io-reg, reg-io paths in macro is on
-# the order of 80ps for a small macro on ASAP7.
-set_max_delay [expr { [info exists in2reg_max] ? $in2reg_max : 80 }] -from $non_clk_inputs \
+# Minimum time, excluding clock latency, for io-io, io-reg, reg-io
+# paths in macro is on the order of 80ps for a small macro on ASAP7.
+set_max_delay -ignore_clock_latency \
+  [expr { [info exists in2reg_max] ? $in2reg_max : 80 }] -from $non_clk_inputs \
   -to [all_registers]
-set_max_delay [expr { [info exists reg2out_max] ? $reg2out_max : 80 }] -from [all_registers] \
+set_max_delay -ignore_clock_latency \
+  [expr { [info exists reg2out_max] ? $reg2out_max : 80 }] -from [all_registers] \
   -to [all_outputs]
 set_max_delay [expr { [info exists in2out_max] ? $in2out_max : 80 }] -from $non_clk_inputs \
   -to [all_outputs]


### PR DESCRIPTION
https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3337#issuecomment-3097914589


| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 35273.33 | 34554.19 | Tighten  |
| finish__timing__setup__ws                     |  -457.76 |   -89.95 | Tighten  |
| finish__timing__drv__setup_violation_count    |      605 |      536 | Tighten  |
| finish__timing__wns_percent_delay             |   -111.1 |    -31.9 | Tighten  |
