### PR TITLE
floorplan: dry run of PDN to check for errors

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -140,6 +140,7 @@ configuration file.
 | <a name="FILL_CELLS"></a>FILL_CELLS| Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.| |
 | <a name="FILL_CONFIG"></a>FILL_CONFIG| JSON rule file for metal fill during chip finishing.| |
 | <a name="FLOORPLAN_DEF"></a>FLOORPLAN_DEF| Use the DEF file to initialize floorplan. Mutually exclusive with FOOTPRINT or DIE_AREA/CORE_AREA or CORE_UTILIZATION.| |
+| <a name="FLOORPLAN_PDN_DRY_RUN"></a>FLOORPLAN_PDN_DRY_RUN| Perform a dry run of the PDN step to check for errors without writing the ODB and SDC files early in the floorplan flow. This makes it easier to connect any errors to the cause: unworkable floorplan.| 1|
 | <a name="FLOW_VARIANT"></a>FLOW_VARIANT| Flow variant to use, used in the flow variant directory name.| base|
 | <a name="FOOTPRINT"></a>FOOTPRINT| Custom footprint definition file for ICeWall-based floorplan initialization. Mutually exclusive with FLOORPLAN_DEF or DIE_AREA/CORE_AREA or CORE_UTILIZATION.| |
 | <a name="FOOTPRINT_TCL"></a>FOOTPRINT_TCL| Specifies a Tcl script with custom footprint-related commands for floorplan setup.| |
@@ -322,6 +323,7 @@ configuration file.
 - [CORE_UTILIZATION](#CORE_UTILIZATION)
 - [DIE_AREA](#DIE_AREA)
 - [FLOORPLAN_DEF](#FLOORPLAN_DEF)
+- [FLOORPLAN_PDN_DRY_RUN](#FLOORPLAN_PDN_DRY_RUN)
 - [FOOTPRINT](#FOOTPRINT)
 - [FOOTPRINT_TCL](#FOOTPRINT_TCL)
 - [HOLD_SLACK_MARGIN](#HOLD_SLACK_MARGIN)

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -152,3 +152,9 @@ source_env_var_if_exists IO_CONSTRAINTS
 
 orfs_write_db $::env(RESULTS_DIR)/2_1_floorplan.odb
 orfs_write_sdc $::env(RESULTS_DIR)/2_1_floorplan.sdc
+
+if { $::env(FLOORPLAN_PDN_DRY_RUN) } {
+  puts "PDN dry run to check for errors"
+  set ::env(WRITE_ODB_AND_SDC_EACH_STAGE) 0
+  source $::env(SCRIPTS_DIR)/pdn.tcl
+}

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -393,6 +393,14 @@ SWAP_ARITH_OPERATORS:
     Improve timing QoR by swapping ALU and MULT arithmetic operators.
   stages:
     - All stages
+FLOORPLAN_PDN_DRY_RUN:
+  description: >
+    Perform a dry run of the PDN step to check for errors without writing
+    the ODB and SDC files early in the floorplan flow. This makes it easier
+    to connect any errors to the cause: unworkable floorplan.
+  stages:
+    - floorplan
+  default: 1
 FLOORPLAN_DEF:
   description: |
     Use the DEF file to initialize floorplan. Mutually exclusive with FOOTPRINT or DIE_AREA/CORE_AREA or CORE_UTILIZATION.


### PR DESCRIPTION
@gadfort @maliberty Thoughts?

If PDN was blazingly fast, I would remove the variable.

Enabled by default as this is to help novices(such as me).