### PR TITLE
Add -bazel flag to skip OpenROAD build dependencies

### DIFF
--- a/docs/user/BuildLocally.md
+++ b/docs/user/BuildLocally.md
@@ -14,9 +14,47 @@ sudo ./setup.sh
 
 ## Using Bazel to build OpenROAD and run the ORFS flow
 
-Long story short: OpenROAD will eventually switch to using Bazel for downloading dependencies and building OpenROAD for all the reasons that the DependencyInstaller.sh and cmake are hard to support and brittle across platforms.
+OpenROAD is switching to Bazel for dependency management and building.
+Bazel eliminates the need for the complex `DependencyInstaller.sh` and
+cmake toolchain for OpenROAD itself.
 
-Currently the simplest way to build OpenROAD and run ORFS is to run one test, which will download all OpenROAD dependencies and build OpenROAD in the exec configuration:
+### Setup
+
+Install ORFS flow dependencies with user permissions:
+
+``` shell
+cd tools/OpenROAD
+bazelisk run //:setup-orfs
+```
+
+If system packages are missing, the command prints the exact `sudo` command
+to run and exits. This way the user sees what will be installed with root
+privileges before it happens — nothing is silently written to system
+directories. In educational and corporate environments where `sudo` is
+controlled by IT policy, the printed command can be handed off to an
+administrator. Running `sudo` separately also benefits from the system's
+apt cache on repeated runs. User-level tools (Yosys, eqy, sby) are built
+into the project's `dependencies/` directory with user permissions only.
+
+After installing system packages, re-run `bazelisk run //:setup-orfs` to
+complete setup.
+
+This installs the minimum tooling that Bazel does not yet manage (currently
+Yosys, eqy, sby, KLayout, and Python packages). Over time, more of these
+may move into Bazel, but that is an implementation detail — this command
+remains the single entry point for developers.
+
+### Build OpenROAD and run the flow
+
+``` shell
+cd tools/OpenROAD
+bazelisk run --//:platform=gui //:install
+cd ../../flow
+source ../env.sh
+make
+```
+
+Or without installing, run an ORFS flow using the exec-built OpenROAD:
 
 ``` shell
 cd tools/OpenROAD
@@ -24,8 +62,6 @@ bazelisk test src/drt/...
 cd ../../flow
 make OPENROAD_EXE=$(pwd)/../tools/OpenROAD/bazel-out/k8-opt-exec-ST-*/bin/openroad
 ```
-
-Bazel could similarly be used to download and make available pre-built binaries for tools such as Yosys, eqy and KLayout.
 
 Running some quick tests will cause the desired exec config of OpenROAD to be built. There's no explicit Bazel way to build an exec config of an executable and we want to to use an exec config that is the same binary as is used for a local OpenROAD modify + test Bazel cycle.
 

--- a/env.sh
+++ b/env.sh
@@ -14,6 +14,7 @@ function __setpaths() {
   export PATH=${DIR}/tools/install/OpenROAD/bin:$PATH
   export PATH=${DIR}/tools/install/yosys/bin:$PATH
   export PATH=${DIR}/tools/install/kepler-formal/bin:$PATH
+  export PATH=${DIR}/dependencies/bin:$PATH
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     export PATH="/Applications/KLayout/klayout.app/Contents/MacOS:$PATH"

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -26,6 +26,59 @@ _installORDependencies() {
     ./tools/OpenROAD/etc/DependencyInstaller.sh ${OR_INSTALLER_ARGS} -yosys-ver="${YOSYS_VER}"
 }
 
+# Install system packages for building Yosys/slang (via OR's -base),
+# then build Yosys/eqy/sby directly, skipping OpenROAD-specific build
+# dependencies (boost, swig, spdlog, eigen, or-tools, etc.) which Bazel
+# manages.
+_installBazelFlowDependencies() {
+    if [[ ${YOSYS_VER} == "" ]]; then
+        YOSYS_VER=v$(grep 'yosys_ver =' tools/yosys/docs/source/conf.py | awk -F'"' '{print $2}')
+    fi
+    # OR's -base installs system packages (build-essential, bison, flex,
+    # tcl-dev, libreadline-dev, libffi-dev, pkg-config, python3-dev, cmake,
+    # etc.) needed for building Yosys and yosys-slang.
+    if [[ "${option}" == "base" || "${option}" == "all" ]]; then
+        ./tools/OpenROAD/etc/DependencyInstaller.sh -base
+    fi
+    # Build Yosys/eqy/sby without the full -common pass that would also
+    # compile boost, swig, spdlog, eigen, gtest, or-tools, abseil, etc.
+    if [[ "${option}" == "common" || "${option}" == "all" ]]; then
+        local yosys_prefix=${PREFIX:-"/usr/local"}
+        local buildDir
+        buildDir=$(mktemp -d /tmp/orfs-yosys-build-XXXXXX)
+
+        echo "Building Yosys ${YOSYS_VER} ..."
+        (
+            cd "${buildDir}"
+            git clone --depth=1 -b "${YOSYS_VER}" --recursive https://github.com/YosysHQ/yosys
+            cd yosys
+            make -j "${numThreads}" PREFIX="${yosys_prefix}" ABC_ARCHFLAGS=-Wno-register
+            make install PREFIX="${yosys_prefix}"
+        )
+
+        echo "Building eqy ${YOSYS_VER} ..."
+        (
+            cd "${buildDir}"
+            git clone --depth=1 -b "${YOSYS_VER}" https://github.com/YosysHQ/eqy
+            cd eqy
+            export PATH="${yosys_prefix}/bin:${PATH}"
+            make -j "${numThreads}" PREFIX="${yosys_prefix}"
+            make install PREFIX="${yosys_prefix}"
+        )
+
+        echo "Building sby ${YOSYS_VER} ..."
+        (
+            cd "${buildDir}"
+            git clone --depth=1 -b "${YOSYS_VER}" --recursive https://github.com/YosysHQ/sby
+            cd sby
+            export PATH="${yosys_prefix}/bin:${PATH}"
+            make -j "${numThreads}" PREFIX="${yosys_prefix}" install
+        )
+
+        rm -rf "${buildDir}"
+    fi
+}
+
 _installPipCommon() {
     if [[ -f /opt/rh/rh-python38/enable ]]; then
         set +u
@@ -150,41 +203,51 @@ _installKlayoutDependenciesUbuntuAarch64() {
 _installUbuntuPackages() {
     export DEBIAN_FRONTEND="noninteractive"
     apt-get -y update
+
+    # Flow-level packages needed regardless of how OpenROAD is built
     apt-get -y install --no-install-recommends \
-        bison \
         curl \
-        flex \
-        help2man \
-        libfl-dev \
-        libfl2 \
-        libgit2-dev \
-        libgoogle-perftools-dev \
-        libqt5multimediawidgets5 \
-        libqt5opengl5 \
-        libqt5svg5-dev \
-        libqt5xmlpatterns5-dev \
-        libz-dev \
         perl \
         python3-pip \
         python3-venv \
-        qtmultimedia5-dev \
-        qttools5-dev \
         ruby \
         ruby-dev \
-        time \
-        zlib1g \
-        zlib1g-dev
+        time
 
-    packages=()
-    # Choose libstdc++ version
-    if _versionCompare $1 -ge 25.04; then
-        packages+=("libstdc++-15-dev")
-    elif _versionCompare $1 -ge 24.04; then
-        packages+=("libstdc++-14-dev")
-    elif _versionCompare $1 -ge 22.10; then
-        packages+=("libstdc++-12-dev")
+    if [[ "${BAZEL}" == "no" ]]; then
+        # Additional packages only needed when building OpenROAD from source
+        # (not with Bazel). OR's -base already installs core build tools
+        # (build-essential, bison, flex, etc.). This list covers ORFS-specific
+        # extras like KLayout Qt deps and profiling.
+        apt-get -y install --no-install-recommends \
+            bison \
+            flex \
+            help2man \
+            libfl-dev \
+            libfl2 \
+            libgit2-dev \
+            libgoogle-perftools-dev \
+            libqt5multimediawidgets5 \
+            libqt5opengl5 \
+            libqt5svg5-dev \
+            libqt5xmlpatterns5-dev \
+            libz-dev \
+            qtmultimedia5-dev \
+            qttools5-dev \
+            zlib1g \
+            zlib1g-dev
+
+        packages=()
+        # Choose libstdc++ version
+        if _versionCompare $1 -ge 25.04; then
+            packages+=("libstdc++-15-dev")
+        elif _versionCompare $1 -ge 24.04; then
+            packages+=("libstdc++-14-dev")
+        elif _versionCompare $1 -ge 22.10; then
+            packages+=("libstdc++-12-dev")
+        fi
+        apt-get install -y --no-install-recommends ${packages[@]}
     fi
-    apt-get install -y --no-install-recommends ${packages[@]}
 
     # install KLayout
     if  [[ $1 == "rodete" ]]; then
@@ -316,6 +379,13 @@ Usage: $0 [-all|-base|-common] [-<ARGS>]
        $0 -constant-build-dir
                                 #  Use constant build directory, instead of
                                 #    random one.
+       $0 -bazel
+                                # Skip OpenROAD build dependencies. Only
+                                #    install flow-level dependencies
+                                #    (klayout, ruby, docker, pip packages).
+                                #    Use this when building OpenROAD with
+                                #    Bazel, which manages its own build
+                                #    dependencies.
 EOF
     exit "${1:-1}"
 }
@@ -331,6 +401,7 @@ option="none"
 isLocal="false"
 constantBuildDir="false"
 CI="no"
+BAZEL="no"
 
 # default values, can be overwritten by cmdline args
 while [ "$#" -gt 0 ]; do
@@ -373,6 +444,9 @@ while [ "$#" -gt 0 ]; do
         -constant-build-dir)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"
             constantBuildDir="true"
+            ;;
+        -bazel)
+            BAZEL="yes"
             ;;
         -threads=*)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"
@@ -431,8 +505,12 @@ case "${os}" in
         fi
         
         # First install OpenROAD base
-        _installORDependencies
-        
+        if [[ "${BAZEL}" == "yes" ]]; then
+            _installBazelFlowDependencies
+        else
+            _installORDependencies
+        fi
+
         # Determine between EL7 vs EL8/9, since yum vs dnf should be used, and different Klayout builds exist
         case "${elVersion}" in
             "7")
@@ -468,7 +546,11 @@ case "${os}" in
             echo "Installing CI Tools"
             _installCI
         fi
-        _installORDependencies
+        if [[ "${BAZEL}" == "yes" ]]; then
+            _installBazelFlowDependencies
+        else
+            _installORDependencies
+        fi
         if [[ "${option}" == "base" || "${option}" == "all" ]]; then
             _installUbuntuPackages "${version}"
             _installUbuntuCleanUp
@@ -487,7 +569,11 @@ case "${os}" in
         if [[ ${CI} == "yes" ]]; then
             echo "WARNING: Installing CI dependencies is only supported on Ubuntu 22.04" >&2
         fi
-        _installORDependencies
+        if [[ "${BAZEL}" == "yes" ]]; then
+            _installBazelFlowDependencies
+        else
+            _installORDependencies
+        fi
         if [[ "${option}" == "base" || "${option}" == "all" ]]; then
             _installDarwinPackages
         fi

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -107,7 +107,10 @@ export OPENROAD_GUI_CMD = $(OPENROAD_EXE) -gui $(OR_ARGS)
 ifneq (${IN_NIX_SHELL},)
   YOSYS_EXE ?= $(shell command -v yosys)
 else
-  YOSYS_EXE ?= $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
+  # Check build_openroad.sh location first, then Bazel setup-orfs location
+  _YOSYS_BUILD := $(abspath $(FLOW_HOME)/../tools/install/yosys/bin/yosys)
+  _YOSYS_DEPS := $(abspath $(FLOW_HOME)/../dependencies/bin/yosys)
+  YOSYS_EXE ?= $(if $(shell test -x $(_YOSYS_BUILD) && echo y),$(_YOSYS_BUILD),$(_YOSYS_DEPS))
 endif
 export YOSYS_EXE
 

--- a/setup.sh
+++ b/setup.sh
@@ -10,6 +10,21 @@ if [ $EUID -ne 0 ]; then
   exit 1
 fi
 
+BAZEL_ARG=""
+for arg in "$@"; do
+  case "${arg}" in
+    --bazel|-bazel)
+      BAZEL_ARG="-bazel"
+      ;;
+    *)
+      echo "unknown option: ${arg}" >&2
+      echo "Usage: $0 [--bazel]"
+      echo "  --bazel  Skip OpenROAD build dependencies (use when building OpenROAD with Bazel)"
+      exit 1
+      ;;
+  esac
+done
+
 tmpfile=$(mktemp)
 # any error messages from this command will stand out
 # more clearly when run as a separate command rather than
@@ -26,5 +41,5 @@ elif grep -q "^+" "$tmpfile"; then
   exit 1
 fi
 
-"$DIR/etc/DependencyInstaller.sh" -base
-sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+"$DIR/etc/DependencyInstaller.sh" -base ${BAZEL_ARG}
+sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies" ${BAZEL_ARG}


### PR DESCRIPTION
Add -bazel option to DependencyInstaller.sh and setup.sh that skips OpenROAD-specific build dependencies (boost, swig, spdlog, eigen, or-tools, etc.) which Bazel manages, while still installing flow-level dependencies and building Yosys/eqy/sby.

This supports the new `bazelisk run //:setup-orfs` target in OpenROAD which provides a single entry point for developer environment setup.

needs https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3976