### PR TITLE
fix: update Bazel install target path to //packaging:install

### DIFF
--- a/bazel/install.sh
+++ b/bazel/install.sh
@@ -88,10 +88,10 @@ for sub in tools/OpenROAD tools/yosys tools/yosys-slang; do
     fi
 done
 
-# --- OpenROAD (delegates to its own //:install) ---
+# --- OpenROAD (delegates to its own //packaging:install) ---
 if [[ $BUILD_OPENROAD -eq 1 ]]; then
     echo "=== Building OpenROAD with GUI support ==="
-    (cd "${WORKSPACE}/tools/OpenROAD" && bazelisk run --//:platform=gui //:install)
+    (cd "${WORKSPACE}/tools/OpenROAD" && bazelisk run --//:platform=gui //packaging:install)
 fi
 
 # --- Yosys ---


### PR DESCRIPTION
## Summary
- The OpenROAD submodule moved its install target from //:install to //packaging:install (OpenROAD commit c75d756f9d), breaking bazelisk run //:install_for_bazel
- Updated the target path and comment in bazel/install.sh to match the new location

Fixes #4101

## Test plan
- [ ] Run bazelisk run //:install_for_bazel and verify it no longer fails with no such target //:install
- [ ] Confirm the OpenROAD build proceeds past the target resolution step
