### PR TITLE
fix: use DESIGN_DIR instead of custom dir variables in chameleon/microwatt

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -88,7 +88,7 @@ DESIGN_CONFIG ?= ./designs/nangate45/gcd/config.mk
 export DESIGN_CONFIG
 include $(DESIGN_CONFIG)
 
-export DESIGN_DIR ?= $(dir $(DESIGN_CONFIG))
+export DESIGN_DIR ?= $(patsubst %/,%,$(dir $(DESIGN_CONFIG)))
 
 # default value "base" for FLOW_VARIANT and "." for WORK_HOME are duplicated
 # from variables.yaml and variables.mk because we need it

--- a/flow/designs/sky130hd/chameleon/config.mk
+++ b/flow/designs/sky130hd/chameleon/config.mk
@@ -33,20 +33,19 @@ export CORE_UTILIZATION       = 70
 export CORE_ASPECT_RATIO      = 1.3
 export CORE_MARGIN            = 2
 
-export chameleon_DIR = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)
-export LEC_AUX_VERILOG_FILES = $(chameleon_DIR)/lec_blackbox_stubs.v
+export LEC_AUX_VERILOG_FILES = $(DESIGN_DIR)/lec_blackbox_stubs.v
 
-export ADDITIONAL_GDS  = $(chameleon_DIR)/gds/apb_sys_0.gds.gz \
-                               $(chameleon_DIR)/gds/DMC_32x16HC.gds.gz \
-                               $(chameleon_DIR)/gds/DFFRAM_4K.gds.gz \
-                               $(chameleon_DIR)/gds/ibex_wrapper.gds.gz
+export ADDITIONAL_GDS  = $(DESIGN_DIR)/gds/apb_sys_0.gds.gz \
+                               $(DESIGN_DIR)/gds/DMC_32x16HC.gds.gz \
+                               $(DESIGN_DIR)/gds/DFFRAM_4K.gds.gz \
+                               $(DESIGN_DIR)/gds/ibex_wrapper.gds.gz
 
-export ADDITIONAL_LEFS  = $(chameleon_DIR)/lef/apb_sys_0.lef \
-                          $(chameleon_DIR)/lef/DFFRAM_4K.lef \
-                          $(chameleon_DIR)/lef/DMC_32x16HC.lef \
-                          $(chameleon_DIR)/lef/ibex_wrapper.lef
+export ADDITIONAL_LEFS  = $(DESIGN_DIR)/lef/apb_sys_0.lef \
+                          $(DESIGN_DIR)/lef/DFFRAM_4K.lef \
+                          $(DESIGN_DIR)/lef/DMC_32x16HC.lef \
+                          $(DESIGN_DIR)/lef/ibex_wrapper.lef
 
-#export MACRO_PLACEMENT_TCL = $(chameleon_DIR)/macro_placement.tcl
+#export MACRO_PLACEMENT_TCL = $(DESIGN_DIR)/macro_placement.tcl
 
 export FP_PDN_RAIL_WIDTH  = 0.48
 export FP_PDN_RAIL_OFFSET = 0

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -11,13 +11,11 @@ export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.
 export DIE_AREA   = 0 0 3020 3610
 export CORE_AREA  = 10 10 3010 3600
 
-export microwatt_DIR = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)
+export ADDITIONAL_GDS  = $(wildcard $(DESIGN_DIR)/gds/*.gds.gz)
 
-export ADDITIONAL_GDS  = $(wildcard $(microwatt_DIR)/gds/*.gds.gz)
+export ADDITIONAL_LEFS  = $(wildcard $(DESIGN_DIR)/lef/*.lef)
 
-export ADDITIONAL_LEFS  = $(wildcard $(microwatt_DIR)/lef/*.lef)
-
-export ADDITIONAL_LIBS = $(wildcard $(microwatt_DIR)/lib/*.lib)
+export ADDITIONAL_LIBS = $(wildcard $(DESIGN_DIR)/lib/*.lib)
 
 export SYNTH_HIERARCHICAL = 1
 


### PR DESCRIPTION
DESIGN_DIR is already defined in the Makefile as $(dir $(DESIGN_CONFIG)). These two designs defined redundant custom variables (chameleon_DIR, microwatt_DIR) that were identical to DESIGN_DIR. Use the standard variable to simplify config and remove non-standard patterns.