### PR TITLE
update OR, MPL global fence default values and failing metrics

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -200,8 +200,8 @@ configuration file.
 | <a name="RTLMP_DEAD_SPACE"></a>RTLMP_DEAD_SPACE| Specifies the target dead space percentage, which influences the utilization of a cluster.| 0.05|
 | <a name="RTLMP_FENCE_LX"></a>RTLMP_FENCE_LX| Defines the lower left X coordinate for the global fence bounding box in microns.| 0.0|
 | <a name="RTLMP_FENCE_LY"></a>RTLMP_FENCE_LY| Defines the lower left Y coordinate for the global fence bounding box in microns.| 0.0|
-| <a name="RTLMP_FENCE_UX"></a>RTLMP_FENCE_UX| Defines the upper right X coordinate for the global fence bounding box in microns.| 100000000.0|
-| <a name="RTLMP_FENCE_UY"></a>RTLMP_FENCE_UY| Defines the upper right Y coordinate for the global fence bounding box in microns.| 100000000.0|
+| <a name="RTLMP_FENCE_UX"></a>RTLMP_FENCE_UX| Defines the upper right X coordinate for the global fence bounding box in microns.| 0.0|
+| <a name="RTLMP_FENCE_UY"></a>RTLMP_FENCE_UY| Defines the upper right Y coordinate for the global fence bounding box in microns.| 0.0|
 | <a name="RTLMP_MAX_INST"></a>RTLMP_MAX_INST| Maximum number of standard cells in a cluster. If unset, rtl_macro_placer will calculate a value based on the design attributes.| |
 | <a name="RTLMP_MAX_LEVEL"></a>RTLMP_MAX_LEVEL| Maximum depth of the physical hierarchy tree.| 2|
 | <a name="RTLMP_MAX_MACRO"></a>RTLMP_MAX_MACRO| Maximum number of macros in a cluster. If unset, rtl_macro_placer will calculate a value based on the design attributes.| |

--- a/flow/designs/nangate45/mempool_group/rules-base.json
+++ b/flow/designs/nangate45/mempool_group/rules-base.json
@@ -174,7 +174,7 @@
         "compare": ">="
     },
     "detailedroute__timing__setup__tns": {
-        "value": -7880.0,
+        "value": -7980.0,
         "compare": ">="
     },
     "detailedroute__timing__hold__ws": {
@@ -182,7 +182,7 @@
         "compare": ">="
     },
     "detailedroute__timing__hold__tns": {
-        "value": -0.606,
+        "value": -8.77,
         "compare": ">="
     },
     "finish__timing__setup__ws": {
@@ -190,7 +190,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -10800.0,
+        "value": -10600.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1102,14 +1102,14 @@ RTLMP_FENCE_UX:
   description: >
     Defines the upper right X coordinate for the global fence bounding box in
     microns.
-  default: 100000000.0
+  default: 0.0
   stages:
     - floorplan
 RTLMP_FENCE_UY:
   description: >
     Defines the upper right Y coordinate for the global fence bounding box in
     microns.
-  default: 100000000.0
+  default: 0.0
   stages:
     - floorplan
 RTLMP_ARGS:


### PR DESCRIPTION
nangate45/mempool_group:
    
| Metric                                        | Old      | New      | Type     |
| ------                                        | ---      | ---      | ----     |
| detailedroute__timing__setup__tns             |  -7880.0 |  -7980.0 | Failing  |
| detailedroute__timing__hold__tns              |   -0.606 |    -8.77 | Failing  |
| finish__timing__setup__tns                    | -10800.0 | -10600.0 | Tighten  |

Also regenerating flow variables' table.