### PR TITLE
setup: skip sudo requirement on macOS for Homebrew compatibility

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # allow this script to be invoked from any folder
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [ $EUID -ne 0 ]; then
+if [[ "$OSTYPE" != "darwin"* ]] && [ $EUID -ne 0 ]; then
   echo "This script must be run with sudo"
   exit 1
 fi


### PR DESCRIPTION
On macOS, Homebrew explicitly recommends against running with sudo.The existing DependencyInstaller.sh already blocks sudo on macOS ,but `setup.sh `was requiring sudo unconditionally, causing a conflict.

This fix skips the sudo requirement on macOS only.

