### PR TITLE
variables: add ASAP7_USE_VT

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -100,6 +100,7 @@ configuration file.
 | <a name="ADDITIONAL_GDS"></a>ADDITIONAL_GDS| Hardened macro GDS files listed here.| |
 | <a name="ADDITIONAL_LEFS"></a>ADDITIONAL_LEFS| Hardened macro LEF view files listed here. The LEF information of the macros is immutable and used throughout all stages. Stored in the .odb file.| |
 | <a name="ADDITIONAL_LIBS"></a>ADDITIONAL_LIBS| Hardened macro library files listed here. The library information is immutable and used throughout all stages. Not stored in the .odb file.| |
+| <a name="ASAP7_USE_VT"></a>ASAP7_USE_VT| A space separated list of VT options to use with the ASAP7 standard cell library: RVT, LVT, SLVT.| RVT|
 | <a name="BALANCE_ROWS"></a>BALANCE_ROWS| Balance rows during placement.| 0|
 | <a name="BLOCKS"></a>BLOCKS| Blocks used as hard macros in a hierarchical flow. Do note that you have to specify block-specific inputs file in the directory mentioned by Makefile.| |
 | <a name="BUFFER_PORTS_ARGS"></a>BUFFER_PORTS_ARGS| Specify arguments to the buffer_ports call during placement. Only used if DONT_BUFFER_PORTS=0.| |
@@ -496,6 +497,7 @@ configuration file.
 
 ## All stages variables
 
+- [ASAP7_USE_VT](#ASAP7_USE_VT)
 - [KEEP_VARS](#KEEP_VARS)
 - [NUM_CORES](#NUM_CORES)
 - [OPENROAD_HIERARCHICAL](#OPENROAD_HIERARCHICAL)

--- a/flow/platforms/asap7/config.mk
+++ b/flow/platforms/asap7/config.mk
@@ -1,6 +1,5 @@
 export PLATFORM                = asap7
 export PROCESS                 = 7
-export ASAP7_USE_VT           ?= RVT
 
 ifeq ($(LIB_MODEL),)
    export LIB_MODEL = NLDM

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1306,3 +1306,10 @@ REMOVE_CELLS_FOR_LEC:
     String patterns directly passed to write_verilog -remove_cells <> for
     lec checks.
   type: string
+ASAP7_USE_VT:
+  description: >
+    A space separated list of VT options to use with the ASAP7 standard cell library:
+    RVT, LVT, SLVT.
+  stages:
+    - All stages
+  default: RVT


### PR DESCRIPTION
Use-case, check effect on timing by using different voltage thresholds, in which case bazel-orfs wants to know that ASAP_USE_VT is an ORFS variable:

    bazelisk run --define "ASAP7_USE_VT=LVT SLVT" Foo_synth $(pwd)/synth gui_synth

