### PR TITLE
flow: eval OPENROAD_EXE

### DIFF
--- a/flow/scripts/flow.sh
+++ b/flow/scripts/flow.sh
@@ -8,7 +8,7 @@ echo "Running $2.tcl, stage $1"
 (
   trap 'mv "$LOG_DIR/$1.tmp.log" "$LOG_DIR/$1.log"' EXIT
 
-  "$OPENROAD_EXE" $OPENROAD_ARGS -exit "$SCRIPTS_DIR/noop.tcl" \
+  eval "$OPENROAD_EXE $OPENROAD_ARGS -exit \"$SCRIPTS_DIR/noop.tcl\"" \
     >"$LOG_DIR/$1.tmp.log" 2>&1
 
   eval "$TIME_CMD $OPENROAD_CMD -no_splash \"$SCRIPTS_DIR/$2.tcl\" -metrics \"$LOG_DIR/$1.json\"" \


### PR DESCRIPTION
+ Allows running OpenROAD under valgrind, which would previously fail due to treating "valgrind openroad" as a program name

For example, `make VALGRIND=1 DESIGN_CONFIG=./designs/sky130hd/ibex/config.mk` sets `OPENROAD_EXE :=  valgrind $(VALGRIND_ARGS) $(OPENROAD_EXE)`. Seems to have been broken since 62e0803, when `scripts/flow.sh` was introduced and moved expanding `OPENROAD_EXE` from Make to the shell.