### PR TITLE
fast_route: cleanup of vestiges

### DIFF
--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -18,7 +18,14 @@ if { ![env_var_exists_and_non_empty FOOTPRINT] } {
   }
 }
 
-fast_route
+if { [env_var_exists_and_non_empty FASTROUTE_TCL] } {
+  log_cmd source $::env(FASTROUTE_TCL)
+} else {
+  log_cmd \
+    set_global_routing_layer_adjustment \
+    $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) $::env(ROUTING_LAYER_ADJUSTMENT)
+  log_cmd set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
+}
 
 set global_placement_args {}
 

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -35,17 +35,6 @@ proc repair_tie_fanout_helper { } {
   repair_tie_fanout -separation $tie_separation $tiehi_pin
 }
 
-proc fast_route { } {
-  if { [env_var_exists_and_non_empty FASTROUTE_TCL] } {
-    log_cmd source $::env(FASTROUTE_TCL)
-  } else {
-    log_cmd \
-      set_global_routing_layer_adjustment \
-      $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) $::env(ROUTING_LAYER_ADJUSTMENT)
-    log_cmd set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
-  }
-}
-
 proc repair_timing_helper { args } {
   set additional_args "$args -verbose"
   append_env_var additional_args SETUP_SLACK_MARGIN -setup_margin 1


### PR DESCRIPTION
global_place.tcl now stores FASTROUTE_TCL/set_routing_layers in .odb so the need for the brittle fast_route utility fn is gone