### PR TITLE
fix: ensure exit() is called for invalid units in correlateRC.py

### DIFF
--- a/flow/util/correlateRC.py
+++ b/flow/util/correlateRC.py
@@ -73,7 +73,7 @@ elif res_unit == "kohm":
     res_scale = 1e3
 else:
     print("unknown resistance unit")
-    exit
+    exit(1)
 
 cap_unit = args.cap_unit
 if cap_unit == "ff":
@@ -82,7 +82,7 @@ elif cap_unit == "pf":
     cap_scale = 1e-12
 else:
     print("unknown capacitance unit")
-    exit
+    exit(1)
 
 
 def makeDict():


### PR DESCRIPTION
### SUMMARY

Fixes a small bug in `correlateRC.py` where `exit` wasn’t actually being called. The script now stops immediately on invalid units instead of crashing later.

---

### FIX


**Before**

```python
print("unknown resistance unit")
exit
```

**After**

```python
print("unknown resistance unit")
exit(1)
```

---

### VERIFICATION

Run with an invalid unit:

```bash
python3 flow/util/correlateRC.py -res_unit mΩ
```

**Now:** prints error and exits
**Before:** continued → `NameError`
