### PR TITLE
fix: use context managers to prevent file descriptor leaks in genMetrics.py

### DIFF
--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -142,16 +142,13 @@ def extractGnuTime(prefix, jsonFile, file):
 #
 def read_sdc(file_name):
     clkList = []
-    sdcFile = None
 
     try:
-        sdcFile = open(file_name, "r")
+        with open(file_name, "r") as sdcFile:
+            lines = sdcFile.readlines()
     except IOError:
         print("[WARN] Failed to open file:", file_name)
         return clkList
-
-    lines = sdcFile.readlines()
-    sdcFile.close()
 
     for line in lines:
         if len(line.split()) < 2:
@@ -185,10 +182,9 @@ def is_git_repo(folder=None):
 def merge_jsons(root_path, output, files):
     paths = sorted(glob(os.path.join(root_path, files)))
     for path in paths:
-        file = open(path, "r")
-        data = json.load(file)
+        with open(path, "r") as file:
+            data = json.load(file)
         output.update(data)
-        file.close()
 
 
 def extract_metrics(

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -146,8 +146,8 @@ def read_sdc(file_name):
     try:
         with open(file_name, "r") as sdcFile:
             lines = sdcFile.readlines()
-except IOError as e:
-    print(f"[WARN] Failed to open file: {file_name} ({e.strerror})")
+    except OSError as e:
+        print(f"[WARN] Failed to open file: {file_name} ({e})")
         return clkList
 
     for line in lines:

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -146,8 +146,8 @@ def read_sdc(file_name):
     try:
         with open(file_name, "r") as sdcFile:
             lines = sdcFile.readlines()
-    except IOError:
-        print("[WARN] Failed to open file:", file_name)
+except IOError as e:
+    print(f"[WARN] Failed to open file: {file_name} ({e.strerror})")
         return clkList
 
     for line in lines:


### PR DESCRIPTION
## SUMMARY

This PR fixes file descriptor leaks in `flow/util/genMetrics.py` by replacing manual file handling with context managers. The changes primarily affect the `read_sdc()` and `merge_jsons()` functions, ensuring files are always properly closed even when exceptions occur.

---

## FIX 

```python
# Before
file = open(path, "r")
data = json.load(file)
output.update(data)
file.close()

# After
with open(path, "r") as file:
    data = json.load(file)
output.update(data)
```

---

## VERIFICATION

Run a normal OpenROAD flow to make sure everything works as before with valid inputs. Then try breaking a metrics JSON file (e.g., truncate it) and rerun the flow. It should handle the error cleanly without leaking file descriptors or crashing.
