### PR TITLE
Add numeric elapsed_seconds to metrics JSON

### DIFF
--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -347,6 +347,7 @@ def extract_metrics(
 
     if failed:
         metrics_dict["total_time"] = "ERR"
+        metrics_dict["total_elapsed_seconds"] = "ERR"
     else:
         metrics_dict["total_time"] = str(total)
         metrics_dict["total_elapsed_seconds"] = total.total_seconds()

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -342,7 +342,7 @@ def extract_metrics(
             )
             total += delta
 
-            stage = key.removesuffix("__runtime__total")
+            stage = key[: -len("__runtime__total")]
             elapsed_seconds[stage + "__elapsed_seconds"] = delta.total_seconds()
 
     if failed:

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -315,6 +315,7 @@ def extract_metrics(
 
     failed = False
     total = timedelta()
+    elapsed_seconds = {}
     for key in metrics_dict:
         if key.endswith("__runtime__total"):
             # Big try block because Hour and microsecond is optional
@@ -341,10 +342,16 @@ def extract_metrics(
             )
             total += delta
 
+            stage = key.removesuffix("__runtime__total")
+            elapsed_seconds[stage + "__elapsed_seconds"] = delta.total_seconds()
+
     if failed:
         metrics_dict["total_time"] = "ERR"
     else:
         metrics_dict["total_time"] = str(total)
+        metrics_dict["total_elapsed_seconds"] = total.total_seconds()
+
+    metrics_dict.update(elapsed_seconds)
 
     metrics_dict = {
         key.replace(":", "__"): value for key, value in metrics_dict.items()


### PR DESCRIPTION
### Summary

Resolves #2506

`genMetrics.py` stores stage runtimes as human-readable strings (e.g., `"0:04.26"`) in the metrics JSON. This makes them hard to consume programmatically — users have to parse the time format manually for analysis, plotting, or comparison.

This adds numeric `elapsed_seconds` fields (float, in seconds) alongside the existing string fields, so runtimes are directly usable as numbers.

### Changes

**`flow/util/genMetrics.py`**
- In the existing runtime accumulation loop, compute `delta.total_seconds()` for each stage and store as `<stage>__elapsed_seconds`
- Add `total_elapsed_seconds` alongside the existing `total_time` string

### Example output (new fields only)

```json
{
  "synth__runtime__total": "0:00.90",
  "synth__elapsed_seconds": 0.9,
  "globalplace__runtime__total": "0:02.59",
  "globalplace__elapsed_seconds": 2.59,
  "total_time": "0:00:18.900000",
  "total_elapsed_seconds": 18.9
}
```

Existing fields (`__runtime__total`, `total_time`, `__cpu__total`, `__mem__peak`) are unchanged. The hierarchical JSON format (`-x` flag) also works correctly since the new keys follow the same `stage__metric` naming convention.