### PR TITLE
Skip save_images on headless machines without display

### DIFF
--- a/flow/scripts/final_report.tcl
+++ b/flow/scripts/final_report.tcl
@@ -64,6 +64,7 @@ report_cell_usage
 report_metrics 6 "finish"
 
 # Save a final image if openroad is compiled with the gui
-if { [ord::openroad_gui_compiled] } {
+# and a display is available (skip on headless machines)
+if { [ord::openroad_gui_compiled] && [env_var_exists_and_non_empty DISPLAY] } {
   gui::show "source $::env(SCRIPTS_DIR)/save_images.tcl" false
 }


### PR DESCRIPTION
### Summary

Resolves #3034

The flow crashes during `final_report.tcl` on headless machines (no X display) because `gui::show` tries to initialize a Qt platform plugin, which fails with a fatal `std::runtime_error` abort when no display is available.

### Changes

**`flow/scripts/final_report.tcl`**

Added a `DISPLAY` environment check alongside the existing `ord::openroad_gui_compiled` check before calling `gui::show` to run `save_images.tcl`. On headless machines where `DISPLAY` is unset/empty, image generation is now gracefully skipped instead of crashing the flow.

Uses the existing `env_var_exists_and_non_empty` helper (already used 3 times in the same file for `RCX_RULES`, `PWR_NETS_VOLTAGES`, `GND_NETS_VOLTAGES`).

### Context

- `variables.mk` already sets `QT_QPA_PLATFORM=offscreen` when `DISPLAY` is empty, but the Tcl script never checked `DISPLAY` before attempting GUI operations
- The generated images (`final_*.webp`, `cts_*.webp`) are optional visualization output — no CI tests or Makefile targets depend on them
- Machines with a display are unaffected — behavior is identical to before