### PR TITLE
make: synth consistency with other stages

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -227,7 +227,7 @@ $(WRAPPED_LIBS):
 # |____/ |_| |_| \_| |_| |_| |_|_____|____/___|____/
 #
 .PHONY: synth
-synth: $(RESULTS_DIR)/1_synth.v
+synth: $(RESULTS_DIR)/1_synth.odb
 
 .PHONY: synth-report
 synth-report: synth
@@ -260,6 +260,7 @@ yosys-dependencies: $(YOSYS_DEPENDENCIES)
 .PHONY: do-yosys
 do-yosys: yosys-dependencies
 	$(SCRIPTS_DIR)/synth.sh $(SYNTH_SCRIPT) $(LOG_DIR)/1_2_yosys.log
+	cp $(SDC_FILE) $(RESULTS_DIR)/1_2_yosys.sdc
 
 .PHONY: do-yosys-canonicalize
 do-yosys-canonicalize: yosys-dependencies
@@ -268,17 +269,8 @@ do-yosys-canonicalize: yosys-dependencies
 $(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
-$(RESULTS_DIR)/1_2_yosys.v: $(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+$(RESULTS_DIR)/1_2_yosys.v $(RESULTS_DIR)/1_2_yosys.sdc: $(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
 	$(UNSET_AND_MAKE) do-yosys
-
-.PHONY: do-synth
-do-synth:
-	mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR)
-	cp $(RESULTS_DIR)/1_2_yosys.v $(RESULTS_DIR)/1_synth.v
-
-$(RESULTS_DIR)/1_synth.v: $(RESULTS_DIR)/1_2_yosys.v
-	$(UNSET_AND_MAKE) do-synth
-
 .PHONY: clean_synth
 clean_synth:
 	rm -f $(RESULTS_DIR)/1_* $(RESULTS_DIR)/mem*.json
@@ -395,23 +387,25 @@ endef
 # ==============================================================================
 
 # Custom target to go from synthesis to placement in a single OpenROAD run
-$(eval $(call do-step,1_3_floorplan_to_place, $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc,floorplan_to_place))
+$(eval $(call do-step,1_3_floorplan_to_place, $(RESULTS_DIR)/1_synth.odb $(RESULTS_DIR)/1_synth.sdc,floorplan_to_place))
 
 .PHONY: floorplan_to_place
-floorplan_to_place: $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc
+floorplan_to_place: $(RESULTS_DIR)/1_synth.odb $(RESULTS_DIR)/1_synth.sdc
 	$(UNSET_AND_MAKE) do-1_3_floorplan_to_place
 
 # ==============================================================================
 
-$(eval $(call do-step,1_3_synth,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc,synth_odb))
+$(eval $(call do-step,1_synth,$(RESULTS_DIR)/1_2_yosys.v $(RESULTS_DIR)/1_2_yosys.sdc,synth_odb))
 
-$(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL) $(LIB_FILES) $(IO_CONSTRAINTS),floorplan))
+$(RESULTS_DIR)/1_synth.sdc: $(RESULTS_DIR)/1_synth.odb
+
+$(eval $(call do-step,2_1_floorplan,$(RESULTS_DIR)/1_synth.odb $(RESULTS_DIR)/1_synth.sdc $(TECH_LEF) $(SC_LEF) $(ADDITIONAL_LEFS) $(FOOTPRINT) $(SIG_MAP_FILE) $(FOOTPRINT_TCL) $(LIB_FILES) $(IO_CONSTRAINTS),floorplan))
 
 $(eval $(call do-copy,2_floorplan,2_1_floorplan.sdc,,.sdc))
 
 # STEP 2: Macro Placement
 #-------------------------------------------------------------------------------
-$(eval $(call do-step,2_2_floorplan_macro,$(RESULTS_DIR)/2_1_floorplan.odb $(RESULTS_DIR)/1_synth.v $(RESULTS_DIR)/1_synth.sdc $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),macro_place))
+$(eval $(call do-step,2_2_floorplan_macro,$(RESULTS_DIR)/2_1_floorplan.odb $(RESULTS_DIR)/1_synth.sdc $(MACRO_PLACEMENT) $(MACRO_PLACEMENT_TCL),macro_place))
 
 # STEP 3: Tapcell and Welltie insertion
 #-------------------------------------------------------------------------------

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -1,7 +1,7 @@
 utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
-load_design 1_synth.v 1_synth.sdc
+load_design 1_synth.odb 1_synth.sdc
 
 proc report_unused_masters { } {
   set db [ord::get_db]

--- a/flow/scripts/floorplan_to_place.tcl
+++ b/flow/scripts/floorplan_to_place.tcl
@@ -1,6 +1,6 @@
 utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
-load_design 1_synth.v 1_synth.sdc
+load_design 1_synth.odb 1_synth.sdc
 
 # Floorplan
 

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -1,16 +1,11 @@
 utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables synth
-load_design 1_synth.v 1_synth.sdc
+load_design 1_2_yosys.v 1_2_yosys.sdc
 
-write_db $::env(RESULTS_DIR)/1_3_synth.odb
+write_db $::env(RESULTS_DIR)/1_synth.odb
 # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
 # the user could have dependencies, such as sourcing util.tcl,
 # which are read in here and a canonicalized version is written
 # out by OpenSTA that has no dependencies.
-write_sdc -no_timestamp $::env(RESULTS_DIR)/1_3_synth.sdc
-
-# Final output of the synthesis stage, the other files are written out for
-# consistency and logging of .odb hashes
-exec cp $::env(RESULTS_DIR)/1_3_synth.sdc $::env(RESULTS_DIR)/1_synth.sdc
-exec cp $::env(RESULTS_DIR)/1_3_synth.odb $::env(RESULTS_DIR)/1_synth.odb
+write_sdc -no_timestamp $::env(RESULTS_DIR)/1_synth.sdc


### PR DESCRIPTION
synth now outputs 1_synth.odb and 1_synth.sdc written out by OpenROAD, just like other stages like floorplan, place, cts, etc.

- 1_synth.sdc is the written out by OpenROAD and if SDC_FILE depended on other util.tcl files, those dependencies are subsumed into 1_synth.sdc
- gui_synth/open_synth now works out of the box, useful for investigating timing, resource usage and synthesis results before proceeding to floorplan.
- more consistent output interface from stages: .odb and .sdc file written out at each stage and input to next.
- "-hier" option is respected when the .odb file is written out from synthesis.

This consistency is nice for users as well as bazel-orfs.

The running time and disk space is not materially affected because write_odb and write_sdc is fast and 1_2_yosys.v is no longer duplicated.