### PR TITLE
make: issue, fix regression

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -182,7 +182,7 @@ $(foreach block,$(BLOCKS),$(eval $(WORK_HOME)/results/$(PLATFORM)/$(DESIGN_NICKN
 # Utility to print tool version information
 #-------------------------------------------------------------------------------
 .PHONY: versions.txt
-versions.txt: check-yosys check-openroad
+versions.txt:
 	mkdir -p $(OBJECTS_DIR)
 	@echo "yosys $(shell $(YOSYS_EXE) -V 2>&1)" > $(OBJECTS_DIR)/$@
 	@echo "openroad $(shell $(OPENROAD_EXE) -version 2>&1)" >> $(OBJECTS_DIR)/$@


### PR DESCRIPTION
with bazel-orfs, I make issues for a specific stage at which point there's no requirement that there is a dependency on yosys AND openroad, so checking if yosys exists for a make io_placement_issue fails, for example.