### PR TITLE
fix: use portable path in mock-cpu constraint.sdc

### DIFF
--- a/flow/designs/asap7/mock-cpu/constraint.sdc
+++ b/flow/designs/asap7/mock-cpu/constraint.sdc
@@ -2,7 +2,7 @@
 #
 # This fifo is from http://www.sunburst-design.com/papers/CummingsSNUG2002SJ_FIFO1.pdf
 
-source designs/src/mock-array/util.tcl
+source $::env(DESIGN_HOME)/src/mock-array/util.tcl
 
 set sdc_version 2.0
 


### PR DESCRIPTION
The hardcoded relative path `designs/src/mock-array/util.tcl` breaks when the working directory isn't the repo root. Use $::env(DESIGN_HOME) which is the standard pattern for all other SDC files.