### PR TITLE
flow: platforn: ihp-sg13g2: Ignore Empty GDS for Multi-port SRAM

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -154,4 +154,4 @@ export CDL_FILE ?= $(PLATFORM_DIR)/cdl/sg13g2_stdcell.cdl
 
 # SRAM macros have empty placeholder cells included. Just ignore them to not
 # thrown an error.
-export GDS_ALLOW_EMPTY = RM_IHPSG13_1P_BITKIT_16x2_(CORNER|EDGE_TB|LE_con_corner|LE_con_edge_lr|LE_con_tap_lr|POWER_ramtap|TAP|TAP_LR)
+export GDS_ALLOW_EMPTY = RM_IHPSG13_\dP_BITKIT_16x2_(CORNER|EDGE_TB|LE_con_corner|LE_con_edge_lr|LE_con_tap_lr|POWER_ramtap|TAP|TAP_LR)


### PR DESCRIPTION
IHP SRAM LEF file contain cells without matching GDS cells. This was disabled earlier already, but only for single-port SRAMs.

Change the port number to a decimal wildcard to fix SRAM macros for all number of ports.

Fixes:
  [ERROR] LEF Cell 'RM_IHPSG13_2P_BITKIT_16x2_EDGE_TB' has no matching GDS/OAS cell. Cell will be empty.