### PR TITLE
use segments' total capacitance when fetching parasitics data

### DIFF
--- a/flow/util/write_segment_rc.tcl
+++ b/flow/util/write_segment_rc.tcl
@@ -40,8 +40,10 @@ proc fetch_segments_rc { net_to_segments_var } {
       set height [$shape getDY]
       set length_um [ord::dbu_to_microns [expr { max($width, $height) }]]
 
-      set resistance [$rseg getResistance 0]
-      set capacitance [$rseg getCapacitance 0]
+      # Default corner
+      set corner 0
+      set resistance [$rseg getResistance $corner]
+      set capacitance [$rseg getTotalCapacitance $corner]
 
       lappend segments $layer $length_um $resistance $capacitance
       lappend seen_shape_ids $shape_id


### PR DESCRIPTION
For #3969.

Even with the fixes on https://github.com/The-OpenROAD-Project/OpenROAD/pull/9765, I was still getting a weirdly bad coefficient of determination for capacitance on asap7/ibex M2. After some digging I realized that the API we were using to get the capacitance of the `RSeg` was actually only for the ground capacitance - the confusion was mainly because the function's names were somewhat bad, I addressed this on https://github.com/The-OpenROAD-Project/OpenROAD/pull/9835.