### PR TITLE
Add report_layer_rc to floorplan stage

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -146,6 +146,7 @@ if { $::env(REMOVE_ABC_BUFFERS) } {
 puts "Default units for flow"
 report_units
 report_units_metric
+report_layer_rc
 report_metrics 2 "floorplan final" false false
 
 source_env_var_if_exists POST_FLOORPLAN_TCL


### PR DESCRIPTION
## Description

Adds a `report_layer_rc` call in the floorplan stage to log per-layer resistance
and capacitance values during the flow run.

Resolves #2841

## Changes

- Added `report_layer_rc` in `flow/scripts/floorplan.tcl` after `report_units_metric`, 
  as part of the other one-time informational reports.

## Why floorplan.tcl?

- RC Values are loaded from `setRC.tcl`, sourced by `load_design` at the top of the file,
  so they will be available at this point.
- Values are constant across all stages of the flow, so one call is sufficient in floorplan.
- Following the pattern of `report_units` and `report_units_metric`, which are 
  one-time informational reports and are placed here.

## Output in log
 The log now includes a table like:
<img width="1920" height="1045" alt="flow" src="https://github.com/user-attachments/assets/8515cd63-39fc-4d24-8be5-e4a49ee4d93d" />


