### PR TITLE
LEC_CHECK: default 0 for out of tree designs

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -161,7 +161,7 @@ configuration file.
 | <a name="KLAYOUT_TECH_FILE"></a>KLAYOUT_TECH_FILE| A mapping from LEF/DEF to GDS using the KLayout tool.| |
 | <a name="LATCH_MAP_FILE"></a>LATCH_MAP_FILE| Optional mapping file supplied to Yosys to map latches| |
 | <a name="LAYER_PARASITICS_FILE"></a>LAYER_PARASITICS_FILE| Path to per layer parasitics file. Defaults to $(PLATFORM_DIR)/setRC.tcl.| |
-| <a name="LEC_CHECK"></a>LEC_CHECK| Perform a formal equivalence check between before and after netlists.| 1|
+| <a name="LEC_CHECK"></a>LEC_CHECK| This is primarily an ORFS CI regression testing feature and is default 0 for DESIGN_CONFIG pointing designs outside of the ORFS tree. Requires `KEPLER_FORMAL_EXE` to point to a built Kepler executable.| |
 | <a name="LIB_FILES"></a>LIB_FILES| A Liberty file of the standard cell library with PVT characterization, input and output characteristics, timing and power definitions for each cell.| |
 | <a name="MACRO_BLOCKAGE_HALO"></a>MACRO_BLOCKAGE_HALO| Distance beyond the edges of a macro that will also be covered by the blockage generated for that macro. Note that the default macro blockage halo comes from the largest of the specified MACRO_PLACE_HALO x or y values. This variable overrides that calculation.| |
 | <a name="MACRO_EXTENSION"></a>MACRO_EXTENSION| Sets the number of GCells added to the blockages boundaries from macros.| |

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -5,6 +5,13 @@
 
 export DESIGN_NICKNAME?=$(DESIGN_NAME)
 
+ifneq ($(findstring $(abspath $(FLOW_HOME)),$(abspath $(DESIGN_CONFIG))),)
+  export ORFS_TEST_SUITE_DESIGN := 1
+else
+  export ORFS_TEST_SUITE_DESIGN := 0
+endif
+export LEC_CHECK ?= $(ORFS_TEST_SUITE_DESIGN)
+
 #-------------------------------------------------------------------------------
 # Setup variables to point to other location for the following sub directory
 # - designs - default is under current directory

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1297,8 +1297,10 @@ WRITE_ODB_AND_SDC_EACH_STAGE:
   default: 1
 LEC_CHECK:
   description: >
-    Perform a formal equivalence check between before and after netlists.
-  default: 1
+    This is primarily an ORFS CI regression testing feature and is default 0
+    for DESIGN_CONFIG pointing designs outside of the ORFS tree.
+
+    Requires `KEPLER_FORMAL_EXE` to point to a built Kepler executable.
   stages:
     - cts
 REMOVE_CELLS_FOR_LEC:


### PR DESCRIPTION
```shell
$ cd OpenROAD-flow-scripts/flow
$ make print-ORFS_TEST_SUITE_DESIGN print-LEC_CHECK
ORFS_TEST_SUITE_DESIGN: 1
LEC_CHECK: 1
$ make DESIGN_CONFIG=../config.mk print-ORFS_TEST_SUITE_DESIGN print-LEC_CHECK
ORFS_TEST_SUITE_DESIGN: 0
LEC_CHECK: 0
```

fixes #3907