### PR TITLE
docs: add forking OpenROAD instructions to Git Guide and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ Document for detailed local build from sources and installation steps found [her
 ORFS supports hosting projects in your own git repository
 without the need to fork ORFS.
 
+> **Note for contributors forking ORFS:** If you intend to fork ORFS
+> to contribute changes, you must also fork the
+> [OpenROAD repository](https://github.com/The-OpenROAD-Project/OpenROAD).
+> This is required because OpenROAD is a Git submodule inside ORFS.
+> See the [Git Guide](./docs/contrib/GitGuide.md) for full instructions.
+
 To build from your own git repository:
 
     cd /home/me/myproject

--- a/docs/contrib/GitGuide.md
+++ b/docs/contrib/GitGuide.md
@@ -1,3 +1,38 @@
 # Git Quickstart
 
 If you have reached this file on GitHub - please refer to this [link](https://openroad-flow-scripts.readthedocs.io/en/latest/contrib/GitGuide.html) for latest documentation.
+
+### Forking OpenROAD (Required for ORFS Contributors)
+
+> **Important:** When forking ORFS, you must also fork the OpenROAD
+> repository. OpenROAD is included as a Git submodule at `tools/OpenROAD/`.
+> If you only fork ORFS, the submodule still points to the original
+> OpenROAD repo, which you cannot push to, and your build will fail.
+
+#### Steps
+
+**Step 1 — Fork both repositories on GitHub:**
+
+- Fork ORFS: https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
+- Fork OpenROAD: https://github.com/The-OpenROAD-Project/OpenROAD
+
+**Step 2 — Clone your ORFS fork:**
+```bash
+git clone https://github.com/<your-username>/OpenROAD-flow-scripts.git
+cd OpenROAD-flow-scripts
+```
+
+**Step 3 — Point the submodule to your OpenROAD fork:**
+```bash
+cd tools/OpenROAD
+git remote set-url origin https://github.com/<your-username>/OpenROAD.git
+cd ../..
+```
+
+**Step 4 — Verify the setup:**
+```bash
+git submodule update --init --recursive
+```
+
+You can now build and submit pull requests to both ORFS and OpenROAD
+from your own forks.


### PR DESCRIPTION
Fixes #2213

OpenROAD is a Git submodule inside ORFS at tools/OpenROAD/. When contributors fork only ORFS, the submodule still points to
the original OpenROAD repo. Since they lack write access to the original, the build fails.

Changes:
- docs/contrib/GitGuide.md: Added step-by-step forking instructions
- README.md: Added a note directing contributors to the Git Guide