### PR TITLE
fix: APB_UART RX FIFO threshold uses wrong register

### DIFF
--- a/flow/designs/src/chameleon/IPs/APB_UART.v
+++ b/flow/designs/src/chameleon/IPs/APB_UART.v
@@ -142,7 +142,7 @@ module APB_UART(
                                                         32'hDEADDEAD;
     
     wire tx_less_threshold = (tx_level < TXFIFOTR);
-    wire rx_more_threshold = (rx_level > TXFIFOTR);
+    wire rx_more_threshold = (rx_level > RXFIFOTR);
     
 
     assign uart_irq = IMASK[0] & (  (~rx_empty & IMASK[2])  | 


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes an incorrect register reference in the APB UART module where the RX FIFO threshold logic was comparing against the TX threshold register. This caused RX threshold interrupts to trigger at incorrect levels.

The issue affects `flow/designs/src/chameleon/IPs/APB_UART.v` (around line 145) and impacts correct interrupt generation based on RX FIFO occupancy.

---

## 2. FIX

```verilog
// Before (incorrect threshold comparison)
wire rx_more_threshold = (rx_level > TXFIFOTR);

// After (correct threshold comparison)
wire rx_more_threshold = (rx_level > RXFIFOTR);
```

---

## 3. VERIFICATION

Configure different threshold values (e.g., `TXFIFOTR = 4`, `RXFIFOTR = 8`) and enable the RX threshold interrupt. Fill the RX FIFO gradually and observe interrupt behavior.

Before the fix, the interrupt triggers based on `TXFIFOTR`; after the fix, it correctly triggers only when `rx_level > RXFIFOTR`.
