### PR TITLE
Yosys CSA tree - demo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tools/yosys"]
 	path = tools/yosys
-	url = ../../The-OpenROAD-Project/yosys.git
+	url = https://github.com/YosysHQ/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
 	url = ../OpenROAD.git

--- a/flake.lock
+++ b/flake.lock
@@ -149,18 +149,18 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1775061651,
-        "narHash": "sha256-3a+Q9hkR4Ny07xdt2DEd3DM1n1pNy7iJlm7UT5pNbbk=",
-        "ref": "nella/carry-save-adders",
-        "rev": "0909e462c3efc2ecd9395e1d69485f9ad4027857",
-        "revCount": 16821,
+        "lastModified": 1775135859,
+        "narHash": "sha256-Feg5TeX5cUd+I0uwciytR3Fv4onpCivC54VDOyG1gPU=",
+        "ref": "nella/csa-orfs-eval",
+        "rev": "a41f55eba71a000a8aba26bb1b209659ffeb159a",
+        "revCount": 16822,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/YosysHQ/yosys"
       },
       "original": {
-        "ref": "nella/carry-save-adders",
-        "rev": "0909e462c3efc2ecd9395e1d69485f9ad4027857",
+        "ref": "nella/csa-orfs-eval",
+        "rev": "a41f55eba71a000a8aba26bb1b209659ffeb159a",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/YosysHQ/yosys"

--- a/flake.lock
+++ b/flake.lock
@@ -54,16 +54,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1724316499,
-        "narHash": "sha256-Qb9MhKBUTCfWg/wqqaxt89Xfi6qTD3XpTzQ9eXi3JmE=",
+        "lastModified": 1771419570,
+        "narHash": "sha256-bxAlQgre3pcQcaRUm/8A0v/X8d2nhfraWSFqVmMcBcU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "797f7dc49e0bc7fab4b57c021cdf68f595e47841",
+        "rev": "6d41bc27aaf7b6a3ba6b169db3bd5d6159cfaa47",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -89,17 +89,17 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1745262648,
-        "narHash": "sha256-NPLjho9TAygCUbRGdR8y+gxYcV0tek2ceMmuoFhwv1s=",
+        "lastModified": 1774752712,
+        "narHash": "sha256-bF0ZqAhLrrTanmNqF5z/fHpGy17t/eAV2SUaOpkNYQ0=",
         "ref": "refs/heads/master",
-        "rev": "7ecbe2e306a961888c17adc8eb761f51c94f06d8",
-        "revCount": 29094,
+        "rev": "ce7ee82f49a965e90de5dfc8de6e4d7d32534984",
+        "revCount": 38824,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
       },
       "original": {
-        "rev": "7ecbe2e306a961888c17adc8eb761f51c94f06d8",
+        "rev": "ce7ee82f49a965e90de5dfc8de6e4d7d32534984",
         "submodules": true,
         "type": "git",
         "url": "https://github.com/The-OpenROAD-Project/OpenROAD"
@@ -149,20 +149,21 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1741764697,
-        "narHash": "sha256-5jQ9l0cyRhEI4UFInW3kqw5B+mdLFr66nfG716rO454=",
-        "ref": "refs/heads/master",
-        "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
-        "revCount": 14791,
+        "lastModified": 1775061651,
+        "narHash": "sha256-3a+Q9hkR4Ny07xdt2DEd3DM1n1pNy7iJlm7UT5pNbbk=",
+        "ref": "nella/carry-save-adders",
+        "rev": "0909e462c3efc2ecd9395e1d69485f9ad4027857",
+        "revCount": 16821,
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/yosys"
+        "url": "https://github.com/YosysHQ/yosys"
       },
       "original": {
-        "rev": "c4b5190229616f7ebf8197f43990b4429de3e420",
+        "ref": "nella/carry-save-adders",
+        "rev": "0909e462c3efc2ecd9395e1d69485f9ad4027857",
         "submodules": true,
         "type": "git",
-        "url": "https://github.com/The-OpenROAD-Project/yosys"
+        "url": "https://github.com/YosysHQ/yosys"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,14 @@
       type = "git";
       url = "https://github.com/The-OpenROAD-Project/OpenROAD";
       submodules = true;
-      rev = "7ecbe2e306a961888c17adc8eb761f51c94f06d8";
+      rev = "ce7ee82f49a965e90de5dfc8de6e4d7d32534984";
     };
     yosys = {
       type = "git";
-      url = "https://github.com/The-OpenROAD-Project/yosys";
+      url = "https://github.com/YosysHQ/yosys";
       submodules = true;
-      rev = "c4b5190229616f7ebf8197f43990b4429de3e420";
+      ref = "nella/carry-save-adders";
+      rev = "0909e462c3efc2ecd9395e1d69485f9ad4027857";
     };
   };
   outputs = { self, nixpkgs, flake-utils, openroad, yosys }: flake-utils.lib.eachDefaultSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,8 @@
       type = "git";
       url = "https://github.com/YosysHQ/yosys";
       submodules = true;
-      ref = "nella/carry-save-adders";
-      rev = "0909e462c3efc2ecd9395e1d69485f9ad4027857";
+      ref = "nella/csa-orfs-eval";
+      rev = "a41f55eba71a000a8aba26bb1b209659ffeb159a";
     };
   };
   outputs = { self, nixpkgs, flake-utils, openroad, yosys }: flake-utils.lib.eachDefaultSystem (

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -131,8 +131,6 @@ if { [env_var_exists_and_non_empty SYNTH_RETIME_MODULES] } {
   select -clear
 }
 
-csa_tree
-
 if {
   [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
   [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -131,6 +131,8 @@ if { [env_var_exists_and_non_empty SYNTH_RETIME_MODULES] } {
   select -clear
 }
 
+csa_tree
+
 if {
   [env_var_exists_and_non_empty SYNTH_WRAPPED_OPERATORS] ||
   [env_var_exists_and_non_empty SWAP_ARITH_OPERATORS]


### PR DESCRIPTION
This PR aims to evaluate QoR of https://github.com/YosysHQ/yosys/pull/5753, which introduces a new CSA pass, potentially improving critical path length. Note that the CSA pass runs before the wrapped operator flow (`SWAP_ARITH_OPERATORS`). The CSA pass consumes `$alu`/`$macc` chains, which may reduce the cells available for the wrapped operator flow, so hopefully this doesn't break things. 

cc @maliberty @QuantamHD