### PR TITLE
slang: add a SYNTH_BLACKBOXES syntax check

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -241,7 +241,7 @@ configuration file.
 | <a name="SLEW_MARGIN"></a>SLEW_MARGIN| Specifies a slew margin when fixing max slew violations. This option allows you to overfix.| |
 | <a name="SWAP_ARITH_OPERATORS"></a>SWAP_ARITH_OPERATORS| Improve timing QoR by swapping ALU and MULT arithmetic operators.| |
 | <a name="SYNTH_ARGS"></a>SYNTH_ARGS| Optional synthesis variables for yosys.| |
-| <a name="SYNTH_BLACKBOXES"></a>SYNTH_BLACKBOXES| List of cells treated as a black box by Yosys. With Bazel, this can be used to run synthesis in parallel for the large modules of the design.| |
+| <a name="SYNTH_BLACKBOXES"></a>SYNTH_BLACKBOXES| List of cells treated as a black box by Yosys. With Bazel, this can be used to run synthesis in parallel for the large modules of the design. Non-existant modules are ignored silently, useful when listing modules statically, even if modules come and go dynamically.| |
 | <a name="SYNTH_CANONICALIZE_TCL"></a>SYNTH_CANONICALIZE_TCL| Specifies a Tcl script with commands to run as part of the synth canonicalize step.| |
 | <a name="SYNTH_GUT"></a>SYNTH_GUT| Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.| 0|
 | <a name="SYNTH_HDL_FRONTEND"></a>SYNTH_HDL_FRONTEND| Select an alternative language frontend to ingest the design. Available option is "slang". If the variable is empty, design is read with the Yosys read_verilog command.| |

--- a/flow/designs/asap7/uart/config.mk
+++ b/flow/designs/asap7/uart/config.mk
@@ -5,6 +5,9 @@ export DESIGN_NAME            = uart
 
 export VERILOG_FILES          = $(sort $(wildcard $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/*.v))
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
+# Exercise syntax on command line for a dummy module and
+# check that non-existant modules are silently ignored.
+export SYNTH_BLACKBOXES = dummy
 
 export PLACE_DENSITY          = 0.70
 export DIE_AREA               = 0 0 17 17

--- a/flow/designs/asap7/uart/config.mk
+++ b/flow/designs/asap7/uart/config.mk
@@ -5,8 +5,8 @@ export DESIGN_NAME            = uart
 
 export VERILOG_FILES          = $(sort $(wildcard $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/*.v))
 export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
-# Exercise syntax on command line for a dummy module and
-# check that non-existant modules are silently ignored.
+# Smoke test for the option; doesn't do anything as the named
+# module does not exist
 export SYNTH_BLACKBOXES = dummy
 
 export PLACE_DENSITY          = 0.70

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -255,6 +255,9 @@ SYNTH_BLACKBOXES:
   description: >
     List of cells treated as a black box by Yosys. With Bazel, this can be used
     to run synthesis in parallel for the large modules of the design.
+
+    Non-existant modules are ignored silently, useful when listing modules
+    statically, even if modules come and go dynamically.
   stages:
     - synth
 SYNTH_NETLIST_FILES:


### PR DESCRIPTION
Non-existand verilog modules should be ignored to be compartible with Yosys.