### PR TITLE
fix: standardize paths in asap7 riscv32i config.mk

### DIFF
--- a/flow/designs/asap7/riscv32i/config.mk
+++ b/flow/designs/asap7/riscv32i/config.mk
@@ -10,8 +10,8 @@ export VERILOG_FILES = $(sort $(wildcard $(DESIGN_HOME)/src/riscv32i/*.v))
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/riscv32i/constraint.sdc
 
 ifeq ($(BLOCKS),)
-	export ADDITIONAL_LEFS = ./platforms/$(PLATFORM)/lef/fakeram7_256x32.lef
-	export ADDITIONAL_LIBS = $(LIB_DIR)/fakeram7_256x32.lib
+	export ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/fakeram7_256x32.lef
+	export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x32.lib
 endif
 
 export CORE_UTILIZATION = 62


### PR DESCRIPTION
Use $(PLATFORM_DIR) consistently instead of hardcoded ./platforms/$(PLATFORM). Fix lib path from $(LIB_DIR)/fakeram7_256x32.lib to $(PLATFORM_DIR)/lib/NLDM/fakeram7_256x32.lib to match the actual directory structure:

    $ find . | grep fakeram7_256x32\.lib
    ./platforms/asap7/lib/NLDM/fakeram7_256x32.lib
    $