### PR TITLE
docs: note OpenROAD fork requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ timeline
 
 There are multiple ways to install and develop OpenROAD and ORFS. However, the best option depends on your use case, experience level, and personal preference.
 
+```{note}
+Forking ORFS? Also fork [`OpenROAD`](https://github.com/The-OpenROAD-Project/OpenROAD) and point the `tools/OpenROAD` submodule at your fork (e.g., `git submodule set-url tools/OpenROAD https://github.com/<you>/OpenROAD.git && git submodule update --init --recursive`). Otherwise a forked clone may fail to build.
+```
+
 
 > **Recommendation for new users:**  
 > If you are new to OpenROAD-flow-scripts, Docker can be a reliable way to get started since it avoids most dependency and environment issues.  

--- a/docs/contrib/GitGuide.md
+++ b/docs/contrib/GitGuide.md
@@ -1,3 +1,43 @@
-# Git Quickstart
+# Git Quickstart (forks)
 
-If you have reached this file on GitHub - please refer to this [link](https://openroad-flow-scripts.readthedocs.io/en/latest/contrib/GitGuide.html) for latest documentation.
+If you are working from your **own fork**, you must fork both this repository **and** the
+`OpenROAD` submodule. Otherwise `git submodule` will still point to the upstream
+`The-OpenROAD-Project/OpenROAD` and builds in your fork will fail.
+
+## Fork + clone
+
+1. Fork **OpenROAD-flow-scripts**.
+2. Fork **OpenROAD** (the tools submodule).
+3. Clone your ORFS fork with submodules:
+   ```bash
+   git clone --recursive https://github.com/<you>/OpenROAD-flow-scripts.git
+   cd OpenROAD-flow-scripts
+   ```
+
+## Point the submodule at your OpenROAD fork
+
+Run these once in your clone:
+
+```bash
+git submodule set-url tools/OpenROAD https://github.com/<you>/OpenROAD.git
+git submodule update --init --recursive
+```
+
+## Keep both forks in sync
+
+```bash
+git remote add upstream https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts.git
+git remote add upstream-or https://github.com/The-OpenROAD-Project/OpenROAD.git
+git fetch upstream upstream-or
+
+# Update ORFS
+git checkout master
+git pull upstream master
+
+# Update OpenROAD submodule to upstream
+git submodule update --remote tools/OpenROAD
+git push origin master
+```
+
+With this setup, `git clone --recursive <your-orfs-fork>` will work, and the submodule
+will track your OpenROAD fork by default.


### PR DESCRIPTION
## Summary
- expand Git Quickstart to cover forking the OpenROAD submodule and setting its URL
- add README note warning fork users to point tools/OpenROAD at their fork

## Rationale
- forks fail to build unless the OpenROAD submodule is also forked; docs now call this out (issue #2213)

## Changes
- docs/contrib/GitGuide.md: fork-aware instructions and submodule URL steps
- README.md: short note about forking OpenROAD when forking ORFS

## Tests
- All CI passing in fork

Fixes #2213