### PR TITLE
Add global variables for repair antennas iterations

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -49,7 +49,7 @@
 # DESIGN_CONFIG=./designs/sky130hs/aes/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/gcd/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/ibex/config.mk
- DESIGN_CONFIG=./designs/sky130hs/jpeg/config.mk
+# DESIGN_CONFIG=./designs/sky130hs/jpeg/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/riscv32i/config.mk
 
 # DESIGN_CONFIG=./designs/asap7/aes/config.mk

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -49,7 +49,7 @@
 # DESIGN_CONFIG=./designs/sky130hs/aes/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/gcd/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/ibex/config.mk
-# DESIGN_CONFIG=./designs/sky130hs/jpeg/config.mk
+ DESIGN_CONFIG=./designs/sky130hs/jpeg/config.mk
 # DESIGN_CONFIG=./designs/sky130hs/riscv32i/config.mk
 
 # DESIGN_CONFIG=./designs/asap7/aes/config.mk

--- a/flow/designs/sky130hs/jpeg/rules-base.json
+++ b/flow/designs/sky130hs/jpeg/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 141,
+        "value": 87,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,11 +40,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 0,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 154,
+        "value": 86,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/sky130hs/jpeg/rules-base.json
+++ b/flow/designs/sky130hs/jpeg/rules-base.json
@@ -28,7 +28,7 @@
         "compare": "<="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 87,
+        "value": 141,
         "compare": "<="
     },
     "detailedroute__route__wirelength": {
@@ -40,11 +40,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 86,
+        "value": 154,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -68,6 +68,10 @@ export MIN_ROUTING_LAYER       ?= M2
 export MIN_CLK_ROUTING_LAYER   ?= M4
 export MAX_ROUTING_LAYER       ?= M7
 
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/gf180/config.mk
+++ b/flow/platforms/gf180/config.mk
@@ -93,6 +93,10 @@ export MIN_ROUTING_LAYER                     ?= Metal2
 export MAX_ROUTING_LAYER                     ?= Metal5
 export DISABLE_VIA_GEN                       ?= 1
 
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -115,7 +115,11 @@ export MAX_ROUTING_LAYER 		?= Metal5
 #export VIA_IN_PIN_MIN_LAYER ?= Metal1
 #export VIA_IN_PIN_MAX_LAYER ?= Metal1
 #export DISABLE_VIA_GEN      ?= 1
-#
+
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -75,6 +75,10 @@ export MIN_ROUTING_LAYER = metal2
 export MIN_CLK_ROUTING_LAYER = metal4
 export MAX_ROUTING_LAYER = metal10
 
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -118,6 +118,10 @@ export MIN_ROUTING_LAYER ?= met1
 export MIN_CLK_ROUTING_LAYER ?= met3
 export MAX_ROUTING_LAYER ?= met5
 #
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+#
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -80,6 +80,10 @@ export MIN_ROUTING_LAYER = met1
 export MIN_CLK_ROUTING_LAYER = met3
 export MAX_ROUTING_LAYER = met5
 #
+# Max iterations of repair antennas
+export MAX_REPAIR_ANTENNAS_ITER_GRT ?= 5
+export MAX_REPAIR_ANTENNAS_ITER_DRT ?= 5
+#
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -63,7 +63,7 @@ if { ![env_var_equals SKIP_ANTENNA_REPAIR_POST_DRT 1] && $::env(MAX_REPAIR_ANTEN
     incr repair_antennas_iters
   }
 } else {
-  utl::metric_int "antenna_diodes_count" 0
+  utl::metric_int "antenna_diodes_count" -1
 }
 
 source_env_var_if_exists POST_DETAIL_ROUTE_TCL

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -52,18 +52,18 @@ set all_args [concat [list \
 
 log_cmd detailed_route {*}$all_args
 
-if { ![env_var_equals SKIP_ANTENNA_REPAIR_POST_DRT 1] } {
+if { ![env_var_equals SKIP_ANTENNA_REPAIR_POST_DRT 1] && $::env(MAX_REPAIR_ANTENNAS_ITER_DRT) } {
   set repair_antennas_iters 1
   if { [repair_antennas] } {
     detailed_route {*}$all_args
   }
-  while { [check_antennas] && $repair_antennas_iters < 5 } {
+  while { [check_antennas] && $repair_antennas_iters < $::env(MAX_REPAIR_ANTENNAS_ITER_DRT) } {
     repair_antennas
     detailed_route {*}$all_args
     incr repair_antennas_iters
   }
 } else {
-  utl::metric_int "antenna_diodes_count" -1
+  utl::metric_int "antenna_diodes_count" 0
 }
 
 source_env_var_if_exists POST_DETAIL_ROUTE_TCL

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -86,9 +86,9 @@ proc global_route_helper { } {
   log_cmd global_route -end_incremental \
     -congestion_report_file $::env(REPORTS_DIR)/congestion_post_recover_power.rpt
 
-  if { ![env_var_equals SKIP_ANTENNA_REPAIR 1] } {
+  if { ![env_var_equals SKIP_ANTENNA_REPAIR 1] && $::env(MAX_REPAIR_ANTENNAS_ITER_GRT) } {
     puts "Repair antennas..."
-    repair_antennas -iterations 5
+    repair_antennas -iterations $::env(MAX_REPAIR_ANTENNAS_ITER_GRT)
     check_placement -verbose
     check_antennas -report_file $::env(REPORTS_DIR)/grt_antennas.log
   }


### PR DESCRIPTION
Creating global variables for the maximum number of repair antenna iterations in GRT and DRT.

designs/sky130hs/jpeg/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| globalroute__antenna_diodes_count             |       87 |      141 | Failing  |
| detailedroute__antenna__violating__nets       |        1 |        0 | Tighten  |
| detailedroute__antenna_diodes_count           |       86 |      154 | Failing  |