### PR TITLE
fix: require --logs, --reports, and --results to prevent NoneType crash in genMetrics

### DIFF
--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -48,9 +48,9 @@ def parse_args():
         "--output", "-o", required=False, default="metadata.json", help="Output file"
     )
     parser.add_argument("--hier", "-x", action="store_true", help="Hierarchical JSON")
-    parser.add_argument("--logs", help="Path to logs")
-    parser.add_argument("--reports", help="Path to reports")
-    parser.add_argument("--results", help="Path to results")
+    parser.add_argument("--logs", required=True, help="Path to logs")
+    parser.add_argument("--reports", required=True, help="Path to reports")
+    parser.add_argument("--results", required=True, help="Path to results")
     args = parser.parse_args()
 
     return args


### PR DESCRIPTION
### 1. SUMMARY

This PR makes `--logs`, `--reports`, and `--results` required CLI arguments in `genMetrics.py` to prevent runtime crashes caused by missing values.
The change is localized to argument parsing in `flow/util/genMetrics.py` and improves error handling without altering core logic.

---

### 2. FIX

```python
# Before
parser.add_argument("--logs", help="Path to logs")
parser.add_argument("--reports", help="Path to reports")
parser.add_argument("--results", help="Path to results")

# After
parser.add_argument("--logs", required=True, help="Path to logs")
parser.add_argument("--reports", required=True, help="Path to reports")
parser.add_argument("--results", required=True, help="Path to results")
```

---

### 3. VERIFICATION

Ran the script without `--logs`, `--reports`, and `--results` to reproduce the issue—previously it crashed with a confusing `TypeError`. After the fix, it now fails immediately with a clear argparse message indicating the missing required arguments. When all three flags are provided, the script runs normally without errors.
