### PR TITLE
synth: avoid stdcells in .rtlil

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -33,6 +33,7 @@ proc get_dfflegalize_args { file_path } {
 
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
 read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+source $::env(SCRIPTS_DIR)/synth_stdcells.tcl
 
 hierarchy -check -top $::env(DESIGN_NAME)
 

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -31,9 +31,6 @@ proc read_checkpoint { file } {
 }
 
 proc read_design_sources { } {
-  # We are reading Verilog sources
-  source $::env(SCRIPTS_DIR)/synth_stdcells.tcl
-
   # Setup verilog include directories
   set vIdirsArgs ""
   if { [env_var_exists_and_non_empty VERILOG_INCLUDE_DIRS] } {


### PR DESCRIPTION
Easier to browse through small .rtlil files now, saves disk space.

Canonicalization improvements are slight as stdcells basically never change.