### PR TITLE
setup: fix unbound SUDO_USER variable when running as root in Docker

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,11 @@ if grep -q "^-" "$tmpfile"; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     git submodule update --init --recursive
   else
-    sudo -u $SUDO_USER git submodule update --init --recursive
+    if [[ -n "${SUDO_USER:-}" ]]; then
+      sudo -u "$SUDO_USER" git submodule update --init --recursive
+    else
+      git submodule update --init --recursive
+    fi
   fi
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,
@@ -39,5 +43,9 @@ fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 else
-  sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    sudo -u "$SUDO_USER" "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+  else
+    "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+  fi
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -26,15 +26,11 @@ tmpfile=$(mktemp)
 git submodule status --recursive > "$tmpfile"
 
 if grep -q "^-" "$tmpfile"; then
-<<<<<<< Updated upstream
-  sudo -u $SUDO_USER git submodule update --init --recursive
-=======
   if [[ "$OSTYPE" == "darwin"* ]]; then
     git submodule update --init --recursive
   else
     run_as_user git submodule update --init --recursive
   fi
->>>>>>> Stashed changes
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,
   # run with current submodules, at the cost of having ORFS
@@ -44,12 +40,8 @@ elif grep -q "^+" "$tmpfile"; then
 fi
 
 "$DIR/etc/DependencyInstaller.sh" -base
-<<<<<<< Updated upstream
-sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
-=======
 if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 else
   run_as_user "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 fi
->>>>>>> Stashed changes

--- a/setup.sh
+++ b/setup.sh
@@ -5,16 +5,20 @@ set -euo pipefail
 # allow this script to be invoked from any folder
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-if [[ "$OSTYPE" == "darwin"* ]] && [[ $EUID -eq 0 ]]; then
-  echo "Do NOT run this script with sudo on macOS"
+if [ $EUID -ne 0 ]; then
+  echo "This script must be run with sudo"
   exit 1
 fi
 
-if [[ "$OSTYPE" != "darwin"* ]] && [[ $EUID -ne 0 ]]; then
-  echo "This script must be run with sudo on Linux"
-  exit 1
-fi
 
+# Run a command as the original user if invoked via sudo, otherwise run directly
+run_as_user() {
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    sudo -u "$SUDO_USER" "$@"
+  else
+    "$@"
+  fi
+}
 tmpfile=$(mktemp)
 # any error messages from this command will stand out
 # more clearly when run as a separate command rather than
@@ -22,15 +26,15 @@ tmpfile=$(mktemp)
 git submodule status --recursive > "$tmpfile"
 
 if grep -q "^-" "$tmpfile"; then
+<<<<<<< Updated upstream
+  sudo -u $SUDO_USER git submodule update --init --recursive
+=======
   if [[ "$OSTYPE" == "darwin"* ]]; then
     git submodule update --init --recursive
   else
-    if [[ -n "${SUDO_USER:-}" ]]; then
-      sudo -u "$SUDO_USER" git submodule update --init --recursive
-    else
-      git submodule update --init --recursive
-    fi
+    run_as_user git submodule update --init --recursive
   fi
+>>>>>>> Stashed changes
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,
   # run with current submodules, at the cost of having ORFS
@@ -40,12 +44,12 @@ elif grep -q "^+" "$tmpfile"; then
 fi
 
 "$DIR/etc/DependencyInstaller.sh" -base
+<<<<<<< Updated upstream
+sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+=======
 if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 else
-  if [[ -n "${SUDO_USER:-}" ]]; then
-    sudo -u "$SUDO_USER" "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
-  else
-    "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
-  fi
+  run_as_user "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 fi
+>>>>>>> Stashed changes


### PR DESCRIPTION
When `setup.sh` is run directly as root , which is standard in Docker containers and CI/CD pipelines so,`$SUDO_USER` is never set. Because the script uses `set -euo pipefail`, the `-u` flag causes the script to crash immediately on any unbound variable reference.

Two lines were affected:

**Line 28:**` bash sudo -u $SUDO_USER git submodule update --init --recursive`

**Line 42:**` sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"`

When `$SUDO_USER` is empty, `sudo -u `consumes` git `(or the script path) as the username and crashes with:
```
sudo: unknown user: git 
sudo: error initializing audit plugin sudoers_audit
```
To resolve this, the script now checks if `$SUDO_USER` is set before attempting to use it. If the variable is set (indicating the script was invoked via sudo), it drops privileges to the original user as intended. However, if it is empty (indicating the script is running natively as root), it simply runs the command directly without the `sudo -u` flag. The macOS paths were already handled correctly by #4023, so this PR completes the fix for the remaining Linux and Docker environments.
