### PR TITLE
LEC: default on for ORFS test scripts

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -162,7 +162,7 @@ configuration file.
 | <a name="KLAYOUT_TECH_FILE"></a>KLAYOUT_TECH_FILE| A mapping from LEF/DEF to GDS using the KLayout tool.| |
 | <a name="LATCH_MAP_FILE"></a>LATCH_MAP_FILE| Optional mapping file supplied to Yosys to map latches| |
 | <a name="LAYER_PARASITICS_FILE"></a>LAYER_PARASITICS_FILE| Path to per layer parasitics file. Defaults to $(PLATFORM_DIR)/setRC.tcl.| |
-| <a name="LEC_CHECK"></a>LEC_CHECK| Perform a formal equivalence check between before and after netlists.| 1|
+| <a name="LEC_CHECK"></a>LEC_CHECK| Perform a formal equivalence check between before and after netlists. If this fails, report an issue to OpenROAD.| 0|
 | <a name="LIB_FILES"></a>LIB_FILES| A Liberty file of the standard cell library with PVT characterization, input and output characteristics, timing and power definitions for each cell.| |
 | <a name="MACRO_BLOCKAGE_HALO"></a>MACRO_BLOCKAGE_HALO| Distance beyond the edges of a macro that will also be covered by the blockage generated for that macro. Note that the default macro blockage halo comes from the largest of the specified MACRO_PLACE_HALO x or y values. This variable overrides that calculation.| |
 | <a name="MACRO_EXTENSION"></a>MACRO_EXTENSION| Sets the number of GCells added to the blockages boundaries from macros.| |

--- a/flow/.gitignore
+++ b/flow/.gitignore
@@ -1,4 +1,3 @@
-settings.mk
 vars.sh
 vars.gdb
 vars.tcl

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -1,5 +1,7 @@
-# settings.mk is not under source control. Put variables into this
-# file to avoid having to adding the to the make command line.
+# Put variables into this file to avoid having to adding
+# the to the make command line.
+#
+# Out of ORFS trees can have their own settings.mk.
 -include settings.mk
 
 # ==============================================================================

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1298,7 +1298,9 @@ WRITE_ODB_AND_SDC_EACH_STAGE:
 LEC_CHECK:
   description: >
     Perform a formal equivalence check between before and after netlists.
-  default: 1
+
+    If this fails, report an issue to OpenROAD.
+  default: 0
   stages:
     - cts
 REMOVE_CELLS_FOR_LEC:

--- a/flow/settings.mk
+++ b/flow/settings.mk
@@ -1,0 +1,1 @@
+export LEC_CHECK ?= 1


### PR DESCRIPTION
If LEC fails, then the user should report a github issue and go about his business.

If LEC doesn't fail on the final netlist, then other than causing friction during development, LEC during development isn't an issue