### PR TITLE
designs: ihp-sg13g2: i2c-gpio-expander: Fix padring power/ground nets

### DIFF
--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/pad.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/pad.tcl
@@ -28,6 +28,14 @@ proc calc_vertical_pad_location { index total IO_LENGTH IO_WIDTH BONDPAD_SIZE SE
   }]
 }
 
+# padframe core power pins
+add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
+add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
+
+# padframe io power pins
+add_global_connection -net {IOVDD} -pin_pattern {^iovdd$} -power
+add_global_connection -net {IOVSS} -pin_pattern {^iovss$} -ground
+
 make_fake_io_site -name IOLibSite -width 1 -height $IO_LENGTH
 make_fake_io_site -name IOLibCSite -width $IO_LENGTH -height $IO_LENGTH
 

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
@@ -11,14 +11,6 @@ add_global_connection -net {VSS} -inst_pattern {.*} -pin_pattern {VSS!} -ground
 add_global_connection -net {VDD} -inst_pattern {.*} -pin_pattern {^VDD$} -power
 add_global_connection -net {VSS} -inst_pattern {.*} -pin_pattern {^VSS$} -ground
 
-# padframe core power pins
-add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
-add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
-
-# padframe io power pins
-add_global_connection -net {IOVDD} -pin_pattern {^iovdd$} -power
-add_global_connection -net {IOVSS} -pin_pattern {^iovss$} -ground
-
 global_connect
 
 # core voltage domain

--- a/flow/platforms/ihp-sg13g2/pdn.tcl
+++ b/flow/platforms/ihp-sg13g2/pdn.tcl
@@ -7,9 +7,6 @@ add_global_connection -net {VDD} -pin_pattern {^VDDPE$}
 add_global_connection -net {VDD} -pin_pattern {^VDDCE$}
 add_global_connection -net {VSS} -pin_pattern {^VSS$} -ground
 add_global_connection -net {VSS} -pin_pattern {^VSSE$}
-# I/O pads
-add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
-add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
 global_connect
 ####################################
 # voltage domains


### PR DESCRIPTION
Place `add_global_connection` for power and ground nets in the padring before the padring got created.

Also remove `add_global_connection` from the ihp-sg13g2 default `pdn.tcl` file, because it should be defined in the `FOOTPRINT_TCL` file.

See #3867 for reference.