### PR TITLE
gui: add gui/open_yosys targets

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -389,6 +389,8 @@ endef
 # Custom target to go from synthesis to placement in a single OpenROAD run
 $(eval $(call do-step,1_3_floorplan_to_place, $(RESULTS_DIR)/1_synth.odb $(RESULTS_DIR)/1_synth.sdc,floorplan_to_place))
 
+$(eval $(call OPEN_GUI_SHORTCUT,yosys,1_2_yosys.v))
+
 .PHONY: floorplan_to_place
 floorplan_to_place: $(RESULTS_DIR)/1_synth.odb $(RESULTS_DIR)/1_synth.sdc
 	$(UNSET_AND_MAKE) do-1_3_floorplan_to_place
@@ -777,6 +779,7 @@ $(eval $(call OPEN_GUI_SHORTCUT,final,6_final.odb))
 
 $(foreach file,$(RESULTS_DEF),$(eval $(call OPEN_GUI,$(file),DEF_FILE)))
 $(foreach file,$(RESULTS_ODB),$(eval $(call OPEN_GUI,$(file),ODB_FILE)))
+$(foreach file,$(RESULTS_V),$(eval $(call OPEN_GUI,$(file),V_FILE)))
 
 # Write a def for the corresponding odb
 $(foreach file,$(RESULTS_ODB),$(file).def): %.def:

--- a/flow/designs/asap7/minimal/README.md
+++ b/flow/designs/asap7/minimal/README.md
@@ -62,6 +62,10 @@ gui_synth
 The module hierarchy can here be examined to give a sense of
 area required for the default placement density.
 
+## `make gui_yosys` OpenROAD GUI information for Yosys netlist
+
+It is possible to set up hierarchical synthesis using ORFS, in which case it can be helpful to view a netlist with blackboxed submodles, in which case there's no .odb file and `make gui_synth` is not available.
+
 ## `make gui_floorplan` OpenROAD GUI information
 
 Next to iterate on floorplan settings:

--- a/flow/designs/asap7/minimal/README.md
+++ b/flow/designs/asap7/minimal/README.md
@@ -64,7 +64,7 @@ area required for the default placement density.
 
 ## `make gui_yosys` OpenROAD GUI information for Yosys netlist
 
-It is possible to set up hierarchical synthesis using ORFS, in which case it can be helpful to view a netlist with blackboxed submodles, in which case there's no .odb file and `make gui_synth` is not available.
+It is possible to set up hierarchical synthesis using ORFS, in which case it can be helpful to view a netlist with blackboxed submodules, in which case there's no .odb file and `make gui_synth` is not available.
 
 ## `make gui_floorplan` OpenROAD GUI information
 

--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -16,6 +16,17 @@ if { [env_var_exists_and_non_empty DEF_FILE] } {
   }
   set input_file $::env(DEF_FILE)
   log_cmd read_def $input_file
+} elseif { [env_var_exists_and_non_empty V_FILE] } {
+  log_cmd read_lef $::env(TECH_LEF)
+  log_cmd read_lef $::env(SC_LEF)
+  if { [env_var_exists_and_non_empty ADDITIONAL_LEFS] } {
+    foreach lef $::env(ADDITIONAL_LEFS) {
+      log_cmd read_lef $lef
+    }
+  }
+  set input_file $::env(V_FILE)
+  log_cmd read_verilog $input_file
+  log_cmd link_design {*}[hier_options] $::env(DESIGN_NAME)
 } else {
   set input_file $::env(ODB_FILE)
   log_cmd read_db {*}[hier_options] $input_file

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -184,6 +184,7 @@ export RESULTS_ODB = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.odb)))
 export RESULTS_DEF = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.def)))
 export RESULTS_GDS = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.gds)))
 export RESULTS_OAS = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.oas)))
+export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
 export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 
 define get_variables


### PR DESCRIPTION
Useful when viewing a netlist with blackboxed modules where there's no .odb file in parallel synthesi