### PR TITLE
Support Kali GNU/Linux and generic Debian derivatives in DependencyInstaller

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -459,7 +459,7 @@ case "${os}" in
             _installPipCommon
         fi
         ;;
-    "Ubuntu" | "Debian GNU/Linux rodete" )
+    "Ubuntu" | "Debian GNU/Linux"* | "Kali GNU/Linux" )
         version=$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | sed 's/"//g')
         if [[ -z ${version} ]]; then
             version=$(awk -F= '/^VERSION_CODENAME/{print $2}' /etc/os-release | sed 's/"//g')


### PR DESCRIPTION
## Summary

- Add `"Kali GNU/Linux"` and wildcard `"Debian GNU/Linux"*` to the OS case match in `etc/DependencyInstaller.sh` so that Debian-based distributions (including Kali) are routed through the existing Ubuntu/Debian package installation path

## Context

This is the companion PR to The-OpenROAD-Project/OpenROAD#9522, which contains the bulk of the changes in the OpenROAD submodule's `DependencyInstaller.sh`.

## Test plan

- [x] Tested `sudo ./setup.sh` on Kali GNU/Linux 2025.4
- [x] Verified full OpenROAD build succeeds
- [x] Verified `openroad -version` runs correctly
- [ ] Verify no regressions on Ubuntu 22.04/24.04
- [ ] Verify no regressions on Debian 12

Fixes #3910

Made with [Cursor](https://cursor.com)