### PR TITLE
io: always write out 3_2_place_iop.tcl

### DIFF
--- a/flow/scripts/io_placement.tcl
+++ b/flow/scripts/io_placement.tcl
@@ -12,7 +12,7 @@ if {
     -ver_layers $::env(IO_PLACER_V) \
     {*}[env_var_or_empty PLACE_PINS_ARGS]
   write_db $::env(RESULTS_DIR)/3_2_place_iop.odb
-  write_pin_placement $::env(RESULTS_DIR)/3_2_place_iop.tcl
 } else {
   log_cmd exec cp $::env(RESULTS_DIR)/3_1_place_gp_skip_io.odb $::env(RESULTS_DIR)/3_2_place_iop.odb
 }
+write_pin_placement $::env(RESULTS_DIR)/3_2_place_iop.tcl


### PR DESCRIPTION
@maliberty I just noticed this while spelunking.

Does it make more sense to always write out io placement?
