### PR TITLE
Tighten clock period and utilization

### DIFF
--- a/flow/designs/nangate45/jpeg/config.mk
+++ b/flow/designs/nangate45/jpeg/config.mk
@@ -7,7 +7,7 @@ export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/include
 export SDC_FILE = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 export ABC_AREA = 1
 
-export CORE_UTILIZATION ?= 45
+export CORE_UTILIZATION ?= 80
 export PLACE_DENSITY_LB_ADDON = 0.20
 export TNS_END_PERCENT        = 100
 

--- a/flow/designs/nangate45/jpeg/constraint.sdc
+++ b/flow/designs/nangate45/jpeg/constraint.sdc
@@ -2,7 +2,7 @@ current_design jpeg_encoder
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 1.2
+set clk_period 1.0
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/flow/designs/nangate45/jpeg/rules-base.json
+++ b/flow/designs/nangate45/jpeg/rules-base.json
@@ -1,10 +1,15 @@
 {
-    "detailedroute__flow__warnings__count:GRT-0246": {
+    "cts__flow__warnings__count:RSZ-0062": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
     },
-    "finish__flow__warnings__count:GUI-0076": {
+    "detailedroute__flow__warnings__count:DRT-0120": {
+        "value": 2,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "detailedroute__flow__warnings__count:GRT-0246": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
@@ -29,12 +34,17 @@
         "compare": "<=",
         "level": "warning"
     },
-    "flow__warnings__count:PDN-1041": {
-        "value": 270,
+    "globalroute__flow__warnings__count:DRT-0120": {
+        "value": 2,
         "compare": "<=",
         "level": "warning"
     },
     "globalroute__flow__warnings__count:GRT-0246": {
+        "value": 1,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "globalroute__flow__warnings__count:RSZ-0062": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
@@ -68,19 +78,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.155,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -0.24,
+        "value": -44.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -88,23 +98,23 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.164,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.24,
+        "value": -48.9,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 671143,
+        "value": 631629,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -124,31 +134,31 @@
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -0.24,
+        "value": -9.33,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "detailedroute__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "finish__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.159,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -0.24,
+        "value": -43.5,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/sky130hs/gcd/config.mk
+++ b/flow/designs/sky130hs/gcd/config.mk
@@ -8,7 +8,7 @@ export ABC_AREA      = 1
 # Adders degrade GCD
 export ADDER_MAP_FILE :=
 
-export CORE_UTILIZATION = 40
+export CORE_UTILIZATION = 50
 export PLACE_DENSITY_LB_ADDON = 0.1
 export TNS_END_PERCENT        = 100
 export EQUIVALENCE_CHECK     ?=   1

--- a/flow/designs/sky130hs/gcd/constraint.sdc
+++ b/flow/designs/sky130hs/gcd/constraint.sdc
@@ -2,7 +2,7 @@ current_design gcd
 
 set clk_name core_clock
 set clk_port_name clk
-set clk_period 1.9
+set clk_period 1.4
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/flow/designs/sky130hs/gcd/rules-base.json
+++ b/flow/designs/sky130hs/gcd/rules-base.json
@@ -1,11 +1,11 @@
 {
-    "detailedroute__flow__warnings__count:DRT-0349": {
-        "value": 10,
+    "cts__flow__warnings__count:RSZ-0062": {
+        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
-    "finish__flow__warnings__count:GUI-0076": {
-        "value": 1,
+    "detailedroute__flow__warnings__count:DRT-0349": {
+        "value": 10,
         "compare": "<=",
         "level": "warning"
     },
@@ -24,8 +24,23 @@
         "compare": "<=",
         "level": "warning"
     },
+    "floorplan__flow__warnings__count:RSZ-0062": {
+        "value": 1,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "floorplan__flow__warnings__count:RSZ-0075": {
+        "value": 153,
+        "compare": "<=",
+        "level": "warning"
+    },
     "globalroute__flow__warnings__count:DRT-0349": {
         "value": 10,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "globalroute__flow__warnings__count:RSZ-0062": {
+        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
@@ -38,11 +53,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 5134,
+        "value": 6621,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 622,
+        "value": 737,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -58,19 +73,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.424,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -0.38,
+        "value": -12.1,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -78,23 +93,23 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.619,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.38,
+        "value": -20.6,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 10120,
+        "value": 15723,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -110,39 +125,39 @@
         "compare": "<="
     },
     "detailedroute__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.356,
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -0.38,
+        "value": -8.81,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "detailedroute__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.535,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -0.38,
+        "value": -16.9,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5389,
+        "value": 7943,
         "compare": "<="
     }
 }


### PR DESCRIPTION
Tightened up sky130hs gcd & nangate45 jpeg after review. Reduced clock period and increased utilization, so rules need to be updated.

## designs/sky130hs/gcd/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |     5134 |     6621 | Failing  |
| placeopt__design__instance__count__stdcell    |      622 |      737 | Failing  |
| cts__timing__setup__ws                        |   -0.095 |   -0.424 | Failing  |
| cts__timing__setup__tns                       |    -0.38 |    -12.1 | Failing  |
| cts__timing__hold__ws                         |   -0.095 |    -0.07 | Tighten  |
| cts__timing__hold__tns                        |    -0.38 |    -0.28 | Tighten  |
| globalroute__timing__setup__ws                |   -0.095 |   -0.619 | Failing  |
| globalroute__timing__setup__tns               |    -0.38 |    -20.6 | Failing  |
| globalroute__timing__hold__ws                 |   -0.095 |    -0.07 | Tighten  |
| globalroute__timing__hold__tns                |    -0.38 |    -0.28 | Tighten  |
| detailedroute__route__wirelength              |    10120 |    15723 | Failing  |
| detailedroute__timing__setup__ws              |   -0.095 |   -0.356 | Failing  |
| detailedroute__timing__setup__tns             |    -0.38 |    -8.81 | Failing  |
| detailedroute__timing__hold__ws               |   -0.095 |    -0.07 | Tighten  |
| detailedroute__timing__hold__tns              |    -0.38 |    -0.28 | Tighten  |
| finish__timing__setup__ws                     |   -0.095 |   -0.535 | Failing  |
| finish__timing__setup__tns                    |    -0.38 |    -16.9 | Failing  |
| finish__timing__hold__ws                      |   -0.095 |    -0.07 | Tighten  |
| finish__timing__hold__tns                     |    -0.38 |    -0.28 | Tighten  |
| finish__design__instance__area                |     5389 |     7943 | Failing  |


## designs/nangate45/jpeg/rules-base.json updates:
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__timing__setup__ws                        |    -0.06 |   -0.155 | Failing  |
| cts__timing__setup__tns                       |    -0.24 |    -44.0 | Failing  |
| cts__timing__hold__ws                         |    -0.06 |    -0.05 | Tighten  |
| cts__timing__hold__tns                        |    -0.24 |     -0.2 | Tighten  |
| globalroute__timing__setup__ws                |    -0.06 |   -0.164 | Failing  |
| globalroute__timing__setup__tns               |    -0.24 |    -48.9 | Failing  |
| globalroute__timing__hold__ws                 |    -0.06 |    -0.05 | Tighten  |
| globalroute__timing__hold__tns                |    -0.24 |     -0.2 | Tighten  |
| detailedroute__route__wirelength              |   671143 |   631629 | Tighten  |
| detailedroute__timing__setup__tns             |    -0.24 |    -9.33 | Failing  |
| detailedroute__timing__hold__ws               |    -0.06 |    -0.05 | Tighten  |
| detailedroute__timing__hold__tns              |    -0.24 |     -0.2 | Tighten  |
| finish__timing__setup__ws                     |    -0.06 |   -0.159 | Failing  |
| finish__timing__setup__tns                    |    -0.24 |    -43.5 | Failing  |
| finish__timing__hold__ws                      |    -0.06 |    -0.05 | Tighten  |
| finish__timing__hold__tns                     |    -0.24 |     -0.2 | Tighten  |
