### PR TITLE
setup: fix macOS thread count using hw.logicalcpu instead of hw.ncpu

### DIFF
--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -12,7 +12,7 @@ fi
 # package versions
 klayoutVersion=0.30.3
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    numThreads=$(sysctl -n hw.ncpu)
+    numThreads=$(sysctl -n hw.logicalcpu)
 else
     numThreads=$(nproc)
 fi


### PR DESCRIPTION
Fixes #4028 

Currently, `etc/DependencyInstaller.sh` uses `sysctl -n hw.ncpu` to determine the thread count on macOS. However, `hw.ncpu` only returns the number of *physical* cores. This ends up underestimating the available parallelism, particularly on Intel Macs that utilize hyperthreading. 


This PR replaces `hw.ncpu` with `hw.logicalcpu`. `hw.logicalcpu` correctly returns all logical cores (including hyperthreaded ones), making it the exact macOS equivalent to the `nproc` command on Linux.

- On an Intel Mac with 4 physical cores and hyperthreading, `hw.ncpu` returns `4`, while `hw.logicalcpu` correctly returns `8`.
- On Apple Silicon (e.g., an M2 with 10 cores), both commands return `10`.

This swap ensures we are fully utilizing the available CPU resources to speed up dependency installation on macOS.