### PR TITLE
fix: validate plot_congestion.py CLI arguments

### DIFF
--- a/flow/util/plot_congestion.py
+++ b/flow/util/plot_congestion.py
@@ -4,6 +4,7 @@ import sys
 import re
 import os
 
+
 def usage(script):
     print(
         f"Usage: {script} <sweep_name> <output_png> <congestion_file...> <sweep_value...>",

--- a/flow/util/plot_congestion.py
+++ b/flow/util/plot_congestion.py
@@ -4,9 +4,29 @@ import sys
 import re
 import os
 
+def usage(script):
+    print(
+        f"Usage: {script} <sweep_name> <output_png> <congestion_file...> <sweep_value...>",
+        file=sys.stderr,
+    )
+    print(
+        "Provide an even number of trailing arguments split equally between files and values.",
+        file=sys.stderr,
+    )
+
+
+if len(sys.argv) < 5:
+    usage(sys.argv[0])
+    sys.exit(2)
+
 sweep = sys.argv[1]
 output = sys.argv[2]
 remainder = sys.argv[3:]
+if len(remainder) % 2 != 0:
+    print("Error: trailing arguments must be an even count.", file=sys.stderr)
+    usage(sys.argv[0])
+    sys.exit(2)
+
 files = remainder[: len(remainder) // 2]
 values = remainder[len(remainder) // 2 :]
 


### PR DESCRIPTION
This PR fixes a small CLI robustness issue in plot_congestion.py.

Problem:

The script accessed positional arguments directly and crashed with IndexError when invoked with too few arguments.
The script also accepted malformed trailing args (odd count) that should be rejected.

