### PR TITLE
Remove duplicate instructions in pre-built install docs

### DIFF
--- a/docs/user/BuildWithPrebuilt.md
+++ b/docs/user/BuildWithPrebuilt.md
@@ -34,17 +34,6 @@ Step 3: Run the install command based on platform use package installer.
 sudo apt install ./openroad_2.0_amd64-ubuntu20.04.deb
 ```
 
-## Install Klayout and Yosys
-Please ensure the Klayout version (denoted with `klayoutVersion` variable) is consistent with the one used in [DependencyInstaller script](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/blob/master/etc/DependencyInstaller.sh).
-
-Instructions for installing:
-- [Klayout>=0.28.8](https://www.klayout.de/build.html)
-- [Yosys>=0.39](https://github.com/YosysHQ/oss-cad-suite-build/blob/master/README.md#installation)
-
-```{tip} Unfortunately KLayout maintainers do not provide Debian 11 compatible packages. You can follow the build-from-sources instruction (Version >=0.25) and Ubuntu 22 instructions [here](https://www.klayout.de/build.html#:~:text=Building%20KLayout%20on%20Linux%20(Version%20%3E%3D%200.25)).
-```
-
-
 ## Verify Installation
 You may clone the OpenROAD-flow-scripts repository non-recursively.
 


### PR DESCRIPTION
Hi, just was reading the docs and noticed that the section for installing pre-built binaries seemed to have the same section on Klayout and Yosys dependencies duplicated. Just figured I'd help clean it up for clarity. 