### PR TITLE
Add flow variable BUFFER_PORTS_DONT_USE_CELLS

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -102,6 +102,7 @@ configuration file.
 | <a name="ADDITIONAL_LIBS"></a>ADDITIONAL_LIBS| Hardened macro library files listed here. The library information is immutable and used throughout all stages. Not stored in the .odb file.| |
 | <a name="BALANCE_ROWS"></a>BALANCE_ROWS| Balance rows during placement.| 0|
 | <a name="BLOCKS"></a>BLOCKS| Blocks used as hard macros in a hierarchical flow. Do note that you have to specify block-specific inputs file in the directory mentioned by Makefile.| |
+| <a name="BUFFER_PORTS_DONT_USE_CELLS"></a>BUFFER_PORTS_DONT_USE_CELLS| List of cells that should not be used for buffering of input/output ports during floorplanning.| |
 | <a name="CAP_MARGIN"></a>CAP_MARGIN| Specifies a capacitance margin when fixing max capacitance violations. This option allows you to overfix.| |
 | <a name="CDL_FILES"></a>CDL_FILES| Insert additional Circuit Description Language (`.cdl`) netlist files.| |
 | <a name="CELL_PAD_IN_SITES_DETAIL_PLACEMENT"></a>CELL_PAD_IN_SITES_DETAIL_PLACEMENT| Cell padding on both sides in site widths to ease routability in detail placement.| 0|
@@ -369,6 +370,7 @@ configuration file.
 ## place variables
 
 - [BALANCE_ROWS](#BALANCE_ROWS)
+- [BUFFER_PORTS_DONT_USE_CELLS](#BUFFER_PORTS_DONT_USE_CELLS)
 - [CELL_PAD_IN_SITES_DETAIL_PLACEMENT](#CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 - [CELL_PAD_IN_SITES_GLOBAL_PLACEMENT](#CELL_PAD_IN_SITES_GLOBAL_PLACEMENT)
 - [CLUSTER_FLOPS](#CLUSTER_FLOPS)

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -5,6 +5,11 @@ load_design 3_2_place_iop.odb 2_floorplan.sdc
 
 set_dont_use $::env(DONT_USE_CELLS)
 
+# Also set dont_use for cells that should not be used for port buffering
+if { [env_var_exists_and_non_empty BUFFER_PORTS_DONT_USE_CELLS] } {
+  set_dont_use $::env(BUFFER_PORTS_DONT_USE_CELLS)
+}
+
 if { $::env(GPL_TIMING_DRIVEN) } {
   remove_buffers
 }
@@ -18,6 +23,13 @@ if { ![env_var_exists_and_non_empty FOOTPRINT] } {
     puts "Perform port buffering..."
     buffer_ports
   }
+}
+
+if { [env_var_exists_and_non_empty BUFFER_PORTS_DONT_USE_CELLS] } {
+  # Unset dont_use for cells that should not be used for port buffering
+  unset_dont_use $::env(BUFFER_PORTS_DONT_USE_CELLS)
+  # ...but set dont_use cells again in case any cells are in both BUFFER_PORTS_DONT_USE_CELLS and DONT_USE_CELLS
+  set_dont_use $::env(DONT_USE_CELLS)
 }
 
 set global_placement_args {}

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -397,6 +397,11 @@ DONT_BUFFER_PORTS:
   stages:
     - place
   default: 0
+BUFFER_PORTS_DONT_USE_CELLS:
+  description: >
+    List of cells that should not be used for buffering of input/output ports during floorplanning.
+  stages:
+    - place
 REMOVE_ABC_BUFFERS:
   description: >
     Remove abc buffers from the netlist. If timing repair in floorplanning is


### PR DESCRIPTION
This PR makes the suggestion in the following comment usable from a design's `config.mk`:
https://github.com/The-OpenROAD-Project/OpenROAD/discussions/7757#discussioncomment-13713371

For example, if the cell library has some delay cells that shouldn't be used for port buffering, add a line

    export BUFFER_PORTS_DONT_USE_CELLS = DLY_CELL1 DLY_CELL2

to your `config.mk` and these cells will be excluded during the `buffer_ports` call within *flow/scripts/global_place.tcl*.