### PR TITLE
variables: add OPENROAD_HIERARCHICAL

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -168,6 +168,7 @@ configuration file.
 | <a name="MAX_ROUTING_LAYER"></a>MAX_ROUTING_LAYER| The highest metal layer name to be used in routing.| |
 | <a name="MIN_BUF_CELL_AND_PORTS"></a>MIN_BUF_CELL_AND_PORTS| Used to insert a buffer cell to pass through wires. Used in synthesis.| |
 | <a name="MIN_ROUTING_LAYER"></a>MIN_ROUTING_LAYER| The lowest metal layer name to be used in routing.| |
+| <a name="OPENROAD_HIERARCHICAL"></a>OPENROAD_HIERARCHICAL| Feature toggle to enable to run OpenROAD in hierarchical mode, otherwise considered flat. Will eventually be the default and this option will be retired.| 0|
 | <a name="PDN_TCL"></a>PDN_TCL| File path which has a set of power grid policies used by pdn to be applied to the design, such as layers to use, stripe width and spacing to generate the actual metal straps.| |
 | <a name="PLACE_DENSITY"></a>PLACE_DENSITY| The desired average placement density of cells: 1.0 = dense, 0.0 = widely spread. The intended effort is also communicated by this parameter. Use a low value for faster builds and higher value for better quality of results. If a too low value is used, the placer will not be able to place all cells and a recommended minimum placement density can be found in the logs. A too high value can lead to excessive runtimes, even timeouts and subtle failures in the flow after placement, such as in CTS or global routing when timing repair fails. The default is platform specific.| |
 | <a name="PLACE_DENSITY_LB_ADDON"></a>PLACE_DENSITY_LB_ADDON| Check the lower boundary of the PLACE_DENSITY and add PLACE_DENSITY_LB_ADDON if it exists.| |
@@ -483,6 +484,7 @@ configuration file.
 - [KLAYOUT_TECH_FILE](#KLAYOUT_TECH_FILE)
 - [LIB_FILES](#LIB_FILES)
 - [MACRO_EXTENSION](#MACRO_EXTENSION)
+- [OPENROAD_HIERARCHICAL](#OPENROAD_HIERARCHICAL)
 - [PLATFORM](#PLATFORM)
 - [PLATFORM_TCL](#PLATFORM_TCL)
 - [PROCESS](#PROCESS)

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -2,6 +2,20 @@ source $::env(SCRIPTS_DIR)/util.tcl
 
 source $::env(SCRIPTS_DIR)/report_metrics.tcl
 
+# Feature toggle for now, eventually the -hier option
+# will be default and this code will be deleted.
+proc hier_options { } {
+  if {
+    [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
+    [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS] ||
+    [env_var_equals OPENROAD_HIERARCHICAL 1]
+  } {
+    return "-hier"
+  } else {
+    return ""
+  }
+}
+
 proc load_design { design_file sdc_file } {
   source_env_var_if_exists PLATFORM_TCL
 
@@ -18,23 +32,9 @@ proc load_design { design_file sdc_file } {
       }
     }
     read_verilog $::env(RESULTS_DIR)/$design_file
-    if {
-      [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
-      [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]
-    } {
-      link_design -hier $::env(DESIGN_NAME)
-    } else {
-      link_design $::env(DESIGN_NAME)
-    }
+    link_design {*}[hier_options] $::env(DESIGN_NAME)
   } elseif { $ext == ".odb" } {
-    if {
-      [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
-      [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]
-    } {
-      read_db -hier $::env(RESULTS_DIR)/$design_file
-    } else {
-      read_db $::env(RESULTS_DIR)/$design_file
-    }
+    read_db {*}[hier_options] $::env(RESULTS_DIR)/$design_file
   } else {
     error "Unrecognized input file $design_file"
   }

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -2,20 +2,6 @@ source $::env(SCRIPTS_DIR)/util.tcl
 
 source $::env(SCRIPTS_DIR)/report_metrics.tcl
 
-# Feature toggle for now, eventually the -hier option
-# will be default and this code will be deleted.
-proc hier_options { } {
-  if {
-    [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
-    [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS] ||
-    [env_var_equals OPENROAD_HIERARCHICAL 1]
-  } {
-    return "-hier"
-  } else {
-    return ""
-  }
-}
-
 proc load_design { design_file sdc_file } {
   source_env_var_if_exists PLATFORM_TCL
 
@@ -32,9 +18,9 @@ proc load_design { design_file sdc_file } {
       }
     }
     read_verilog $::env(RESULTS_DIR)/$design_file
-    link_design {*}[hier_options] $::env(DESIGN_NAME)
+    log_cmd link_design {*}[hier_options] $::env(DESIGN_NAME)
   } elseif { $ext == ".odb" } {
-    read_db {*}[hier_options] $::env(RESULTS_DIR)/$design_file
+    log_cmd read_db {*}[hier_options] $::env(RESULTS_DIR)/$design_file
   } else {
     error "Unrecognized input file $design_file"
   }

--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -16,7 +16,7 @@ if { [env_var_exists_and_non_empty DEF_FILE] } {
   log_cmd read_def $input_file
 } else {
   set input_file $::env(ODB_FILE)
-  log_cmd read_db $input_file
+  log_cmd read_db {*}[hier_options] $input_file
 }
 
 proc read_timing { input_file } {

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -186,3 +186,17 @@ proc source_env_var_if_exists { env_var } {
     log_cmd source $::env($env_var)
   }
 }
+
+# Feature toggle for now, eventually the -hier option
+# will be default and this code will be deleted.
+proc hier_options { } {
+  if {
+    [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
+    [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS] ||
+    [env_var_equals OPENROAD_HIERARCHICAL 1]
+  } {
+    return "-hier"
+  } else {
+    return ""
+  }
+}

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1039,3 +1039,9 @@ MAX_REPAIR_ANTENNAS_ITER_GRT:
     antennas will run.
   stages:
     - grt
+OPENROAD_HIERARCHICAL:
+  description: >
+    Feature toggle to enable to run OpenROAD in hierarchical mode,
+    otherwise considered flat. Will eventually be the default and
+    this option will be retired.
+  default: 0


### PR DESCRIPTION
Quick test:

    make DESIGN_CONFIG=designs/asap7/aes/config.mk SYNTH_HIERARCHICAL=1 SYNTH_MINIMUM_KEEP_SIZE=0 OPENROAD_HIERARCHICAL=1 clean_synth synth do-1_3_synth

Recall: do_1_3_synth creates a .odb file

Now run in GUI:

    make DESIGN_CONFIG=designs/asap7/aes/config.mk SYNTH_HIERARCHICAL=1 SYNTH_MINIMUM_KEEP_SIZE=0 OPENROAD_HIERARCHICAL=1 gui_synth

Crashes:

```
OpenROAD v2.0-23724-ge561a140c1 
Features included (+) or not (-): +GPU +GUI +Python
This program is licensed under the BSD-3 license. See the LICENSE file for details.
Components of this program may be licensed under more restrictive licenses which must be honored.
source /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/liberty_suppressions.tcl
read_liberty /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lib/NLDM/asap7sc7p5t_AO_RVT_FF_nldm_211120.lib.gz
read_liberty /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lib/NLDM/asap7sc7p5t_INVBUF_RVT_FF_nldm_220122.lib.gz
read_liberty /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lib/NLDM/asap7sc7p5t_OA_RVT_FF_nldm_211120.lib.gz
read_liberty /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lib/NLDM/asap7sc7p5t_SIMPLE_RVT_FF_nldm_211120.lib.gz
read_liberty /home/oyvind/OpenROAD-flow-scripts/flow/platforms/asap7/lib/NLDM/asap7sc7p5t_SEQ_RVT_FF_nldm_220123.lib
read_db ./results/asap7/aes/base/1_synth.odb
GUI_TIMING=1 reading timing, takes a little while for large designs...
read_sdc /home/oyvind/OpenROAD-flow-scripts/flow/results/asap7/aes/base/1_synth.sdc
find_timing_paths
Signal 11 received
Stack trace:
 0# 0x00005F5FEE32C795 in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 1# 0x000075B2C8C458D0 in /lib/x86_64-linux-gnu/libc.so.6
 2# odb::dbObject::getId() const in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 3# sta::NetIdLess::operator()(sta::Net const*, sta::Net const*) const in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 4# sta::dbNetwork::visitConnectedPins(sta::Net const*, sta::PinVisitor&, sta::NetSet&) const in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 5# sta::dbNetwork::visitConnectedPins(sta::Net const*, sta::PinVisitor&, sta::NetSet&) const in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 6# sta::Network::visitConnectedPins(sta::Pin const*, sta::PinVisitor&) const in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 7# sta::Graph::makeWireEdgesFromPin(sta::Pin const*, sta::PinSet&) in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 8# sta::Graph::makeInstDrvrWireEdges(sta::Instance const*, sta::PinSet&) in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
 9# sta::Graph::makeWireEdges() in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
10# sta::Graph::makeGraph() in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
11# sta::Sta::ensureGraph() in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
12# sta::Sta::searchPreamble() in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
13# sta::Sta::findPathEnds(sta::ExceptionFrom*, sta::Vector<sta::ExceptionThru*>*, sta::ExceptionTo*, bool, sta::Corner const*, sta::MinMaxAll const*, int, int, bool, float, float, bool, sta::Set<char const*, sta::CharPtrLess>*, bool, bool, bool, bool, bool, bool) in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
14# 0x00005F5FEE567B04 in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
15# TclNRRunCallbacks in /lib/x86_64-linux-gnu/libtcl8.6.so
16# 0x000075B2CDAF0B4B in /lib/x86_64-linux-gnu/libtcl8.6.so
17# Tcl_EvalEx in /lib/x86_64-linux-gnu/libtcl8.6.so
18# Tcl_Eval in /lib/x86_64-linux-gnu/libtcl8.6.so
19# gui::TclCmdInputWidget::executeCommand(QString const&, bool, bool) in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
20# gui::startGui(int&, char**, Tcl_Interp*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool) in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
21# 0x00005F5FEE32BB15 in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
22# Tcl_MainEx in /lib/x86_64-linux-gnu/libtcl8.6.so
23# main in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
24# 0x000075B2C8C2A578 in /lib/x86_64-linux-gnu/libc.so.6
25# __libc_start_main in /lib/x86_64-linux-gnu/libc.so.6
26# _start in /home/oyvind/OpenROAD-flow-scripts/tools/install/OpenROAD/bin/openroad
make: *** [Makefile:786: gui_1_synth.odb] Segmentation fault (core dumped)
```
