### PR TITLE
Removed rvfi_probes_o interface and connectivity

### DIFF
--- a/flow/designs/asap7/cva6/canonicalize.tcl
+++ b/flow/designs/asap7/cva6/canonicalize.tcl
@@ -1,0 +1,4 @@
+# Remove rvfi_probes_o interface since contributes 4k ports and connections
+# (many of which are buffers tied to tie cells)
+
+delete cva6/o:rvfi_probes_o*

--- a/flow/designs/asap7/cva6/config.mk
+++ b/flow/designs/asap7/cva6/config.mk
@@ -105,3 +105,6 @@ export SYNTH_HDL_FRONTEND = slang
 export ASAP7_USE_VT = RVT LVT SLVT
 
 export CTS_LIB_NAME = asap7sc7p5t_INVBUF_SLVT_FF_nldm_211120
+
+# Remove rvfi_probes_o interface
+export SYNTH_CANONICALIZE_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/canonicalize.tcl

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 19725.15,
+        "value": 18975.35,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 20690,
+        "value": 19709,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 136421,
+        "value": 123443,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,11 +20,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 11863,
+        "value": 10734,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 11863,
+        "value": 10734,
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
@@ -32,7 +32,7 @@
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
-        "value": 1074578,
+        "value": 716033,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -48,15 +48,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -139.89,
+        "value": -82.95,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 20850,
+        "value": 19864,
         "compare": "<="
     },
     "finish__timing__drv__setup_violation_count": {
-        "value": 5931,
+        "value": 5367,
         "compare": "<="
     },
     "finish__timing__drv__hold_violation_count": {


### PR DESCRIPTION
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| synth__design__instance__area__stdcell        | 19725.15 | 18975.35 | Tighten  |
| placeopt__design__instance__area              |    20690 |    19709 | Tighten  |
| placeopt__design__instance__count__stdcell    |   136421 |   123443 | Tighten  |
| cts__design__instance__count__setup_buffer    |    11863 |    10734 | Tighten  |
| cts__design__instance__count__hold_buffer     |    11863 |    10734 | Tighten  |
| detailedroute__route__wirelength              |  1074578 |   716033 | Tighten  |
| finish__timing__setup__ws                     |  -139.89 |   -82.95 | Tighten  |
| finish__design__instance__area                |    20850 |    19864 | Tighten  |
| finish__timing__drv__setup_violation_count    |     5931 |     5367 | Tighten  |
