### PR TITLE
Tighten sky130hs gcd

### DIFF
--- a/flow/designs/sky130hs/gcd/config.mk
+++ b/flow/designs/sky130hs/gcd/config.mk
@@ -8,7 +8,7 @@ export ABC_AREA      = 1
 # Adders degrade GCD
 export ADDER_MAP_FILE :=
 
-export CORE_UTILIZATION = 40
+export CORE_UTILIZATION = 45
 export PLACE_DENSITY_LB_ADDON = 0.1
 export TNS_END_PERCENT        = 100
 export EQUIVALENCE_CHECK     ?=   1

--- a/flow/designs/sky130hs/gcd/constraint.sdc
+++ b/flow/designs/sky130hs/gcd/constraint.sdc
@@ -2,7 +2,7 @@ current_design gcd
 
 set clk_name core_clock
 set clk_port_name clk
-set clk_period 1.9
+set clk_period 1.4
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/flow/designs/sky130hs/gcd/rules-base.json
+++ b/flow/designs/sky130hs/gcd/rules-base.json
@@ -1,11 +1,11 @@
 {
-    "detailedroute__flow__warnings__count:DRT-0349": {
-        "value": 10,
+    "cts__flow__warnings__count:RSZ-0062": {
+        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
-    "finish__flow__warnings__count:GUI-0076": {
-        "value": 1,
+    "detailedroute__flow__warnings__count:DRT-0349": {
+        "value": 10,
         "compare": "<=",
         "level": "warning"
     },
@@ -24,8 +24,23 @@
         "compare": "<=",
         "level": "warning"
     },
+    "floorplan__flow__warnings__count:RSZ-0062": {
+        "value": 1,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "floorplan__flow__warnings__count:RSZ-0075": {
+        "value": 153,
+        "compare": "<=",
+        "level": "warning"
+    },
     "globalroute__flow__warnings__count:DRT-0349": {
         "value": 10,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "globalroute__flow__warnings__count:RSZ-0062": {
+        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
@@ -38,11 +53,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 5134,
+        "value": 6702,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 622,
+        "value": 741,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -50,7 +65,7 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 54,
+        "value": 75,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
@@ -58,19 +73,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.45,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -0.38,
+        "value": -13.2,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -78,23 +93,23 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.635,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.38,
+        "value": -19.1,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 10120,
+        "value": 15082,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -110,39 +125,39 @@
         "compare": "<="
     },
     "detailedroute__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.341,
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -0.38,
+        "value": -7.52,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "detailedroute__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__timing__setup__ws": {
-        "value": -0.095,
+        "value": -0.552,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -0.38,
+        "value": -15.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.095,
+        "value": -0.07,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -0.38,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5389,
+        "value": 8200,
         "compare": "<="
     }
 }


### PR DESCRIPTION
Tightened up sky130hs gcd after review. Reduced clock period and increased utilization, so rules need to be updated. Partially replaces https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3641.

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| placeopt__design__instance__area              |     5134 |     6702 | Failing  |
| placeopt__design__instance__count__stdcell    |      622 |      741 | Failing  |
| cts__design__instance__count__setup_buffer    |       54 |       75 | Failing  |
| cts__timing__setup__ws                        |   -0.095 |    -0.45 | Failing  |
| cts__timing__setup__tns                       |    -0.38 |    -13.2 | Failing  |
| cts__timing__hold__ws                         |   -0.095 |    -0.07 | Tighten  |
| cts__timing__hold__tns                        |    -0.38 |    -0.28 | Tighten  |
| globalroute__timing__setup__ws                |   -0.095 |   -0.635 | Failing  |
| globalroute__timing__setup__tns               |    -0.38 |    -19.1 | Failing  |
| globalroute__timing__hold__ws                 |   -0.095 |    -0.07 | Tighten  |
| globalroute__timing__hold__tns                |    -0.38 |    -0.28 | Tighten  |
| detailedroute__route__wirelength              |    10120 |    15082 | Failing  |
| detailedroute__timing__setup__ws              |   -0.095 |   -0.341 | Failing  |
| detailedroute__timing__setup__tns             |    -0.38 |    -7.52 | Failing  |
| detailedroute__timing__hold__ws               |   -0.095 |    -0.07 | Tighten  |
| detailedroute__timing__hold__tns              |    -0.38 |    -0.28 | Tighten  |
| finish__timing__setup__ws                     |   -0.095 |   -0.552 | Failing  |
| finish__timing__setup__tns                    |    -0.38 |    -15.2 | Failing  |
| finish__timing__hold__ws                      |   -0.095 |    -0.07 | Tighten  |
| finish__timing__hold__tns                     |    -0.38 |    -0.28 | Tighten  |
| finish__design__instance__area                |     5389 |     8200 | Failing  |
