### PR TITLE
sky130hd/uW: remove custom MPL configs and increase density

### DIFF
--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -21,21 +21,9 @@ export ADDITIONAL_LIBS = $(wildcard $(microwatt_DIR)/lib/*.lib)
 
 export SYNTH_HIERARCHICAL = 1
 
-export MACRO_PLACE_HALO = 100 100
+export PLACE_DENSITY = 0.3
 
-# We use large placement blockages to try eliminating the channels between
-# RAMs in order to make that space inaccessible for GPL. Experiments have
-# showed that connections crossing the RAMs vertically can be painful to
-# route.
-export MACRO_BLOCKAGE_HALO = 151
-
-# There's less space due to the adapted blockage halos, so GPL requires a
-# higher density in order to run.
-export PLACE_DENSITY = 0.2
-
-# Extra effort to ease routing: avoid very tall std cell clusters in MPL.
-export RTLMP_MIN_AR = 0.40
-export RTLMP_NOTCH_WT = 20.0
+export MACRO_PLACE_HALO = 60 60
 
 # CTS tuning
 export CTS_BUF_DISTANCE = 600

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -8,7 +8,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 5449862,
+        "value": 5444158,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.98,
+        "value": -2.8094,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -579.49,
+        "value": -450.2784,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -44,7 +44,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 3011,
+        "value": 2016,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -52,11 +52,11 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -644.87,
+        "value": -497.9736,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -0.04,
+        "value": -0.0355,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
@@ -64,7 +64,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 8784214,
+        "value": 8055403,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -72,19 +72,19 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 5,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1795,
+        "value": 1307,
         "compare": "<="
     },
     "detailedroute__timing__setup__ws": {
-        "value": -1.9157,
+        "value": -1.5245,
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -199.9884,
+        "value": -82.9414,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
@@ -100,19 +100,19 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -620.89,
+        "value": -557.0015,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.27,
+        "value": -0.5048,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -4.48,
+        "value": -19.2273,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5601374,
+        "value": 5582894,
         "compare": "<="
     },
     "finish__timing__wns_percent_delay": {


### PR DESCRIPTION
Resolve #3409.

New metrics:

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |  5449862 |  5444158 | Tighten  |
| cts__timing__setup__ws                        |    -2.98 |  -2.8094 | Tighten  |
| cts__timing__setup__tns                       |  -579.49 | -450.2784 | Tighten  |
| globalroute__antenna_diodes_count             |     3011 |     2016 | Tighten  |
| globalroute__timing__setup__tns               |  -644.87 | -497.9736 | Tighten  |
| globalroute__timing__hold__ws                 |    -0.04 |  -0.0355 | Tighten  |
| detailedroute__route__wirelength              |  8784214 |  8055403 | Tighten  |
| detailedroute__antenna__violating__nets       |        5 |        0 | Tighten  |
| detailedroute__antenna_diodes_count           |     1795 |     1307 | Tighten  |
| detailedroute__timing__setup__ws              |  -1.9157 |  -1.5245 | Tighten  |
| detailedroute__timing__setup__tns             | -199.9884 | -82.9414 | Tighten  |
| finish__timing__setup__tns                    |  -620.89 | -557.0015 | Tighten  |
| finish__timing__hold__ws                      |    -0.27 |  -0.5048 | Failing  |
| finish__timing__hold__tns                     |    -4.48 | -19.2273 | Failing  |
| finish__design__instance__area                |  5601374 |  5582894 | Tighten  |
