### PR TITLE
flow: scripts: variables: Fix KEPLER_FORMAL_EXE export

### DIFF
--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -118,7 +118,7 @@ KLAYOUT_DIR = $(abspath $(FLOW_HOME)/../tools/install/klayout/)
 KLAYOUT_BIN_FROM_DIR = $(KLAYOUT_DIR)/klayout
 
 KEPLER_FORMAL_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/kepler-formal/bin/kepler-formal)
-export KEPLER_FORMAL_EXE := $(KEPLER_FORMAL_EXE)
+export KEPLER_FORMAL_EXE
 
 ifeq ($(wildcard $(KLAYOUT_BIN_FROM_DIR)), $(KLAYOUT_BIN_FROM_DIR))
 export KLAYOUT_CMD ?= sh -c 'LD_LIBRARY_PATH=$(dir $(KLAYOUT_BIN_FROM_DIR)) $$0 "$$@"' $(KLAYOUT_BIN_FROM_DIR)


### PR DESCRIPTION
Fix KEPLER_FORMAL_EXE export overriding user assignments 'export VAR := $(VAR)' re-assigns the variable with simple expansion, causing the ?= default to always win over user-provided values. Change to plain 'export' to only mark it for export without reassigning.