### PR TITLE
flow: only enable LEC_CHECK when kepler-formal is installed

### DIFF
--- a/flow/settings.mk
+++ b/flow/settings.mk
@@ -1,1 +1,5 @@
-export LEC_CHECK ?= 1
+# Enable LEC (Logical Equivalence Check) only if kepler-formal is installed.
+# kepler-formal is primarily an OpenROAD/ORFS developer tool, not an end-user
+# tool. End-users would typically run LEC transactionally at project completion,
+# not in every CI run where it wastes CI time.
+export LEC_CHECK ?= $(if $(wildcard $(KEPLER_FORMAL_EXE)),1,0)


### PR DESCRIPTION
kepler-formal is primarily an OpenROAD/ORFS developer tool. End-users would typically run LEC transactionally at project completion, not in every CI run. Default LEC_CHECK to 0 when kepler-formal is not present to avoid hard failures in environments where it is not installed.