### PR TITLE
Add Debian and Kali GNU/Linux support to DependencyInstaller

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -258,6 +258,64 @@ _installUbuntuPackages() {
     fi
 }
 
+_installDebianPackages() {
+    export DEBIAN_FRONTEND="noninteractive"
+    apt-get -y update
+    apt-get -y install --no-install-recommends \
+        bison \
+        curl \
+        flex \
+        help2man \
+        libfl-dev \
+        libfl2 \
+        libgit2-dev \
+        libgoogle-perftools-dev \
+        libqt5multimediawidgets5 \
+        libqt5opengl5 \
+        libqt5svg5-dev \
+        libqt5xmlpatterns5-dev \
+        libz-dev \
+        perl \
+        python3-pip \
+        python3-venv \
+        qtmultimedia5-dev \
+        qttools5-dev \
+        ruby \
+        ruby-dev \
+        time \
+        zlib1g \
+        zlib1g-dev
+
+    # Install KLayout from Debian repos
+    apt-get -y install --no-install-recommends klayout python3-pandas \
+        || echo "WARNING: KLayout not available via apt. Please install manually."
+
+    if command -v docker &> /dev/null; then
+        echo "Docker is already installed, skip docker reinstall."
+        return 0
+    fi
+
+    # Add Docker's official GPG key:
+    install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+        -o /etc/apt/keyrings/docker.asc
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    # Add the Debian Docker repository
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+    apt-get -y update
+    apt-get -y install --no-install-recommends \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin \
+        || echo "WARNING: Docker installation failed. You may need to install Docker manually."
+}
+
 _installDarwinPackages() {
     brew install libffi tcl-tk ruby
     brew install python libomp doxygen capnp tbb bison flex boost spdlog zlib
@@ -481,6 +539,23 @@ case "${os}" in
             else
                 echo "Skip common for rodete"
             fi
+        fi
+        ;;
+    "Debian GNU/Linux" | "Kali GNU/Linux" )
+        version=$(awk -F= '/^VERSION_ID/{print $2}' /etc/os-release | sed 's/"//g')
+        if [[ -z ${version} ]]; then
+            version=$(awk -F= '/^VERSION_CODENAME/{print $2}' /etc/os-release | sed 's/"//g')
+        fi
+        if [[ ${CI} == "yes" ]]; then
+            echo "WARNING: Installing CI dependencies is only supported on Ubuntu 22.04" >&2
+        fi
+        _installORDependencies
+        if [[ "${option}" == "base" || "${option}" == "all" ]]; then
+            _installDebianPackages
+            _installUbuntuCleanUp
+        fi
+        if [[ "${option}" == "common" || "${option}" == "all" ]]; then
+            _installPipCommon
         fi
         ;;
     "Darwin" )

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -148,6 +148,10 @@ _installKlayoutDependenciesUbuntuAarch64() {
 }
 
 _installUbuntuPackages() {
+    # Detect distro for Docker repo URL and KLayout install method
+    local distro_id
+    distro_id=$(. /etc/os-release && echo "${ID}")
+
     export DEBIAN_FRONTEND="noninteractive"
     apt-get -y update
     apt-get -y install --no-install-recommends \
@@ -175,19 +179,23 @@ _installUbuntuPackages() {
         zlib1g \
         zlib1g-dev
 
-    packages=()
-    # Choose libstdc++ version
-    if _versionCompare $1 -ge 25.04; then
-        packages+=("libstdc++-15-dev")
-    elif _versionCompare $1 -ge 24.04; then
-        packages+=("libstdc++-14-dev")
-    elif _versionCompare $1 -ge 22.10; then
-        packages+=("libstdc++-12-dev")
+    # Choose libstdc++ version (Ubuntu-specific versioned packages)
+    if [[ "$distro_id" == "ubuntu" ]]; then
+        packages=()
+        if _versionCompare $1 -ge 25.04; then
+            packages+=("libstdc++-15-dev")
+        elif _versionCompare $1 -ge 24.04; then
+            packages+=("libstdc++-14-dev")
+        elif _versionCompare $1 -ge 22.10; then
+            packages+=("libstdc++-12-dev")
+        fi
+        apt-get install -y --no-install-recommends ${packages[@]}
     fi
-    apt-get install -y --no-install-recommends ${packages[@]}
 
     # install KLayout
-    if  [[ $1 == "rodete" ]]; then
+    # Debian/Kali and rodete use apt; Ubuntu >= 23.04 uses apt;
+    # older Ubuntu uses version-specific .deb downloads
+    if [[ $1 == "rodete" ]] || [[ "$distro_id" != "ubuntu" ]]; then
         apt-get -y install --no-install-recommends klayout python3-pandas
     elif _versionCompare "$1" -ge 23.04; then
         apt-get -y install --no-install-recommends klayout python3-pandas
@@ -236,14 +244,20 @@ _installUbuntuPackages() {
         return 0
     fi
 
+    # Determine Docker repo distro (Kali uses Debian repos)
+    local docker_distro="$distro_id"
+    if [[ "$distro_id" == "kali" ]]; then
+        docker_distro="debian"
+    fi
+
     # Add Docker's official GPG key:
     install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+    curl -fsSL https://download.docker.com/linux/${docker_distro}/gpg \
         -o /etc/apt/keyrings/docker.asc
     chmod a+r /etc/apt/keyrings/docker.asc
 
     # Add the repository to Apt sources:
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${docker_distro} \
         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
         tee /etc/apt/sources.list.d/docker.list > /dev/null
 
@@ -256,64 +270,6 @@ _installUbuntuPackages() {
             docker-buildx-plugin \
             docker-compose-plugin
     fi
-}
-
-_installDebianPackages() {
-    export DEBIAN_FRONTEND="noninteractive"
-    apt-get -y update
-    apt-get -y install --no-install-recommends \
-        bison \
-        curl \
-        flex \
-        help2man \
-        libfl-dev \
-        libfl2 \
-        libgit2-dev \
-        libgoogle-perftools-dev \
-        libqt5multimediawidgets5 \
-        libqt5opengl5 \
-        libqt5svg5-dev \
-        libqt5xmlpatterns5-dev \
-        libz-dev \
-        perl \
-        python3-pip \
-        python3-venv \
-        qtmultimedia5-dev \
-        qttools5-dev \
-        ruby \
-        ruby-dev \
-        time \
-        zlib1g \
-        zlib1g-dev
-
-    # Install KLayout from Debian repos
-    apt-get -y install --no-install-recommends klayout python3-pandas \
-        || echo "WARNING: KLayout not available via apt. Please install manually."
-
-    if command -v docker &> /dev/null; then
-        echo "Docker is already installed, skip docker reinstall."
-        return 0
-    fi
-
-    # Add Docker's official GPG key:
-    install -m 0755 -d /etc/apt/keyrings
-    curl -fsSL https://download.docker.com/linux/debian/gpg \
-        -o /etc/apt/keyrings/docker.asc
-    chmod a+r /etc/apt/keyrings/docker.asc
-
-    # Add the Debian Docker repository
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-        tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-    apt-get -y update
-    apt-get -y install --no-install-recommends \
-        docker-ce \
-        docker-ce-cli \
-        containerd.io \
-        docker-buildx-plugin \
-        docker-compose-plugin \
-        || echo "WARNING: Docker installation failed. You may need to install Docker manually."
 }
 
 _installDarwinPackages() {
@@ -551,7 +507,7 @@ case "${os}" in
         fi
         _installORDependencies
         if [[ "${option}" == "base" || "${option}" == "all" ]]; then
-            _installDebianPackages
+            _installUbuntuPackages "${version}"
             _installUbuntuCleanUp
         fi
         if [[ "${option}" == "common" || "${option}" == "all" ]]; then


### PR DESCRIPTION
### Summary

Partial fix for #3910

The ORFS `etc/DependencyInstaller.sh` only matches `"Ubuntu"` and `"Debian GNU/Linux rodete"` in its OS detection. Both `"Debian GNU/Linux"` and `"Kali GNU/Linux"` fall through to the `"unsupported system"` error.

### Changes

**`etc/DependencyInstaller.sh`**

- Added a `"Debian GNU/Linux" | "Kali GNU/Linux"` case entry that detects the version from `/etc/os-release` and routes through OpenROAD dependency installation + ORFS packages
- Reuses the existing `_installUbuntuPackages` function (no duplicate function) with distro-aware handling:
  - **KLayout**: installed via `apt` on Debian/Kali (available since Debian 11) instead of Ubuntu-specific `.deb` URLs
  - **Docker**: uses `download.docker.com/linux/debian` repo instead of `download.docker.com/linux/ubuntu` (Kali maps to Debian)
  - **libstdc++**: Ubuntu-specific versioned package selection is skipped on Debian/Kali
- Existing Ubuntu, Enterprise Linux, and Darwin code paths are completely untouched

### Verification

- `bash -n` syntax validation passes
- `shellcheck` reports zero new warnings
- Docker Debian GPG URL confirmed valid (HTTP 200)

### Scope

This PR covers **fix #1** (OS detection) from the issue at the ORFS level. Fixes #2–#5 (`libtcl`, `libpython`, `or-tools`, `abseil`) are in the OpenROAD submodule's `DependencyInstaller.sh` and would need a separate PR to that repo.