### PR TITLE
fix: prevent file descriptor leak in is_git_repo() by using context manager

### DIFF
--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -175,10 +175,11 @@ def read_sdc(file_name):
 
 def is_git_repo(folder=None):
     cmd = ["git", "branch"]
-    if folder is not None:
-        return call(cmd, stderr=STDOUT, stdout=open(os.devnull, "w"), cwd=folder) == 0
-    else:
-        return call(cmd, stderr=STDOUT, stdout=open(os.devnull, "w")) == 0
+    with open(os.devnull, "w") as devnull:
+        if folder is not None:
+            return call(cmd, stderr=STDOUT, stdout=devnull, cwd=folder) == 0
+        else:
+            return call(cmd, stderr=STDOUT, stdout=devnull) == 0
 
 
 def merge_jsons(root_path, output, files):


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a file descriptor leak in `is_git_repo()` in `flow/util/genMetrics.py`. It ensures `os.devnull` is properly closed after use.

---

## 2. FIX / CHANGES

### Before

```python
return call(cmd, stderr=STDOUT, stdout=open(os.devnull, "w")) == 0
```

### After

```python
with open(os.devnull, "w") as devnull:
    return call(cmd, stderr=STDOUT, stdout=devnull) == 0
```

---

## 3. VERIFICATION

**Steps:**

* Call `is_git_repo()` repeatedly
* Check open FDs (`lsof -p <pid>`)

**Expected:**

* No FD growth over time
* Same behavior as before
* No warnings raised
