### PR TITLE
Fix false GDS dependency in generate_abstract target

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -630,7 +630,7 @@ do-finish:
 	$(UNSET_AND_MAKE) do-6_1_fill do-6_1_fill.sdc do-6_final.sdc do-6_report do-gds elapsed
 
 .PHONY: generate_abstract
-generate_abstract: $(RESULTS_DIR)/6_final.gds $(RESULTS_DIR)/6_final.def  $(RESULTS_DIR)/6_final.v $(RESULTS_DIR)/6_final.sdc
+generate_abstract: $(RESULTS_DIR)/6_final.def $(RESULTS_DIR)/6_final.v $(RESULTS_DIR)/6_final.sdc
 	$(UNSET_AND_MAKE) do-generate_abstract
 
 # Set ABSTRACT_SOURCE if you want to create an abstract from another stage than 6_final.


### PR DESCRIPTION
generate_abstract.tcl reads ODB and SDC files to produce LEF/LIB abstracts — it does not use GDS at all. The dependency on 6_final.gds forced unnecessary GDS generation (requiring KLayout) before abstract generation could run.