### PR TITLE
Restore missing macro in NG45 ariane133.

### DIFF
--- a/flow/designs/nangate45/ariane133/macros.v
+++ b/flow/designs/nangate45/ariane133/macros.v
@@ -64,11 +64,8 @@ module limping_SyncSpRamBeNx64_00000008_00000100_0_2
    assign wren_b = ~WrEn_SI; // active-low global-write-enable
    assign csel_b = ~CSel_SI; // active-low chip-select-enable
    
-   fakeram45_256x16 macro_mem_0 (.clk(Clk_CI),.rd_out(RdData_DO[15:0]), .ce_in(csel_b),.we_in(wren_b),.addr_in(Addr_DI),.w_mask_in(WMaskIn),.wd_in(WrData_DI[15:0]));
-   // fakeram45_256x16 macro_mem_1 (.clk(Clk_CI),.rd_out(RdData_DO[31:16]),.ce_in(csel_b),.we_in(wren_b),.addr_in(Addr_DI),.w_mask_in(WMaskIn),.wd_in(WrData_DI[31:16]));
-   // fakeram45_256x16 macro_mem_2 (.clk(Clk_CI),.rd_out(RdData_DO[47:32]),.ce_in(csel_b),.we_in(wren_b),.addr_in(Addr_DI),.w_mask_in(WMaskIn),.wd_in(WrData_DI[47:32]));
-   // fakeram45_256x16 macro_mem_3 (.clk(Clk_CI),.rd_out(RdData_DO[63:48]),.ce_in(csel_b),.we_in(wren_b),.addr_in(Addr_DI),.w_mask_in(WMaskIn),.wd_in(WrData_DI[63:48]));
-   assign RdData_DO[63:16] = 48'h0;
+   assign RdData_DO[47:0] = 48'h0;
+   fakeram45_256x16 macro_mem_3 (.clk(Clk_CI),.rd_out(RdData_DO[63:48]),.ce_in(csel_b),.we_in(wren_b),.addr_in(Addr_DI),.w_mask_in(WMaskIn),.wd_in(WrData_DI[63:48]));
    
 
 endmodule // limping_SyncSpRamBeNx64_00000008_00000100_0_2


### PR DESCRIPTION
### Summary

Fixed incorrect bit mapping in the limping_SyncSpRamBeNx64_00000008_00000100_0_2 module that was causing critical cache dirty/valid bits to be lost, resulting in a total of 132 macros, whereas 133 macros were expected.

### Problem

The limping_SyncSpRamBeNx64_00000008_00000100_0_2 module (used by valid_dirty_sram) was storing bits [15:0] and zeroing bits [63:16]. However, the critical data (dirty_wdata[1:0], replicated for all eight cache ways) is located at bits [63:48], not [15:0].

As a result, the cache's valid/dirty status bits always read as zero, which could lead to the pruning of the valid_dirty_sram.

### Fix

Changed the limping module to store bits [63:48] (the critical dirty/valid bits) instead of bits [15:0]:

// Before (incorrect):
fakeram45_256x16 macro_mem_0 (..., .rd_out(RdData_DO[15:0]), .wd_in(WrData_DI[15:0]));
assign RdData_DO[63:16] = 48'h0;

// After (fixed):
fakeram45_256x16 macro_mem_3 (..., .rd_out(RdData_DO[63:48]), .wd_in(WrData_DI[63:48]));
assign RdData_DO[47:0] = 48'h0;
