### PR TITLE
[slang] Automatically blackbox macros from ADDITIONAL_LIBS

### DIFF
--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -63,6 +63,16 @@ proc read_design_sources { } {
       lappend slang_args -G "$key=$value"
     }
 
+    # Automatically blackbox macros from ADDITIONAL_LIBS so that
+    # any competing Verilog definitions in the source files are
+    # ignored in favor of the liberty view, consistent with the
+    # behavior of the builtin Verilog frontend.
+    if { [env_var_exists_and_non_empty ADDITIONAL_LIBS] } {
+      foreach m [get_liberty_cell_names $::env(ADDITIONAL_LIBS)] {
+        lappend slang_args --blackboxed-module "$m"
+      }
+    }
+
     # Apply module blackboxing based on module names as they appear
     # in the input, that is before any module name mangling done
     # by elaboration and synthesis

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -1,3 +1,18 @@
+# Extract cell names from liberty files by parsing "cell(...)" declarations
+proc get_liberty_cell_names { lib_files } {
+  set cell_names [list]
+  foreach lib $lib_files {
+    set fid [open $lib r]
+    while { [gets $fid line] >= 0 } {
+      if { [regexp {^\s*cell\s*\(\s*"?([^")\s]+)"?\s*\)} $line -> cell_name] } {
+        lappend cell_names $cell_name
+      }
+    }
+    close $fid
+  }
+  return $cell_names
+}
+
 proc log_cmd { cmd args } {
   # log the command, escape arguments with spaces
   set log_cmd "$cmd[join [lmap arg $args { format " %s" [expr { [string match {* *} $arg] ? "\"$arg\"" : "$arg" }] }] ""]" ;# tclint-disable-line line-length


### PR DESCRIPTION
@povik I tested Claude to see if it could fix this problem. Is this helpful?

When using the slang HDL frontend, macros defined in ADDITIONAL_LIBS liberty files were not automatically blackboxed. If the same module had a competing Verilog definition in the source files, slang would elaborate the Verilog version instead of using the liberty view.

Fix by extracting cell names from ADDITIONAL_LIBS and passing them as --blackboxed-module arguments to slang, making the behavior consistent with the builtin Verilog frontend.

Tested:

  asap7/uart with a fake ADDITIONAL_LIBS containing uart_tx:
    Confirmed slang blackboxes uart_tx from the liberty file
    instead of elaborating it from the Verilog source.

  asap7/cva6 (which uses slang and ADDITIONAL_LIBS with fakeram
    macros that also have .sv definitions in VERILOG_FILES):
    make DESIGN_CONFIG=designs/asap7/cva6/config.mk do-yosys-canonicalize
    Passes in ~5s with no errors.

  asap7/uart without ADDITIONAL_LIBS:
    Normal synthesis still passes (no regression).

Fixes #3849