### PR TITLE
makefile: add explicit check-yosys/openroad targets

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -182,7 +182,7 @@ $(foreach block,$(BLOCKS),$(eval $(WORK_HOME)/results/$(PLATFORM)/$(DESIGN_NICKN
 # Utility to print tool version information
 #-------------------------------------------------------------------------------
 .PHONY: versions.txt
-versions.txt:
+versions.txt: check-yosys check-openroad
 	mkdir -p $(OBJECTS_DIR)
 	@echo "yosys $(shell $(YOSYS_EXE) -V 2>&1)" > $(OBJECTS_DIR)/$@
 	@echo "openroad $(shell $(OPENROAD_EXE) -version 2>&1)" >> $(OBJECTS_DIR)/$@

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -132,7 +132,7 @@ MAKEFLAGS += --no-builtin-rules
 
 #-------------------------------------------------------------------------------
 # Default target when invoking without specific target.
-.DEFAULT_GOAL := finish
+.DEFAULT_GOAL := all
 
 #-------------------------------------------------------------------------------
 # Proper way to initiate SHELL for make
@@ -746,8 +746,22 @@ clean_finish:
 #
 # ==============================================================================
 
+.PHONY: check-openroad
+check-openroad:
+	@if [ "$(strip $(OPENROAD_IS_VALID))" != "true" ]; then \
+		echo "OPENROAD_EXE is set to '$(OPENROAD_EXE)', but it is either not found or not executable."; \
+		exit 1; \
+	fi
+
+.PHONY: check-yosys
+check-yosys:
+	@if [ "$(strip $(YOSYS_IS_VALID))" != "true" ]; then \
+		echo "YOSYS_EXE is set to '$(YOSYS_EXE)', but it is either not found or not executable."; \
+		exit 1; \
+	fi
+
 .PHONY: all
-all: synth floorplan place cts route finish
+all: check-yosys check-openroad synth floorplan place cts route finish
 
 .PHONY: clean
 clean:

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -98,9 +98,6 @@ else
 endif
 
 OPENROAD_IS_VALID := $(if $(OPENROAD_EXE),$(shell test -x $(OPENROAD_EXE) && echo "true"),)
-ifneq ($(strip $(OPENROAD_IS_VALID)),true)
-  $(error OPENROAD_EXE is set to '$(OPENROAD_EXE)', but it is either not found or not executable.)
-endif
 
 export OPENROAD_ARGS = -no_init -threads $(NUM_CORES) $(OR_ARGS)
 export OPENROAD_CMD = $(OPENROAD_EXE) -exit $(OPENROAD_ARGS)
@@ -115,9 +112,6 @@ endif
 export YOSYS_EXE
 
 YOSYS_IS_VALID := $(if $(YOSYS_EXE),$(shell test -x $(YOSYS_EXE) && echo "true"),)
-ifneq ($(strip $(YOSYS_IS_VALID)),true)
-  $(error YOSYS_EXE is set to '$(YOSYS_EXE)', but it is either not found or not executable.)
-endif
 
 # Use locally installed and built klayout if it exists, otherwise use klayout in path
 KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)


### PR DESCRIPTION
`make all` checks for yosys/openroad being installed correctly, but it is possible to invoke the targets directly, bypassing this safety check for use-cases where e.g. only synthesis is run without yosys or a netlist is cached and no yosys is needed