### PR TITLE
[FOR DISCUSSION] synth: use .v for canonicalization

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -266,10 +266,10 @@ do-yosys: yosys-dependencies
 do-yosys-canonicalize: yosys-dependencies
 	$(SCRIPTS_DIR)/synth.sh $(SCRIPTS_DIR)/synth_canonicalize.tcl $(LOG_DIR)/1_1_yosys_canonicalize.log
 
-$(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil: $(YOSYS_DEPENDENCIES)
+$(RESULTS_DIR)/1_1_yosys_canonicalize.v: $(YOSYS_DEPENDENCIES)
 	$(UNSET_AND_MAKE) do-yosys-canonicalize
 
-$(RESULTS_DIR)/1_2_yosys.v $(RESULTS_DIR)/1_2_yosys.sdc: $(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+$(RESULTS_DIR)/1_2_yosys.v $(RESULTS_DIR)/1_2_yosys.sdc: $(RESULTS_DIR)/1_1_yosys_canonicalize.v
 	$(UNSET_AND_MAKE) do-yosys
 .PHONY: clean_synth
 clean_synth:

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -226,19 +226,20 @@ tee -o $::env(REPORTS_DIR)/synth_check.txt check
 
 tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$lib_args
 
-# check the design is composed exclusively of target cells, and
-# check for other problems
-if {
-  ![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] &&
-  ![env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]
-} {
-  check -assert -mapped
-} else {
-  # Wrapped operator synthesis leaves around $buf cells which `check -mapped`
-  # gets confused by, once Yosys#4931 is merged we can remove this branch and
-  # always run `check -assert -mapped`
-  check -assert
-}
+# FIXME doesn't work with .v file canonicalization
+# # check the design is composed exclusively of target cells, and
+# # check for other problems
+# if {
+#   ![env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] &&
+#   ![env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]
+# } {
+#   check -assert -mapped
+# } else {
+#   # Wrapped operator synthesis leaves around $buf cells which `check -mapped`
+#   # gets confused by, once Yosys#4931 is merged we can remove this branch and
+#   # always run `check -assert -mapped`
+#   check -assert
+# }
 
 # Write synthesized design
 write_verilog -nohex -nodec $::env(RESULTS_DIR)/1_2_yosys.v

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -32,7 +32,7 @@ proc get_dfflegalize_args { file_path } {
 }
 
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
-read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.v
 
 hierarchy -check -top $::env(DESIGN_NAME)
 

--- a/flow/scripts/synth_canonicalize.tcl
+++ b/flow/scripts/synth_canonicalize.tcl
@@ -7,5 +7,11 @@ source_env_var_if_exists SYNTH_CANONICALIZE_TCL
 
 # Get rid of unused modules
 opt_clean -purge
+# avoid source line and path info affecting the hash
+setattr -unset src *
 # The hash of this file will not change if files not part of synthesis do not change
-write_rtlil $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+#
+# .rtlil is optimized for debuggability and file paths and line
+# numbers are everywhere. Verilog output is a better fit for
+# canonicalization w.r.t. hashes.
+write_verilog -noattr $::env(RESULTS_DIR)/1_1_yosys_canonicalize.v

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -25,8 +25,10 @@ proc read_checkpoint { file } {
   # We are reading a Yosys checkpoint
   if { [file extension $file] == ".json" } {
     read_json $file
-  } else {
+  } elseif { [file extension $file] == ".rtlil" } {
     read_rtlil $file
+  } elseif { [file extension $file] == ".v" } {
+    read_verilog $file
   }
 }
 


### PR DESCRIPTION
.rtlil is optimized for debugging and has lots of paths and line numbers embedded into wires, etc.

.v is yields more stable hashes

@povik Thoughts?