### PR TITLE
Add var BUFFER_PORTS_ARGS

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -102,6 +102,7 @@ configuration file.
 | <a name="ADDITIONAL_LIBS"></a>ADDITIONAL_LIBS| Hardened macro library files listed here. The library information is immutable and used throughout all stages. Not stored in the .odb file.| |
 | <a name="BALANCE_ROWS"></a>BALANCE_ROWS| Balance rows during placement.| 0|
 | <a name="BLOCKS"></a>BLOCKS| Blocks used as hard macros in a hierarchical flow. Do note that you have to specify block-specific inputs file in the directory mentioned by Makefile.| |
+| <a name="BUFFER_PORTS_ARGS"></a>BUFFER_PORTS_ARGS| Specify arguments to the buffer_ports call during placement. Only used if DONT_BUFFER_PORTS=0.| |
 | <a name="CAP_MARGIN"></a>CAP_MARGIN| Specifies a capacitance margin when fixing max capacitance violations. This option allows you to overfix.| |
 | <a name="CDL_FILES"></a>CDL_FILES| Insert additional Circuit Description Language (`.cdl`) netlist files.| |
 | <a name="CELL_PAD_IN_SITES_DETAIL_PLACEMENT"></a>CELL_PAD_IN_SITES_DETAIL_PLACEMENT| Cell padding on both sides in site widths to ease routability in detail placement.| 0|
@@ -129,7 +130,6 @@ configuration file.
 | <a name="DFF_LIB_FILES"></a>DFF_LIB_FILES| Technology mapping liberty files for flip-flops.| |
 | <a name="DIE_AREA"></a>DIE_AREA| The die area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2).| |
 | <a name="DONT_BUFFER_PORTS"></a>DONT_BUFFER_PORTS| Do not buffer input/output ports during floorplanning.| 0|
-| <a name="BUFFER_PORTS_ARGS"></a>BUFFER_PORTS_ARGS| Specify arguments to the buffer_ports call during placement. Only used if DONT_BUFFER_PORTS=0.| |
 | <a name="DONT_USE_CELLS"></a>DONT_USE_CELLS| Dont use cells eases pin access in detailed routing.| |
 | <a name="DPO_MAX_DISPLACEMENT"></a>DPO_MAX_DISPLACEMENT| Specifies how far an instance can be moved when optimizing.| 5 1|
 | <a name="EARLY_SIZING_CAP_RATIO"></a>EARLY_SIZING_CAP_RATIO| Ratio between the input pin capacitance and the output pin load during initial gate sizing.| |
@@ -370,6 +370,7 @@ configuration file.
 ## place variables
 
 - [BALANCE_ROWS](#BALANCE_ROWS)
+- [BUFFER_PORTS_ARGS](#BUFFER_PORTS_ARGS)
 - [CELL_PAD_IN_SITES_DETAIL_PLACEMENT](#CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 - [CELL_PAD_IN_SITES_GLOBAL_PLACEMENT](#CELL_PAD_IN_SITES_GLOBAL_PLACEMENT)
 - [CLUSTER_FLOPS](#CLUSTER_FLOPS)

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -129,6 +129,7 @@ configuration file.
 | <a name="DFF_LIB_FILES"></a>DFF_LIB_FILES| Technology mapping liberty files for flip-flops.| |
 | <a name="DIE_AREA"></a>DIE_AREA| The die area specified as a list of lower-left and upper-right corners in microns (X1 Y1 X2 Y2).| |
 | <a name="DONT_BUFFER_PORTS"></a>DONT_BUFFER_PORTS| Do not buffer input/output ports during floorplanning.| 0|
+| <a name="BUFFER_PORTS_ARGS"></a>BUFFER_PORTS_ARGS| Specify arguments to the buffer_ports call during placement. Only used if DONT_BUFFER_PORTS=0.| |
 | <a name="DONT_USE_CELLS"></a>DONT_USE_CELLS| Dont use cells eases pin access in detailed routing.| |
 | <a name="DPO_MAX_DISPLACEMENT"></a>DPO_MAX_DISPLACEMENT| Specifies how far an instance can be moved when optimizing.| 5 1|
 | <a name="EARLY_SIZING_CAP_RATIO"></a>EARLY_SIZING_CAP_RATIO| Ratio between the input pin capacitance and the output pin load during initial gate sizing.| |

--- a/flow/scripts/floorplan_to_place.tcl
+++ b/flow/scripts/floorplan_to_place.tcl
@@ -240,7 +240,7 @@ if { $::env(GPL_TIMING_DRIVEN) } {
 if { ![env_var_exists_and_non_empty FOOTPRINT] } {
   if { ![env_var_equals DONT_BUFFER_PORTS 1] } {
     puts "Perform port buffering..."
-    buffer_ports
+    buffer_ports {*}[env_var_or_empty BUFFER_PORTS_ARGS]
   }
 }
 

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -16,7 +16,7 @@ if { $::env(GPL_TIMING_DRIVEN) } {
 if { ![env_var_exists_and_non_empty FOOTPRINT] } {
   if { !$::env(DONT_BUFFER_PORTS) } {
     puts "Perform port buffering..."
-    buffer_ports
+    buffer_ports {*}[env_var_or_empty BUFFER_PORTS_ARGS]
   }
 }
 

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -399,7 +399,7 @@ DONT_BUFFER_PORTS:
   default: 0
 BUFFER_PORTS_ARGS:
   description: >
-    Specify arguments (such as -buffer_cell) to the buffer_ports call during placement.
+    Specify arguments to the buffer_ports call during placement. Only used if DONT_BUFFER_PORTS=0.
   stages:
     - place
 REMOVE_ABC_BUFFERS:

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -397,6 +397,11 @@ DONT_BUFFER_PORTS:
   stages:
     - place
   default: 0
+BUFFER_PORTS_ARGS:
+  description: >
+    Specify arguments (such as -buffer_cell) to the buffer_ports call during placement.
+  stages:
+    - place
 REMOVE_ABC_BUFFERS:
   description: >
     Remove abc buffers from the netlist. If timing repair in floorplanning is


### PR DESCRIPTION
This variable allows to specify arguments (such as `-buffer_cell <BUFFER_CELL>`) to the `buffer_ports` call during place.

For more background, see discussion on (now closed) pull request https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3655 and the conversation at https://github.com/The-OpenROAD-Project/OpenROAD/discussions/7757#discussioncomment-13713371