### PR TITLE
Gui synth

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -414,9 +414,8 @@ do-$(1)$(if $(4),$(4),):
 	cp $(RESULTS_DIR)/$(2) $(RESULTS_DIR)/$(1)$(if $(4),$(4),.odb)
 endef
 
+$(eval $(call do-step,1_3_synth,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc,synth_odb))
 
-# STEP 1: Translate verilog to odb
-#-------------------------------------------------------------------------------
 $(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL) $(DONT_USE_SC_LIB),floorplan))
 
 $(eval $(call do-copy,2_floorplan,2_1_floorplan.sdc,,.sdc))
@@ -775,13 +774,7 @@ nuke: clean_test clean_issues
 $(foreach file,$(RESULTS_DEF) $(RESULTS_GDS) $(RESULTS_OAS),klayout_$(file)): klayout_%: $(OBJECTS_DIR)/klayout.lyt
 	$(KLAYOUT_CMD) -nn $(OBJECTS_DIR)/klayout.lyt $(RESULTS_DIR)/$*
 
-.PHONY: gui_synth
-gui_synth:
-	$(OPENROAD_GUI_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
-.PHONY: open_synth
-open_synth:
-	$(OPENROAD_NO_EXIT_CMD) $(SCRIPTS_DIR)/sta-synth.tcl
-
+$(eval $(call OPEN_GUI_SHORTCUT,synth,1_synth.odb))
 $(eval $(call OPEN_GUI_SHORTCUT,floorplan,2_floorplan.odb))
 $(eval $(call OPEN_GUI_SHORTCUT,place,3_place.odb))
 $(eval $(call OPEN_GUI_SHORTCUT,cts,4_cts.odb))

--- a/flow/scripts/sta-synth.tcl
+++ b/flow/scripts/sta-synth.tcl
@@ -1,2 +1,0 @@
-source $::env(SCRIPTS_DIR)/load.tcl
-load_design 1_synth.v 1_synth.sdc

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -1,0 +1,16 @@
+utl::set_metrics_stage "floorplan__{}"
+source $::env(SCRIPTS_DIR)/load.tcl
+erase_non_stage_variables synth
+load_design 1_synth.v 1_synth.sdc
+
+write_db $::env(RESULTS_DIR)/1_3_synth.odb
+# Canonicalize 1_synth.sdc. The original SDC_FILE provided by
+# the user could have dependencies, such as sourcing util.tcl,
+# which are read in here and a canonicalized version is written
+# out by OpenSTA that has no dependencies.
+write_sdc -no_timestamp $::env(RESULTS_DIR)/1_3_synth.sdc
+
+# Final output of the synthesis stage, the other files are written out for
+# consistency and logging of .odb hashes
+exec cp $::env(RESULTS_DIR)/1_3_synth.sdc $::env(RESULTS_DIR)/1_synth.sdc
+exec cp $::env(RESULTS_DIR)/1_3_synth.odb $::env(RESULTS_DIR)/1_synth.odb


### PR DESCRIPTION
`make gui_synth` is an important use-case for fast turnaround, less accurate, RTL rinse and repeat cycles when looking at timing reports, endpoint slack histograms in the GUI.

The only reason why an .odb file and canonicalized .sdc file is not always written out by the synth stage by ORFS by default, is that this takes a bit of extra time and space and it was not deemed desirable. It is a bit of a toss-up, accept less consistency in the flow, or pay a moderate performance penalty. Switching to always writing .odb and canonicalized .sdc is simple enough to do if we change our mind and want simpler, more consistency and fewer suprises across stages.

- gui_synth: improve user experience, same code as for gui_floorplan/grt, etc. GUI_TIMING=0 now works.
- sta-synth.tcl was trying to do the same as open.tcl. DRY, now we only have open.tcl
- .odb file output from synth + canonicalization of 1_synth.sdc, i.e. it is written out by OpenSTA instead of copied from user. This means that any dependencies that the user's SDC_FILE has is not dragged into floorplan.

bazel-orfs will be updated to use this. No change to normal ORFS flow.

To use gui_synth, there is an additional step:

    make synth
    # New step that writes out 1_synth.odb and canonicalizes
    # 1_synth.sdc
    make do-1_3_synth
    make gui_synth
