### PR TITLE
[Flow] Fix potential division-by-zero crash in report_metrics.tcl

### DIFF
--- a/flow/scripts/report_metrics.tcl
+++ b/flow/scripts/report_metrics.tcl
@@ -224,7 +224,11 @@ proc report_metrics { stage when { include_erc true } { include_clock_skew true 
     report_puts "\n=========================================================================="
     report_puts "$when slack div critical path delay"
     report_puts "--------------------------------------------------------------------------"
-    report_puts "[format "%4f" [expr $path_slack / $path_delay * 100]]"
+    if { $path_delay != 0.0 } {
+      report_puts "[format "%4f" [expr $path_slack / $path_delay * 100]]"
+    } else {
+      report_puts "N/A (0 delay)"
+    }
   }
 
   report_puts "\n=========================================================================="


### PR DESCRIPTION
- Added a protective check before calculating path_slack / path_delay percentage.
- Prevents TCL fatal errors on designs with 0-delay critical paths.

Hi @luarss and @maliberty this is quick fix for the 0 division error can you review and merge it. Thanks for your time. 