### PR TITLE
[AutoTuner] Replace failed metric string "-" with ERROR_METRIC

### DIFF
--- a/tools/AutoTuner/src/autotuner/distributed.py
+++ b/tools/AutoTuner/src/autotuner/distributed.py
@@ -147,7 +147,12 @@ class AutoTunerBase(tune.Trainable):
 
         # if not a valid config, then don't run and pass back an error
         if not self.is_valid_config:
-            return {METRIC: ERROR_METRIC, "effective_clk_period": "-", "num_drc": "-"}
+            return {
+                METRIC: ERROR_METRIC,
+                "effective_clk_period": ERROR_METRIC,
+                "num_drc": ERROR_METRIC,
+                "die_area": ERROR_METRIC,
+            }
         self._variant = f"{self.variant}-{self.step_}"
         metrics_file = openroad(
             args=args,
@@ -242,7 +247,7 @@ class PPAImprov(AutoTunerBase):
         error = "ERR" in metrics.values() or "ERR" in reference.values()
         not_found = "N/A" in metrics.values() or "N/A" in reference.values()
         if error or not_found:
-            return (ERROR_METRIC, "-", "-", "-")
+            return (ERROR_METRIC, ERROR_METRIC, ERROR_METRIC, ERROR_METRIC)
         ppa = self.get_ppa(metrics)
         gamma = ppa / 10
         score = ppa * (self.step_ / 100) ** (-1) + (gamma * metrics["num_drc"])

--- a/tools/AutoTuner/src/autotuner/utils.py
+++ b/tools/AutoTuner/src/autotuner/utils.py
@@ -79,7 +79,7 @@ def calculate_score(metrics, step=1):
     not_found = "N/A" in metrics.values()
 
     if error or not_found:
-        return (ERROR_METRIC, "-", "-", "-")
+        return (ERROR_METRIC, ERROR_METRIC, ERROR_METRIC, ERROR_METRIC)
 
     effective_clk_period = metrics["clk_period"] - metrics["worst_slack"]
     num_drc = metrics["num_drc"]


### PR DESCRIPTION
Fixes #3482

When AutoTuner trials fail, sub-metrics (`effective_clk_period`, `num_drc`, `die_area`) were returned as the string `"-"`. This caused TensorBoard HPARAMS to silently drop entire metric columns because of mixed string/numeric data types across trials.

### Changes

- `utils.py` — `calculate_score()`: return `ERROR_METRIC` instead of `"-"` for all sub-metrics on error/not-found
- `distributed.py` — `AutoTunerBase.step()`: return `ERROR_METRIC` instead of `"-"` for invalid config, and add missing `die_area` key to match the success path
- `distributed.py` — `PPAImprov.evaluate()`: return `ERROR_METRIC` instead of `"-"` for all sub-metrics on error/not-found

### Why this works

`ERROR_METRIC` (`9e99`) is already defined in `utils.py` and used for the primary score on failure. The `TensorBoardLogger.log_sweep_metrics()` method uses `isinstance(value, (int, float))` checks — with `"-"` (string), failed metrics were silently skipped; with `ERROR_METRIC` (float), they are now properly logged.

### Trade-off

As noted in #3482, `9e99` will distort TensorBoard Parallel Coordinates axis scales for failed runs. Users can adjust the Max slider per axis to filter these out.

### Testing

- Unit tested `calculate_score()` for ERR, N/A, and success cases — all return consistent numeric types
- Verified `isinstance` compatibility with `TensorBoardLogger` 
- Black formatting passes

@jeffng-or @luarss