### PR TITLE
added set_max_fanout constraint to nangate45 jpeg

### DIFF
--- a/flow/designs/nangate45/jpeg/constraint.sdc
+++ b/flow/designs/nangate45/jpeg/constraint.sdc
@@ -13,3 +13,5 @@ set non_clock_inputs [all_inputs -no_clocks]
 
 set_input_delay [expr $clk_period * $clk_io_pct] -clock $clk_name $non_clock_inputs
 set_output_delay [expr $clk_period * $clk_io_pct] -clock $clk_name [all_outputs]
+
+set_max_fanout 10 [current_design]

--- a/flow/designs/nangate45/jpeg/rules-base.json
+++ b/flow/designs/nangate45/jpeg/rules-base.json
@@ -4,17 +4,7 @@
         "compare": "<=",
         "level": "warning"
     },
-    "detailedroute__flow__warnings__count:DRT-0120": {
-        "value": 1,
-        "compare": "<=",
-        "level": "warning"
-    },
     "detailedroute__flow__warnings__count:GRT-0246": {
-        "value": 1,
-        "compare": "<=",
-        "level": "warning"
-    },
-    "finish__flow__warnings__count:GUI-0076": {
         "value": 1,
         "compare": "<=",
         "level": "warning"
@@ -36,11 +26,6 @@
     },
     "floorplan__flow__warnings__count:RSZ-0075": {
         "value": 1001,
-        "compare": "<=",
-        "level": "warning"
-    },
-    "globalroute__flow__warnings__count:DRT-0120": {
-        "value": 1,
         "compare": "<=",
         "level": "warning"
     },
@@ -87,7 +72,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -35.5,
+        "value": -38.3,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -107,7 +92,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -44.3,
+        "value": -46.3,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -139,7 +124,7 @@
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -9.03,
+        "value": -9.44,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
@@ -155,7 +140,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -42.0,
+        "value": -46.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
Addresses buffered net with 102 inst terms

TNS degraded slightly:

| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| cts__timing__setup__tns                       |    -35.5 |    -38.3 | Failing  |
| globalroute__timing__setup__tns               |    -44.3 |    -46.3 | Failing  |
| detailedroute__timing__setup__tns             |    -9.03 |    -9.44 | Failing  |
| finish__timing__setup__tns                    |    -42.0 |    -46.0 | Failing  |

@maliberty @precisionmoon @povik , FYI