### PR TITLE
Fix inverted SRAM bank mapping in dmem read MUX

### DIFF
--- a/flow/designs/src/riscv32i/dmem.v
+++ b/flow/designs/src/riscv32i/dmem.v
@@ -59,10 +59,10 @@ module dmem (clk, r_w, mem_addr, mem_data, mem_out);
    
    always @* begin
       case (sel_mem)
-	2'b00: mem_out = inter_dmem3;
-	2'b01: mem_out = inter_dmem2;
-	2'b10: mem_out = inter_dmem1;
-	2'b11: mem_out = inter_dmem0;
+	2'b11: mem_out = inter_dmem3;
+	2'b10: mem_out = inter_dmem2;
+	2'b01: mem_out = inter_dmem1;
+	2'b00: mem_out = inter_dmem0;
       endcase // case (sel_mem)
    end
 


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes an incorrect read data selection in the `dmem` module where the output MUX returned data from the wrong SRAM bank. The issue affects `flow/designs/src/riscv32i/dmem.v` (lines 60–67), causing all memory reads to be inconsistent with the corresponding write bank.

---

## 2. FIX 

```verilog
// Before (incorrect mapping)
case (sel_mem)
  2'b00: mem_out = inter_dmem3;
  2'b01: mem_out = inter_dmem2;
  2'b10: mem_out = inter_dmem1;
  2'b11: mem_out = inter_dmem0;
endcase

// After (correct mapping)
case (sel_mem)
  2'b11: mem_out = inter_dmem3;
  2'b10: mem_out = inter_dmem2;
  2'b01: mem_out = inter_dmem1;
  2'b00: mem_out = inter_dmem0;
endcase
```

---

## 3. VERIFICATION

Run the existing RISC-V testbench and write a known value (e.g., `0xDEADBEEF`) to an address in a specific memory bank (e.g., `0x8000_0000` for `dmem3`), then read it back. Before the fix, the read returns data from the wrong bank; after the fix, it correctly returns the written value. Repeat across other address regions to confirm all banks map correctly.

