### PR TITLE
fix: separate EQUIVALENCE_CHECK from RUN_EQY to avoid requiring eqy

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -253,7 +253,7 @@ configuration file.
 | <a name="RTLMP_RPT_DIR"></a>RTLMP_RPT_DIR| Path to the directory where reports are saved.| |
 | <a name="RTLMP_WIRELENGTH_WT"></a>RTLMP_WIRELENGTH_WT| Weight for half-perimiter wirelength.| 100.0|
 | <a name="RULES_JSON"></a>RULES_JSON| json files with the metrics baseline regression rules. In the ORFS Makefile, this defaults to $DESIGN_DIR/rules-base.json, but ORFS does not mandate the users source directory layout and this can be placed elsewhere when the user sets up an ORFS config.mk or from bazel-orfs.| |
-| <a name="RUN_EQY"></a>RUN_EQY| Actually run the eqy equivalence checking tool. Requires EQUIVALENCE_CHECK to be enabled and eqy to be installed.| 0|
+| <a name="RUN_EQY"></a>RUN_EQY| Actually run the eqy equivalence checking tool. Requires EQUIVALENCE_CHECK to be enabled and eqy to be installed. Defaults to 1 when eqy is found in PATH.| |
 | <a name="RUN_LOG_NAME_STEM"></a>RUN_LOG_NAME_STEM| Stem of the log file name, the log file will be named `$(LOG_DIR)/$(RUN_LOG_NAME_STEM).log`.| run|
 | <a name="RUN_SCRIPT"></a>RUN_SCRIPT| Path to script to run from `make run`, python or tcl script detected by .py or .tcl extension.| |
 | <a name="SC_LEF"></a>SC_LEF| Path to technology standard cell LEF file.| |

--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -137,7 +137,7 @@ configuration file.
 | <a name="DPO_MAX_DISPLACEMENT"></a>DPO_MAX_DISPLACEMENT| Specifies how far an instance can be moved when optimizing.| 5 1|
 | <a name="EARLY_SIZING_CAP_RATIO"></a>EARLY_SIZING_CAP_RATIO| Ratio between the input pin capacitance and the output pin load during initial gate sizing.| |
 | <a name="ENABLE_DPO"></a>ENABLE_DPO| Enable detail placement with improve_placement feature.| 1|
-| <a name="EQUIVALENCE_CHECK"></a>EQUIVALENCE_CHECK| Enable running equivalence checks to verify logical correctness of repair_timing.| 0|
+| <a name="EQUIVALENCE_CHECK"></a>EQUIVALENCE_CHECK| Enable writing equivalence check files to verify logical correctness of repair_timing. Set RUN_EQY to actually run the eqy tool.| 0|
 | <a name="FASTROUTE_TCL"></a>FASTROUTE_TCL| Specifies a Tcl script with commands to run before FastRoute.| |
 | <a name="FILL_CELLS"></a>FILL_CELLS| Fill cells are used to fill empty sites. If not set or empty, fill cell insertion is skipped.| |
 | <a name="FILL_CONFIG"></a>FILL_CONFIG| JSON rule file for metal fill during chip finishing.| |
@@ -253,6 +253,7 @@ configuration file.
 | <a name="RTLMP_RPT_DIR"></a>RTLMP_RPT_DIR| Path to the directory where reports are saved.| |
 | <a name="RTLMP_WIRELENGTH_WT"></a>RTLMP_WIRELENGTH_WT| Weight for half-perimiter wirelength.| 100.0|
 | <a name="RULES_JSON"></a>RULES_JSON| json files with the metrics baseline regression rules. In the ORFS Makefile, this defaults to $DESIGN_DIR/rules-base.json, but ORFS does not mandate the users source directory layout and this can be placed elsewhere when the user sets up an ORFS config.mk or from bazel-orfs.| |
+| <a name="RUN_EQY"></a>RUN_EQY| Actually run the eqy equivalence checking tool. Requires EQUIVALENCE_CHECK to be enabled and eqy to be installed.| 0|
 | <a name="RUN_LOG_NAME_STEM"></a>RUN_LOG_NAME_STEM| Stem of the log file name, the log file will be named `$(LOG_DIR)/$(RUN_LOG_NAME_STEM).log`.| run|
 | <a name="RUN_SCRIPT"></a>RUN_SCRIPT| Path to script to run from `make run`, python or tcl script detected by .py or .tcl extension.| |
 | <a name="SC_LEF"></a>SC_LEF| Path to technology standard cell LEF file.| |
@@ -489,6 +490,7 @@ configuration file.
 - [PRE_CTS_TCL](#PRE_CTS_TCL)
 - [REMOVE_CELLS_FOR_EQY](#REMOVE_CELLS_FOR_EQY)
 - [REPORT_CLOCK_SKEW](#REPORT_CLOCK_SKEW)
+- [RUN_EQY](#RUN_EQY)
 - [SETUP_REPAIR_SEQUENCE](#SETUP_REPAIR_SEQUENCE)
 - [SETUP_SLACK_MARGIN](#SETUP_SLACK_MARGIN)
 - [SKIP_CRIT_VT_SWAP](#SKIP_CRIT_VT_SWAP)

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -68,7 +68,7 @@ if { !$::env(SKIP_CTS_REPAIR_TIMING) } {
 
   repair_timing_helper
 
-  if { $::env(EQUIVALENCE_CHECK) } {
+  if { $::env(EQUIVALENCE_CHECK) && $::env(RUN_EQY) } {
     run_equivalence_test
   }
   if { $::env(LEC_CHECK) } {

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -132,6 +132,10 @@ ifneq ($(shell command -v stdbuf),)
   STDBUF_CMD ?= stdbuf -o L
 endif
 
+ifneq ($(shell command -v eqy),)
+  export RUN_EQY ?= 1
+endif
+
 #-------------------------------------------------------------------------------
 WRAPPED_LEFS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/lef/$(lef:.lef=_mod.lef))
 WRAPPED_LIBS = $(foreach lib,$(notdir $(WRAP_LIBS)),$(OBJECTS_DIR)/$(lib:.lib=_mod.lib))

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -86,8 +86,15 @@ DETAILED_METRICS:
     - grt
 EQUIVALENCE_CHECK:
   description: >
-    Enable running equivalence checks to verify logical correctness of
-    repair_timing.
+    Enable writing equivalence check files to verify logical correctness of
+    repair_timing. Set RUN_EQY to actually run the eqy tool.
+  default: 0
+  stages:
+    - cts
+RUN_EQY:
+  description: >
+    Actually run the eqy equivalence checking tool. Requires EQUIVALENCE_CHECK
+    to be enabled and eqy to be installed.
   default: 0
   stages:
     - cts

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -94,8 +94,8 @@ EQUIVALENCE_CHECK:
 RUN_EQY:
   description: >
     Actually run the eqy equivalence checking tool. Requires EQUIVALENCE_CHECK
-    to be enabled and eqy to be installed.
-  default: 0
+    to be enabled and eqy to be installed. Defaults to 1 when eqy is found
+    in PATH.
   stages:
     - cts
 CORE_UTILIZATION:


### PR DESCRIPTION
EQUIVALENCE_CHECK now only controls writing equivalence check files. The new RUN_EQY variable (default 0) gates actually executing the eqy tool, so builds don't fail when eqy is not installed.