### PR TITLE
[DNM] platforms: ihpsg13g2: Add IO cells to DONT_USE_CELLS

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -41,7 +41,8 @@ export DONT_USE_CELLS += \
 sg13g2_lgcp_1 \
 sg13g2_sighold \
 sg13g2_slgcp_1 \
-sg13g2_dfrbp_2
+sg13g2_dfrbp_2 \
+sg13g2_IOPad*
 
 
 # Define fill cells


### PR DESCRIPTION
Yosys started to add the IHP IO cells as standard cells and global placement fails with:
  [ERROR RSZ-2001] failed bnet construction for _078639_/p2c

Add 'sg13g2_IOPad*' to DONT_USE_CELLS to make sure Yosys won't use those cells.