### PR TITLE
fix(genReport): prevent KeyError when no .log files by initializing `last_log`

### DIFF
--- a/flow/util/genReport.py
+++ b/flow/util/genReport.py
@@ -264,6 +264,7 @@ for log_dir, dirs, files in sorted(os.walk(LOGS_FOLDER, topdown=False)):
     # check if design ran to completion without errors or warnings
     d["log_errors"] = list()
     d["log_warnings"] = list()
+    d["last_log"] = ""
     for name_ in sorted(files):
         temp_e, temp_w = parse_messages(os.path.join(log_dir, name_))
         d["log_errors"] += temp_e


### PR DESCRIPTION
## 1. SUMMARY

This PR fixes a crash in `genReport.py` caused by accessing an uninitialized `last_log` key when no `.log` files are present. It ensures safe initialization and consistent behavior with existing fields.


---

## 2. FIX 

```python
# Before
d["log_errors"] = list()
d["log_warnings"] = list()
for name_ in sorted(files):
    if name_.endswith(".log"):
        d["last_log"] = name_
d["finished"] = d["last_log"] in LAST_EXPECTED_LOG

# After
d["log_errors"] = list()
d["log_warnings"] = list()
d["last_log"] = ""
for name_ in sorted(files):
    if name_.endswith(".log"):
        d["last_log"] = name_
d["finished"] = d["last_log"] in LAST_EXPECTED_LOG
```

---

## 3. VERIFICATION 

Tested by running `genReport.py` on a log directory with no `.log` files and with only non-log files present. The script no longer crashes and completes execution without any traceback. The report is generated correctly with `finished=False`, confirming graceful handling of missing logs.
