### PR TITLE
dump stage variables as .md table at start of each stage

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -2,6 +2,7 @@ utl::set_metrics_stage "cts__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 source $::env(SCRIPTS_DIR)/lec_check.tcl
 erase_non_stage_variables cts
+dump_stage_variables cts
 load_design 3_place.odb 3_place.sdc
 source_step_tcl PRE CTS
 

--- a/flow/scripts/density_fill.tcl
+++ b/flow/scripts/density_fill.tcl
@@ -1,5 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables final
+dump_stage_variables final
 load_design 5_route.odb 5_route.sdc
 source_step_tcl PRE DENSITY_FILL
 

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -13,6 +13,7 @@ if { $::env(SKIP_DETAILED_ROUTE) } {
 }
 
 erase_non_stage_variables route
+dump_stage_variables route
 set_propagated_clock [all_clocks]
 
 set additional_args ""

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -1,6 +1,7 @@
 utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables floorplan
+dump_stage_variables floorplan
 load_design 1_synth.odb 1_synth.sdc
 source_step_tcl PRE FLOORPLAN
 

--- a/flow/scripts/generate_abstract.tcl
+++ b/flow/scripts/generate_abstract.tcl
@@ -1,5 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables generate_abstract
+dump_stage_variables generate_abstract
 
 set stem [expr {
   [env_var_exists_and_non_empty ABSTRACT_SOURCE] ?

--- a/flow/scripts/global_place_skip_io.tcl
+++ b/flow/scripts/global_place_skip_io.tcl
@@ -1,5 +1,6 @@
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables place
+dump_stage_variables place
 load_design 2_floorplan.odb 2_floorplan.sdc
 source_step_tcl PRE GLOBAL_PLACE_SKIP_IO
 

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -1,6 +1,7 @@
 utl::set_metrics_stage "globalroute__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables grt
+dump_stage_variables grt
 load_design 4_cts.odb 4_cts.sdc
 
 # This proc is here to allow us to use 'return' to return early from this

--- a/flow/scripts/stage_variables.py
+++ b/flow/scripts/stage_variables.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# Print a .md table of stage variables that are set in the environment.
+# Paths shortened relative to FLOW_DIR. Descriptions truncated with "..."
+# to signal that variables.yaml has full details.
+# No external dependencies: parses variables.yaml line by line.
+#
+import os
+import re
+import sys
+
+
+def parse_variables(yaml_path):
+    """Parse variables.yaml into {name: {description, stages}}."""
+    variables = {}
+    current_var = None
+    current_field = None
+
+    with open(yaml_path) as f:
+        for line in f:
+            # Top-level variable: "VAR_NAME:"
+            m = re.match(r"^(\w+):\s*$", line)
+            if m:
+                current_var = m.group(1)
+                variables[current_var] = {"description": "", "stages": []}
+                current_field = None
+                continue
+
+            if current_var is None:
+                continue
+
+            # Field: "  description: >" or "  stages:"
+            m = re.match(r"^  (\w+):", line)
+            if m:
+                current_field = m.group(1)
+                continue
+
+            # List item under stages: "    - name"
+            m = re.match(r"^    - (\S+)", line)
+            if m and current_field == "stages":
+                variables[current_var]["stages"].append(m.group(1))
+                continue
+
+            # Continuation of description
+            if current_field == "description":
+                variables[current_var]["description"] += " " + line.strip()
+
+    return variables
+
+
+def shorten_path(value, flow_dir):
+    """Replace FLOW_DIR prefix with ./ to keep values compact."""
+    if flow_dir and value.startswith(flow_dir + "/"):
+        return "./" + value[len(flow_dir) + 1 :]
+    return value
+
+
+def main():
+    stage = sys.argv[1]
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    flow_dir = os.path.dirname(dir_path)
+    yaml_path = os.path.join(dir_path, "variables.yaml")
+    variables = parse_variables(yaml_path)
+
+    rows = []
+    for key in sorted(variables):
+        v = variables[key]
+        stages = v["stages"]
+        if not stages:
+            continue
+        if "All stages" not in stages and stage not in stages:
+            continue
+        if key not in os.environ:
+            continue
+        desc = v["description"].strip()
+        val = shorten_path(os.environ[key], flow_dir)
+        rows.append((key, val, desc))
+
+    if not rows:
+        return
+
+    w0 = max(max(len(r[0]) for r in rows), len("Variable"))
+    w1 = max(max(len(r[1]) for r in rows), len("Value"))
+
+    # Script runs inside Tcl exec (no tty on any fd).
+    # Query /dev/tty directly for terminal width; fall back to COLUMNS env.
+    width = 0
+    try:
+        with open("/dev/tty") as tty:
+            width = os.get_terminal_size(tty.fileno()).columns
+    except (OSError, AttributeError):
+        cols = os.environ.get("COLUMNS", "")
+        width = int(cols) if cols.isdigit() else 0
+
+    # framing: "| " + " | " + " | " + " |" = 10 chars
+    min_desc = 20
+    if width > 0:
+        # Shrink value column if needed to fit description within terminal.
+        max_w1 = width - w0 - 10 - min_desc
+        if w1 > max_w1 > len("Value"):
+            w1 = max_w1
+        desc_budget = max(width - w0 - w1 - 10, min_desc)
+    else:
+        desc_budget = 40  # brief hint + "..." crib for AI to check variables.yaml
+
+    def trunc(text, budget):
+        if budget == 0 or len(text) <= budget:
+            return text
+        return text[: budget - 3] + "..."
+
+    def fmt(c0, c1, c2):
+        v = trunc(c1, w1)
+        d = trunc(c2, desc_budget)
+        if desc_budget:
+            return f"| {c0:<{w0}} | {v:<{w1}} | {d:<{desc_budget}} |"
+        return f"| {c0:<{w0}} | {v:<{w1}} | {d} |"
+
+    header = fmt("Variable", "Value", "Description")
+    print(header)
+    print(re.sub(r"[^|]", "-", header))
+    for var, val, desc in rows:
+        print(fmt(var, val, desc))
+
+
+if __name__ == "__main__":
+    main()

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -1,6 +1,7 @@
 utl::set_metrics_stage "floorplan__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables synth
+dump_stage_variables synth
 load_design 1_2_yosys.v 1_2_yosys.sdc
 source_step_tcl PRE SYNTH
 

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -167,6 +167,11 @@ proc erase_non_stage_variables { stage_name } {
   }
 }
 
+# Log stage variables to help humans and bots debug build issues.
+proc dump_stage_variables { stage_name } {
+  puts [exec $::env(SCRIPTS_DIR)/stage_variables.py $stage_name]
+}
+
 set global_route_congestion_report $::env(REPORTS_DIR)/congestion.rpt
 
 proc place_density_with_lb_addon { } {


### PR DESCRIPTION
Adds dump_stage_variables to log all set stage variables (name, value, description) as a GitHub-flavored markdown table at the beginning of each stage. Descriptions are sourced from variables.yaml via stage_variables.py and truncated to fit 80 char lines. Helps humans and AI debug build issues by making the effective configuration visible in the log. Once per stage is enough, balance between information and spammyness.