### PR TITLE
Genreport variable bug

### DIFF
--- a/flow/util/genReport.py
+++ b/flow/util/genReport.py
@@ -170,7 +170,7 @@ def gen_report(name, data):
             args.verbose - 2,
         )
 
-    if len(d["drcs"].keys()) > 0:
+    if len(data["drcs"].keys()) > 0:
         if data["status"] == STATUS_GREEN:
             output += "  Design has the violations under the allowed limit: "
         else:


### PR DESCRIPTION
closes #4033 

This PR fixes a logic bug in [flow/util/genReport.py](cci:7://file:///c:/Users/smsha/Desktop/OpenROAD-flow-scripts/flow/util/genReport.py:0:0-0:0). 
In [gen_report(name, data)](cci:1://file:///c:/Users/smsha/Desktop/OpenROAD-flow-scripts/flow/util/genReport.py:111:0-181:25) on line 173, the code incorrectly referenced the global loop variable `d["drcs"]` instead of the function parameter `data["drcs"]`. 
While this did not break the current flow because the global `d` from the main loop happened to mirror `data`, it broke function encapsulation and would silent-fail if [gen_report()](cci:1://file:///c:/Users/smsha/Desktop/OpenROAD-flow-scripts/flow/util/genReport.py:111:0-181:25) was ever called outside of that specific loop iteration. This PR changes it to properly evaluate its passed argument.

@luarss @maliberty can you please review this. It is small typo error but needs to be correct the functionality.
Thanks for you time :)

