### PR TITLE
ihp-sg13g2/riscv32i: USE_FILL fix

### DIFF
--- a/flow/designs/ihp-sg13g2/riscv32i/config.mk
+++ b/flow/designs/ihp-sg13g2/riscv32i/config.mk
@@ -5,7 +5,7 @@ export PLATFORM    = ihp-sg13g2
 export VERILOG_FILES = $(sort $(wildcard $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/*.v))
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 
-export USE_FILL 1
+export USE_FILL = 1
 
 export CORE_UTILIZATION = 35
 export PLACE_DENSITY_LB_ADDON = 0.2


### PR DESCRIPTION
export syntax sucker-punch fix

Before fix:

    $ make DESIGN_CONFIG=designs/ihp-sg13g2/riscv32i/config.mk print-USE_FILL
    USE_FILL =

After fix:

    $ make DESIGN_CONFIG=designs/ihp-sg13g2/riscv32i/config.mk print-USE_FILL
    USE_FILL = 1
