### PR TITLE
fix: override PDN_TCL for riscv32i-mock-sram to fix PDN-0232/0233

### DIFF
--- a/flow/designs/asap7/riscv32i-mock-sram/config.mk
+++ b/flow/designs/asap7/riscv32i-mock-sram/config.mk
@@ -1,5 +1,11 @@
 export DESIGN_NICKNAME = riscv32i-mock-sram
 export BLOCKS=fakeram7_256x32
 
+# Override platform default (BLOCKS_grid_strategy.tcl) which defines an
+# ElementGrid macro grid with no stripes, producing empty PDN grids
+# (PDN-0232/0233). BLOCK_grid_strategy.tcl uses M4-M5 connections that
+# match the block's MAX_ROUTING_LAYER=M4 constraint.
+export PDN_TCL = $(PLATFORM_DIR)/openRoad/pdn/BLOCK_grid_strategy.tcl
+
 include designs/asap7/riscv32i/config.mk
 


### PR DESCRIPTION
The platform default BLOCKS_grid_strategy.tcl defines an ElementGrid macro grid with only an M5-M6 connection rule but no stripes, producing empty macro PDN grids. Use BLOCK_grid_strategy.tcl instead, which has M4-M5 connections matching the block's MAX_ROUTING_LAYER=M4 constraint.

This is the same pattern used by aes-block (via block.mk).