### PR TITLE
fix: use SDC_FILE_EXTRA for mock-cpu util.tcl sourcing

### DIFF
--- a/flow/designs/asap7/mock-cpu/config.mk
+++ b/flow/designs/asap7/mock-cpu/config.mk
@@ -5,6 +5,7 @@ export DESIGN_NICKNAME        = mock-cpu
 
 export VERILOG_FILES = $(wildcard $(DESIGN_HOME)/src/fifo/*.v)
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
+export SDC_FILE_EXTRA = $(DESIGN_HOME)/src/mock-array/util.tcl
 
 export CORE_UTILIZATION         = 40
 export CORE_ASPECT_RATIO        = 1

--- a/flow/designs/asap7/mock-cpu/constraint.sdc
+++ b/flow/designs/asap7/mock-cpu/constraint.sdc
@@ -2,7 +2,7 @@
 #
 # This fifo is from http://www.sunburst-design.com/papers/CummingsSNUG2002SJ_FIFO1.pdf
 
-source $::env(DESIGN_HOME)/src/mock-array/util.tcl
+source $::env(SDC_FILE_EXTRA)
 
 set sdc_version 2.0
 

--- a/flow/designs/asap7/mock-cpu/io.tcl
+++ b/flow/designs/asap7/mock-cpu/io.tcl
@@ -1,10 +1,4 @@
-# bazel has root of OpenROAD-flow-scripts as working directory
-foreach prefix {"" flow/} {
-  set f ${prefix}designs/src/mock-array/util.tcl
-  if { [file exists $f] } {
-    source $f
-  }
-}
+source $::env(SDC_FILE_EXTRA)
 
 set_io_pin_constraint -order -group -region bottom:* \
   -pin_names [concat [match_pins .*] [match_pins clk input 1]]


### PR DESCRIPTION
The constraint.sdc used a hardcoded $::env(DESIGN_HOME) path and io.tcl tried two relative paths with file-exists guards. Both are fragile and break in sandboxed build environments.

Use SDC_FILE_EXTRA to declare the dependency in config.mk and source $::env(SDC_FILE_EXTRA) for a portable path in both files.