### PR TITLE
fix: use stat -hierarchy for hierarchical synth to report area

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -226,7 +226,11 @@ if { $::env(SYNTH_INSBUF) } {
 # Reports
 tee -o $::env(REPORTS_DIR)/synth_check.txt check
 
-tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$lib_args
+if { $::env(SYNTH_HIERARCHICAL) } {
+  tee -o $::env(REPORTS_DIR)/synth_stat.txt stat -hierarchy {*}$lib_args
+} else {
+  tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$lib_args
+}
 
 # check the design is composed exclusively of target cells, and
 # check for other problems

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -226,11 +226,7 @@ if { $::env(SYNTH_INSBUF) } {
 # Reports
 tee -o $::env(REPORTS_DIR)/synth_check.txt check
 
-if { $::env(SYNTH_HIERARCHICAL) } {
-  tee -o $::env(REPORTS_DIR)/synth_stat.txt stat -hierarchy {*}$lib_args
-} else {
-  tee -o $::env(REPORTS_DIR)/synth_stat.txt stat {*}$lib_args
-}
+tee -o $::env(REPORTS_DIR)/synth_stat.txt stat -hierarchy {*}$lib_args
 
 # check the design is composed exclusively of target cells, and
 # check for other problems

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -228,11 +228,12 @@ def extract_metrics(
     # Synthesis
     # =========================================================================
 
-    # The new format (>= 0.57) is: <count> <area> cells
+    # The new format (>= 0.57) with -hierarchy is:
+    #    <count> <area> <local_count> <local_area> cells
     extractTagFromFile(
         "synth__design__instance__count__stdcell",
         metrics_dict,
-        "^\\s+(\\d+)\\s+[-0-9.]+\\s+cells$",
+        "^\\s+(\\d+)\\s+[-0-9.]+\\s+\\S+\\s+\\S+\\s+cells$",
         rptPath + "/synth_stat.txt",
     )
 


### PR DESCRIPTION
When SYNTH_HIERARCHICAL=1, the yosys stat command reports zero area for the top module because all cells are in submodules. Adding -hierarchy makes stat include submodule area, so
synth__design__instance__area__stdcell is no longer N/A.