### PR TITLE
scripts: log_cmd estimate_parasitics

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -34,7 +34,7 @@ set_dont_use $::env(DONT_USE_CELLS)
 log_cmd clock_tree_synthesis {*}$cts_args
 
 utl::push_metrics_stage "cts__{}__pre_repair_timing"
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 if { $::env(DETAILED_METRICS) } {
   report_metrics 4 "cts pre-repair-timing"
 }
@@ -50,7 +50,7 @@ if { $result != 0 } {
   error "Detailed placement failed in CTS: $msg"
 }
 
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 
 if { $::env(CTS_SNAPSHOTS) } {
   save_progress 4_1_pre_repair_hold_setup

--- a/flow/scripts/detail_place.tcl
+++ b/flow/scripts/detail_place.tcl
@@ -27,7 +27,7 @@ proc do_dpl { } {
 
   utl::info FLW 12 "Placement violations [check_placement -verbose]."
 
-  estimate_parasitics -placement
+  log_cmd estimate_parasitics -placement
 }
 
 set result [catch { do_dpl } errMsg]

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -130,7 +130,7 @@ if { !$::env(SKIP_REPAIR_TIE_FANOUT) } {
 }
 
 if { [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS] } {
-  estimate_parasitics -placement
+  log_cmd estimate_parasitics -placement
   replace_arith_modules
 }
 

--- a/flow/scripts/global_place.tcl
+++ b/flow/scripts/global_place.tcl
@@ -50,11 +50,11 @@ if { $result != 0 } {
   error $errMsg
 }
 
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 
 if { $::env(CLUSTER_FLOPS) } {
   cluster_flops
-  estimate_parasitics -placement
+  log_cmd estimate_parasitics -placement
 }
 
 report_metrics 3 "global place" false false

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -42,7 +42,7 @@ proc global_route_helper { } {
     -right $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 
   set_propagated_clock [all_clocks]
-  estimate_parasitics -global_routing
+  log_cmd estimate_parasitics -global_routing
 
   if { [env_var_exists_and_non_empty DONT_USE_CELLS] } {
     set_dont_use $::env(DONT_USE_CELLS)
@@ -69,7 +69,7 @@ proc global_route_helper { } {
 
     # Repair timing using global route parasitics
     puts "Repair setup and hold violations..."
-    estimate_parasitics -global_routing
+    log_cmd estimate_parasitics -global_routing
 
     repair_timing_helper
 
@@ -104,7 +104,7 @@ proc global_route_helper { } {
   }
 
   puts "Estimate parasitics..."
-  estimate_parasitics -global_routing
+  log_cmd estimate_parasitics -global_routing
 
   report_metrics 5 "global route"
 

--- a/flow/scripts/repair_timing_post_place.tcl
+++ b/flow/scripts/repair_timing_post_place.tcl
@@ -8,14 +8,14 @@ set_placement_padding -global \
   -right $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 
 puts "Repair setup and hold violations"
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 log_cmd repair_timing -repair_tns $::env(TNS_END_PERCENT)
 
 # Legalize placement after timing repair
 detailed_placement
 
 puts "Estimate parasitics"
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 report_metrics 3 "place repair timing" true false
 
 orfs_write_db $::env(RESULTS_DIR)/3_6_place_repair_timing.odb

--- a/flow/scripts/resize.tcl
+++ b/flow/scripts/resize.tcl
@@ -3,7 +3,7 @@ source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables place
 load_design 3_3_place_gp.odb 2_floorplan.sdc
 
-estimate_parasitics -placement
+log_cmd estimate_parasitics -placement
 
 set instance_count_before [sta::network_leaf_instance_count]
 set pin_count_before [sta::network_leaf_pin_count]


### PR DESCRIPTION
Sometimes estimate_parasitics can take an extraordinate amount of time and log_cmd avoids mis-attributing this in progress output