### PR TITLE
Improve macOS handling in setup and dependency installer scripts

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -11,7 +11,11 @@ fi
 
 # package versions
 klayoutVersion=0.30.3
-numThreads=$(nproc)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    numThreads=$(sysctl -n hw.ncpu)
+else
+    numThreads=$(nproc)
+fi
 
 _versionCompare() {
     local a b IFS=. ; set -f

--- a/setup.sh
+++ b/setup.sh
@@ -5,18 +5,12 @@ set -euo pipefail
 # allow this script to be invoked from any folder
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# macOS detection
-IS_DARWIN=false
-if [[ "$(uname)" == "Darwin" ]]; then
-  IS_DARWIN=true
-fi
-
-if $IS_DARWIN && [[ $EUID -eq 0 ]]; then
+if [[ "$OSTYPE" == "darwin"* ]] && [[ $EUID -eq 0 ]]; then
   echo "Do NOT run this script with sudo on macOS"
   exit 1
 fi
 
-if ! $IS_DARWIN && [[ $EUID -ne 0 ]]; then
+if [[ "$OSTYPE" != "darwin"* ]] && [[ $EUID -ne 0 ]]; then
   echo "This script must be run with sudo on Linux"
   exit 1
 fi
@@ -28,7 +22,7 @@ tmpfile=$(mktemp)
 git submodule status --recursive > "$tmpfile"
 
 if grep -q "^-" "$tmpfile"; then
-  if $IS_DARWIN; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
     git submodule update --init --recursive
   else
     sudo -u $SUDO_USER git submodule update --init --recursive
@@ -42,7 +36,7 @@ elif grep -q "^+" "$tmpfile"; then
 fi
 
 "$DIR/etc/DependencyInstaller.sh" -base
-if $IS_DARWIN; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 else
   sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"

--- a/setup.sh
+++ b/setup.sh
@@ -5,8 +5,19 @@ set -euo pipefail
 # allow this script to be invoked from any folder
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ $EUID -ne 0 ]; then
-  echo "This script must be run with sudo"
+# macOS detection
+IS_DARWIN=false
+if [[ "$(uname)" == "Darwin" ]]; then
+  IS_DARWIN=true
+fi
+
+if $IS_DARWIN && [[ $EUID -eq 0 ]]; then
+  echo "Do NOT run this script with sudo on macOS"
+  exit 1
+fi
+
+if ! $IS_DARWIN && [[ $EUID -ne 0 ]]; then
+  echo "This script must be run with sudo on Linux"
   exit 1
 fi
 
@@ -17,7 +28,11 @@ tmpfile=$(mktemp)
 git submodule status --recursive > "$tmpfile"
 
 if grep -q "^-" "$tmpfile"; then
-  sudo -u $SUDO_USER git submodule update --init --recursive
+  if $IS_DARWIN; then
+    git submodule update --init --recursive
+  else
+    sudo -u $SUDO_USER git submodule update --init --recursive
+  fi
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,
   # run with current submodules, at the cost of having ORFS
@@ -27,4 +42,8 @@ elif grep -q "^+" "$tmpfile"; then
 fi
 
 "$DIR/etc/DependencyInstaller.sh" -base
-sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+if $IS_DARWIN; then
+  "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+else
+  sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+fi


### PR DESCRIPTION
This PR improves macOS behavior in the ORFS setup path:

- Allow `sudo` on Linux and disallow on macOS
- Fix submodule update to run with correct user per OS
- Use `sysctl` for CPU count on macOS instead of `nproc`
- Minor portability and error message improvements

Addresses #4022