### PR TITLE
flow: design: ihp-sg13g2: i2c-gpio-expander: Improve PDN

### DIFF
--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl/pdn.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl/pdn.tcl
@@ -11,14 +11,6 @@ add_global_connection -net {VSS} -inst_pattern {.*} -pin_pattern {VSS!} -ground
 add_global_connection -net {VDD} -inst_pattern {.*} -pin_pattern {^VDD$} -power
 add_global_connection -net {VSS} -inst_pattern {.*} -pin_pattern {^VSS$} -ground
 
-# padframe core power pins
-add_global_connection -net {VDD} -pin_pattern {^vdd$} -power
-add_global_connection -net {VSS} -pin_pattern {^vss$} -ground
-
-# padframe io power pins
-add_global_connection -net {IOVDD} -pin_pattern {^iovdd$} -power
-add_global_connection -net {IOVSS} -pin_pattern {^iovss$} -ground
-
 global_connect
 
 # core voltage domain

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl/pdn.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/I2cDeviceCtrl/pdn.tcl
@@ -21,10 +21,10 @@ define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {Metal4 Metal5}
 add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.44} -pitch {7.56} -offset {0} \
   -followpins
 add_pdn_ring -grid {grid} -layers {Metal4 Metal5} -widths {3.0} -spacings {2.0} \
-  -core_offsets {4.5} -connect_to_pads
-add_pdn_stripe -grid {grid} -layer {Metal4} -width {1.840} -pitch {75.6} -offset {13.6} \
+  -core_offsets {4.5}
+add_pdn_stripe -grid {grid} -layer {Metal4} -width {2.0} -pitch {40.0} -offset {10.0} \
   -extend_to_core_ring
-add_pdn_stripe -grid {grid} -layer {Metal5} -width {1.840} -pitch {75.6} -offset {13.6} \
+add_pdn_stripe -grid {grid} -layer {Metal5} -width {2.0} -pitch {40.0} -offset {10.0} \
   -extend_to_core_ring
 add_pdn_connect -grid {grid} -layers {Metal1 Metal4}
 add_pdn_connect -grid {grid} -layers {Metal4 Metal5}

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/config.mk
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/config.mk
@@ -40,6 +40,8 @@ sg13g2_IOPadIOVss_inst \
 sg13g2_IOPadIOVdd_inst
 export FOOTPRINT_TCL = $(PLATFORM_DIR)/pad.tcl
 
+export MACRO_PLACEMENT_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/macros.tcl
+
 export PDN_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/pdn.tcl
 
 export BLOCKS = I2cDeviceCtrl

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/macros.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/macros.tcl
@@ -1,0 +1,1 @@
+place_macro -macro_name system_expander.i2cCtrl -location {375.54 372} -orientation R0 -exact

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/pdn.tcl
@@ -20,13 +20,15 @@ set_voltage_domain -name {CORE} -power {VDD} -ground {VSS}
 define_pdn_grid -name {grid} -voltage_domains {CORE} -pins {TopMetal1 TopMetal2}
 add_pdn_stripe -grid {grid} -layer {Metal1} -width {0.44} -pitch {7.56} -offset {0} \
   -followpins -extend_to_core_ring
-add_pdn_ring -grid {grid} -layers {TopMetal1 TopMetal2} -widths {8.0} -spacings {5.0} \
+add_pdn_ring -grid {grid} -layers {Metal5 TopMetal1} -widths {8.0} -spacings {5.0} \
   -core_offsets {4.5} -connect_to_pads
-add_pdn_stripe -grid {grid} -layer {TopMetal1} -width {2.200} -pitch {75.6} -offset {13.6} \
+add_pdn_stripe -grid {grid} -layer {TopMetal1} -width {4.0} -pitch {60.0} -offset {10.0} \
   -extend_to_core_ring
-add_pdn_stripe -grid {grid} -layer {TopMetal2} -width {2.200} -pitch {75.6} -offset {13.6} \
+add_pdn_stripe -grid {grid} -layer {TopMetal2} -width {4.0} -pitch {60.0} -offset {10.0} \
   -extend_to_core_ring
 add_pdn_connect -grid {grid} -layers {Metal1 TopMetal1}
+add_pdn_connect -grid {grid} -layers {Metal5 TopMetal1}
+add_pdn_connect -grid {grid} -layers {Metal5 TopMetal2}
 add_pdn_connect -grid {grid} -layers {TopMetal1 TopMetal2}
 
 define_pdn_grid \


### PR DESCRIPTION
* remove add_global_connect for padframe from the macro
* Move I2cDeviceCtrl macro slightly for better via connection
* Increase pdn_stripe width for macro and chip-level PDN
* Decrease pdn stripe pitch and offset