### PR TITLE
util/docker_shell: Don't hard-code DISPLAY for fetching auth info

### DIFF
--- a/flow/util/docker_shell
+++ b/flow/util/docker_shell
@@ -31,7 +31,7 @@ KLAYOUT_CMD=${KLAYOUT_CMD:-/usr/bin/klayout}
 
 XSOCK=/tmp/.X11-unix
 XAUTH=/tmp/.docker.xauth
-xauth nlist :0 | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 ARGUMENTS=$@
 
 if test -t 0; then


### PR DESCRIPTION
The flow/util/docker_shell script looks up the X authorization information (magic cookie) for display :0 and exports it to the container, but sets DISPLAY to match DISPLAY of the host shell. There are no guarantees that the authorization information for :0 is the same as for $DISPLAY, if $DISPLAY != :0.

This patch changes flow/util/docker_shell to always extract the authorization information for $DISPLAY.