### PR TITLE
Tighten up nangate45 jpeg

### DIFF
--- a/flow/designs/nangate45/jpeg/config.mk
+++ b/flow/designs/nangate45/jpeg/config.mk
@@ -7,7 +7,7 @@ export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/include
 export SDC_FILE = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 export ABC_AREA = 1
 
-export CORE_UTILIZATION ?= 45
+export CORE_UTILIZATION ?= 80
 export PLACE_DENSITY_LB_ADDON = 0.20
 export TNS_END_PERCENT        = 100
 

--- a/flow/designs/nangate45/jpeg/constraint.sdc
+++ b/flow/designs/nangate45/jpeg/constraint.sdc
@@ -2,7 +2,7 @@ current_design jpeg_encoder
 
 set clk_name clk
 set clk_port_name clk
-set clk_period 1.2
+set clk_period 1.0
 set clk_io_pct 0.2
 
 set clk_port [get_ports $clk_port_name]

--- a/flow/designs/nangate45/jpeg/rules-base.json
+++ b/flow/designs/nangate45/jpeg/rules-base.json
@@ -1,10 +1,15 @@
 {
-    "detailedroute__flow__warnings__count:GRT-0246": {
+    "cts__flow__warnings__count:RSZ-0062": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
     },
-    "finish__flow__warnings__count:GUI-0076": {
+    "detailedroute__flow__warnings__count:DRT-0120": {
+        "value": 1,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "detailedroute__flow__warnings__count:GRT-0246": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
@@ -29,12 +34,17 @@
         "compare": "<=",
         "level": "warning"
     },
-    "flow__warnings__count:PDN-1041": {
-        "value": 270,
+    "globalroute__flow__warnings__count:DRT-0120": {
+        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
     "globalroute__flow__warnings__count:GRT-0246": {
+        "value": 1,
+        "compare": "<=",
+        "level": "warning"
+    },
+    "globalroute__flow__warnings__count:RSZ-0062": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
@@ -68,19 +78,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.139,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -0.24,
+        "value": -35.6,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -88,23 +98,23 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.17,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.24,
+        "value": -43.2,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 671143,
+        "value": 634316,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -124,31 +134,31 @@
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -0.24,
+        "value": -7.87,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "detailedroute__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "finish__timing__setup__ws": {
-        "value": -0.06,
+        "value": -0.159,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -0.24,
+        "value": -41.1,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.06,
+        "value": -0.05,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -0.24,
+        "value": -0.2,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
Tighten up nangate45 jpeg - decreased clock period and increased utilization.

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__timing__setup__ws                        |    -0.06 |   -0.139 | Failing  |
| cts__timing__setup__tns                       |    -0.24 |    -35.6 | Failing  |
| cts__timing__hold__ws                         |    -0.06 |    -0.05 | Tighten  |
| cts__timing__hold__tns                        |    -0.24 |     -0.2 | Tighten  |
| globalroute__timing__setup__ws                |    -0.06 |    -0.17 | Failing  |
| globalroute__timing__setup__tns               |    -0.24 |    -43.2 | Failing  |
| globalroute__timing__hold__ws                 |    -0.06 |    -0.05 | Tighten  |
| globalroute__timing__hold__tns                |    -0.24 |     -0.2 | Tighten  |
| detailedroute__route__wirelength              |   671143 |   634316 | Tighten  |
| detailedroute__timing__setup__tns             |    -0.24 |    -7.87 | Failing  |
| detailedroute__timing__hold__ws               |    -0.06 |    -0.05 | Tighten  |
| detailedroute__timing__hold__tns              |    -0.24 |     -0.2 | Tighten  |
| finish__timing__setup__ws                     |    -0.06 |   -0.159 | Failing  |
| finish__timing__setup__tns                    |    -0.24 |    -41.1 | Failing  |
| finish__timing__hold__ws                      |    -0.06 |    -0.05 | Tighten  |
| finish__timing__hold__tns                     |    -0.24 |     -0.2 | Tighten  |

