### PR TITLE
fix: DRC violation type parsing

### DIFF
--- a/flow/util/genReport.py
+++ b/flow/util/genReport.py
@@ -295,7 +295,7 @@ for log_dir, dirs, files in sorted(os.walk(LOGS_FOLDER, topdown=False)):
         with open(drc_report_file, "r") as file_:
             for line_ in file_.readlines():
                 if "violation type:" in line_:
-                    type_ = line_.strip("violation type:").strip()
+                    type_ = line_.split("violation type:", 1)[1].strip()
                     if type_ in d["drcs"].keys():
                         d["drcs"][type_] += 1
                     else:


### PR DESCRIPTION
## SUMMARY

This PR fixes incorrect parsing of DRC violation types in `flow/util/genReport.py`. The current code mangles names due to misuse of `str.strip()`, leading to wrong DRC summaries.

---

## FIX

**Before**

```python
type_ = line_.strip("violation type:").strip()
```

**After**

```python
type_ = line_.split("violation type:", 1)[1].strip()
```

---

## VERIFICATION

* Run a flow to generate a DRC report and execute `genReport.py`
* Before fix: types are corrupted (e.g. `_enclosure`, `ff_grid`)
* After fix: types are correct (`via_enclosure`, `off_grid`)
* DRC summary matches the actual report
