### PR TITLE
Fix leakage power unit from '1nw' to '1nW'

### DIFF
--- a/flow/platforms/nangate45/lib/fakeram45_256x16.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_256x16.lib
@@ -7,7 +7,7 @@ library(fakeram45_256x16) {
     time_unit : "1ns";
     voltage_unit : "1V";
     current_unit : "1uA";
-    leakage_power_unit : "1nw";
+    leakage_power_unit : "1nW";
     nom_process : 1;
     nom_temperature : 25.000;
     nom_voltage : 1.1;


### PR DESCRIPTION
[WARNING STA-0040] ./platforms/nangate45/lib/fakeram45_256x16.lib line 10, unknown unit suffix nw.