### PR TITLE
Ballads of time

### DIFF
--- a/docs/contrib/DeveloperGuide.md
+++ b/docs/contrib/DeveloperGuide.md
@@ -5,3 +5,63 @@
 - Continuous Integration: [Guide](./CI.md).
 - How do I update the codebase? There are different ways to update your codebase depending on the method you installed it. We provide detailed instructions in this [guide](../user/FAQS.md).
 - How do I contribute? Follow our Git Quickstart guide [here](./GitGuide.md).
+
+## Timing and Logging (`run_command.py`)
+
+Every flow stage (synthesis, floorplan, CTS, routing, etc.) is wrapped by
+`flow/scripts/run_command.py`, which replaces the previous GNU `time` + `tee`
+shell pipeline with a pure-Python implementation.
+
+### What it does
+
+`run_command.py` runs a command and:
+
+- Measures **wall-clock time**, **CPU time** (user + sys), and **peak memory**
+  using Python's `time.monotonic()` and `resource.getrusage()`.
+- Streams output **line-by-line** to both the console and a log file
+  (replacing `tee`), flushing after every line for real-time `tail -f`
+  observability.
+- Appends an `Elapsed time: ...` line in the format expected by
+  `genElapsedTime.py` and `genMetrics.py`.
+
+### Usage
+
+```
+python3 flow/scripts/run_command.py [--log FILE] [--append] [--tee] -- command [args...]
+```
+
+| Flag       | Effect |
+|------------|--------|
+| `--log FILE` | Write command output + timing line to FILE |
+| `--append`   | Append to log file instead of overwriting |
+| `--tee`      | Also write output to stdout (like the `tee` command) |
+
+### Monitoring long-running stages
+
+When running under Bazel (`bazelisk test ...`) or other batch systems that
+hide console output, you can monitor progress by finding and tailing the log:
+
+```bash
+# Find the running stage's log file
+ps -Af | grep run_command
+# or
+ps -Af | grep tmp.log
+
+# Watch it in real time
+tail -f /path/to/logs/4_cts.tmp.log
+```
+
+Output appears immediately in the log file (line-buffered with flush),
+so `tail -f` shows real-time progress.
+
+### Cross-platform support
+
+Works on both Linux and macOS using only Python standard library modules.
+Peak memory is normalized automatically (`ru_maxrss` is KB on Linux,
+bytes on macOS).
+
+### Testing
+
+```bash
+python3 -m pytest flow/test/test_run_command.py -v
+```

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -241,7 +241,7 @@ synth-report: synth
 
 .PHONY: do-synth-report
 do-synth-report:
-	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_metrics.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/1_2_yosys_metrics.log)
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/1_2_yosys_metrics.log) --tee -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/synth_metrics.tcl
 
 .PHONY: memory
 memory:
@@ -641,7 +641,7 @@ generate_abstract: $(RESULTS_DIR)/6_final.gds $(RESULTS_DIR)/6_final.def  $(RESU
 .PHONY: do-generate_abstract
 do-generate_abstract:
 	mkdir -p $(LOG_DIR) $(REPORTS_DIR)
-	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/generate_abstract.tcl -metrics $(LOG_DIR)/generate_abstract.json) 2>&1 | tee $(abspath $(LOG_DIR)/generate_abstract.log)
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/generate_abstract.log) --tee -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/generate_abstract.tcl -metrics $(LOG_DIR)/generate_abstract.json
 
 .PHONY: clean_abstract
 clean_abstract:
@@ -661,7 +661,8 @@ gds: $(GDS_FINAL_FILE)
 # Merge wrapped macros using Klayout
 #-------------------------------------------------------------------------------
 $(WRAPPED_GDSOAS): $(OBJECTS_DIR)/klayout_wrap.lyt $(WRAPPED_LEFS)
-	($(TIME_CMD) $(SCRIPTS_DIR)/klayout.sh -zz -rd design_name=$(basename $(notdir $@)) \
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/6_merge_$(basename $(notdir $@)).log) --tee -- \
+	        $(SCRIPTS_DIR)/klayout.sh -zz -rd design_name=$(basename $(notdir $@)) \
 	        -rd in_def=$(OBJECTS_DIR)/def/$(notdir $(@:$(STREAM_SYSTEM_EXT)=def)) \
 	        -rd in_files="$(ADDITIONAL_GDSOAS)" \
 	        -rd config_file=$(FILL_CONFIG) \
@@ -669,7 +670,7 @@ $(WRAPPED_GDSOAS): $(OBJECTS_DIR)/klayout_wrap.lyt $(WRAPPED_LEFS)
 	        -rd out_file=$@ \
 	        -rd tech_file=$(OBJECTS_DIR)/klayout_wrap.lyt \
 	        -rd layer_map=$(GDS_LAYER_MAP) \
-	        -r $(UTILS_DIR)/def2stream.py) 2>&1 | tee $(abspath $(LOG_DIR)/6_merge_$(basename $(notdir $@)).log)
+	        -r $(UTILS_DIR)/def2stream.py
 
 # Merge GDS using Klayout
 #-------------------------------------------------------------------------------
@@ -678,14 +679,15 @@ $(GDS_MERGED_FILE): check-klayout $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klay
 
 .PHONY: do-gds-merged
 do-gds-merged:
-	($(TIME_CMD) $(STDBUF_CMD) $(SCRIPTS_DIR)/klayout.sh -zz -rd design_name=$(DESIGN_NAME) \
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/6_1_merge.log) --tee -- \
+	        $(SCRIPTS_DIR)/klayout.sh -zz -rd design_name=$(DESIGN_NAME) \
 	        -rd in_def=$(RESULTS_DIR)/6_final.def \
 	        -rd in_files="$(GDSOAS_FILES) $(WRAPPED_GDSOAS)" \
 	        -rd seal_file="$(SEAL_GDSOAS)" \
 	        -rd out_file=$(GDS_MERGED_FILE) \
 	        -rd tech_file=$(OBJECTS_DIR)/klayout.lyt \
 	        -rd layer_map=$(GDS_LAYER_MAP) \
-	        -r $(UTILS_DIR)/def2stream.py) 2>&1 | tee $(abspath $(LOG_DIR)/6_1_merge.log)
+	        -r $(UTILS_DIR)/def2stream.py
 
 $(RESULTS_DIR)/6_final.v: $(LOG_DIR)/6_report.log
 
@@ -702,9 +704,10 @@ drc: $(REPORTS_DIR)/6_drc.lyrdb
 
 $(REPORTS_DIR)/6_drc.lyrdb: $(GDS_FINAL_FILE) $(KLAYOUT_DRC_FILE)
 ifneq ($(KLAYOUT_DRC_FILE),)
-	($(TIME_CMD) $(SCRIPTS_DIR)/klayout.sh -zz -rd in_gds="$<" \
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/6_drc.log) --tee -- \
+	        $(SCRIPTS_DIR)/klayout.sh -zz -rd in_gds="$<" \
 	        -rd report_file=$(abspath $@) \
-	        -r $(KLAYOUT_DRC_FILE)) 2>&1 | tee $(abspath $(LOG_DIR)/6_drc.log)
+	        -r $(KLAYOUT_DRC_FILE)
 	# Hacky way of getting DRV count (don't error on no matches)
 	grep -c "<value>" $@ > $(REPORTS_DIR)/6_drc_count.rpt || [[ $$? == 1 ]]
 else
@@ -712,7 +715,7 @@ else
 endif
 
 $(RESULTS_DIR)/6_final.cdl: $(RESULTS_DIR)/6_final.v
-	($(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/cdl.tcl) 2>&1 | tee $(abspath $(LOG_DIR)/6_cdl.log)
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/6_cdl.log) --tee -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/cdl.tcl
 
 $(OBJECTS_DIR)/6_final_concat.cdl: $(RESULTS_DIR)/6_final.cdl $(CDL_FILE)
 	cat $^ > $@
@@ -722,10 +725,11 @@ lvs: $(RESULTS_DIR)/6_lvs.lvsdb
 
 $(RESULTS_DIR)/6_lvs.lvsdb: $(GDS_FINAL_FILE) $(KLAYOUT_LVS_FILE) $(OBJECTS_DIR)/6_final_concat.cdl
 ifneq ($(KLAYOUT_LVS_FILE),)
-	($(TIME_CMD) $(SCRIPTS_DIR)/klayout.sh -b -rd in_gds="$<" \
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/6_lvs.log) --tee -- \
+	        $(SCRIPTS_DIR)/klayout.sh -b -rd in_gds="$<" \
 	        -rd cdl_file=$(abspath $(OBJECTS_DIR)/6_final_concat.cdl) \
 	        -rd report_file=$(abspath $@) \
-	        -r $(KLAYOUT_LVS_FILE)) 2>&1 | tee $(abspath $(LOG_DIR)/6_lvs.log)
+	        -r $(KLAYOUT_LVS_FILE)
 else
 	echo "LVS not supported on this platform" > $@
 endif

--- a/flow/scripts/deleteNonClkNets.tcl
+++ b/flow/scripts/deleteNonClkNets.tcl
@@ -1,3 +1,5 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 read_lef $::env(TECH_LEF)
 read_lef $::env(SC_LEF)
 if { [info exist ::env(ADDITIONAL_LEFS)] } {

--- a/flow/scripts/deletePowerNets.tcl
+++ b/flow/scripts/deletePowerNets.tcl
@@ -1,3 +1,5 @@
+source $::env(SCRIPTS_DIR)/util.tcl
+
 read_lef $::env(TECH_LEF)
 read_lef $::env(SC_LEF)
 if { [info exist ::env(ADDITIONAL_LEFS)] } {

--- a/flow/scripts/flow.sh
+++ b/flow/scripts/flow.sh
@@ -11,8 +11,8 @@ echo "Running $2.tcl, stage $1"
   eval "$OPENROAD_EXE $OPENROAD_ARGS -exit \"$SCRIPTS_DIR/noop.tcl\"" \
     >"$LOG_DIR/$1.tmp.log" 2>&1
 
-  eval "$TIME_CMD $OPENROAD_CMD -no_splash \"$SCRIPTS_DIR/$2.tcl\" -metrics \"$LOG_DIR/$1.json\"" \
-    2>&1 | tee -a "$(realpath "$LOG_DIR/$1.tmp.log")"
+  $PYTHON_EXE "$SCRIPTS_DIR/run_command.py" --log "$(realpath "$LOG_DIR/$1.tmp.log")" --append --tee -- \
+    $OPENROAD_CMD -no_splash "$SCRIPTS_DIR/$2.tcl" -metrics "$LOG_DIR/$1.json"
 )
 
 # Log the hash for this step. The summary "make elapsed" in "make finish",

--- a/flow/scripts/run_command.py
+++ b/flow/scripts/run_command.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Run a command with timing and optional log file output.
+
+Replaces the GNU `time` + `tee` shell pipeline with a pure-Python
+implementation that works on both Linux and macOS without external
+dependencies.
+
+Usage:
+    run_command.py [--log FILE] [--append] [--tee] -- command [args...]
+
+Output is streamed line-by-line and flushed after every line so that
+`tail -f <logfile>` works in real time.  The log path is visible in
+`ps` output for discoverability (replaces `ps -Af | grep tee`).
+
+On completion an "Elapsed time: ..." line is appended to stderr (and
+the log file) in the same format that the rest of the ORFS
+infrastructure expects.
+"""
+
+import argparse
+import resource
+import subprocess
+import sys
+import time
+
+
+def _maxrss_kb(ru_maxrss: int) -> int:
+    """Normalize ru_maxrss to kilobytes (Linux reports KB, macOS reports bytes)."""
+    if sys.platform == "darwin":
+        return ru_maxrss // 1024
+    return ru_maxrss
+
+
+def _format_elapsed(seconds: float) -> str:
+    """Format seconds as [H:]MM:SS.ff matching GNU time %E output."""
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = seconds % 60
+    if h:
+        return f"{h}:{m:02d}:{s:05.2f}"
+    return f"{m}:{s:05.2f}"
+
+
+def _build_timing_line(
+    wall: float,
+    user: float,
+    sys_: float,
+    peak_kb: int,
+) -> str:
+    cpu_pct = int(100 * (user + sys_) / wall) if wall > 0 else 0
+    return (
+        f"Elapsed time: {_format_elapsed(wall)}[h:]min:sec. "
+        f"CPU time: user {user:.2f} sys {sys_:.2f} ({cpu_pct}%). "
+        f"Peak memory: {peak_kb}KB."
+    )
+
+
+def run(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run a command with timing, optional tee-to-log."
+    )
+    parser.add_argument("--log", help="Log file path")
+    parser.add_argument(
+        "--append", action="store_true", help="Append to log file instead of overwrite"
+    )
+    parser.add_argument(
+        "--tee",
+        action="store_true",
+        help="Also write output to stdout (like tee)",
+    )
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+
+    cmd = args.command
+    if cmd and cmd[0] == "--":
+        cmd = cmd[1:]
+    if not cmd:
+        parser.error("No command specified")
+
+    # Snapshot children resource usage before the subprocess.
+    before = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+    log_file = None
+    if args.log:
+        log_file = open(args.log, "a" if args.append else "w")
+
+    wall_start = time.monotonic()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    try:
+        for line in iter(proc.stdout.readline, b""):
+            if args.tee:
+                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
+            if log_file:
+                log_file.write(line.decode(errors="replace"))
+                log_file.flush()
+        proc.wait()
+    except BaseException:
+        proc.kill()
+        proc.wait()
+        raise
+    finally:
+        wall = time.monotonic() - wall_start
+
+        after = resource.getrusage(resource.RUSAGE_CHILDREN)
+        user = after.ru_utime - before.ru_utime
+        sys_ = after.ru_stime - before.ru_stime
+        peak_kb = _maxrss_kb(after.ru_maxrss)
+
+        timing_line = _build_timing_line(wall, user, sys_, peak_kb)
+
+        sys.stderr.write(timing_line + "\n")
+        sys.stderr.flush()
+        if log_file:
+            log_file.write(timing_line + "\n")
+            log_file.flush()
+            log_file.close()
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/flow/scripts/synth.sh
+++ b/flow/scripts/synth.sh
@@ -2,4 +2,5 @@
 set -u -eo pipefail
 mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
 $YOSYS_EXE -V > $(realpath $2)
-eval "$TIME_CMD $YOSYS_EXE $YOSYS_FLAGS -c $1" 2>&1 | tee --append $(realpath $2)
+$PYTHON_EXE "$SCRIPTS_DIR/run_command.py" --log "$(realpath $2)" --append --tee -- \
+  $YOSYS_EXE $YOSYS_FLAGS -c $1

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -72,13 +72,7 @@ export NUM_CORES
 # setup all commands used within this flow
 export PYTHON_EXE ?= $(shell command -v python3)
 
-export TIME_BIN   ?= env time
-TIME_CMD = $(TIME_BIN) -f 'Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.'
-TIME_TEST = $(shell $(TIME_CMD) echo foo 2>/dev/null)
-ifeq (,$(strip $(TIME_TEST)))
-  TIME_CMD = $(TIME_BIN)
-endif
-export TIME_CMD
+export RUN_CMD = $(PYTHON_EXE) $(FLOW_HOME)/scripts/run_command.py
 
 # The following determine the executable location for each tool used by this flow.
 # Priority is given to
@@ -128,9 +122,6 @@ export KLAYOUT_CMD := $(shell command -v klayout)
 endif
 endif
 
-ifneq ($(shell command -v stdbuf),)
-  STDBUF_CMD ?= stdbuf -o L
-endif
 
 #-------------------------------------------------------------------------------
 WRAPPED_LEFS = $(foreach lef,$(notdir $(WRAP_LEFS)),$(OBJECTS_DIR)/lef/$(lef:.lef=_mod.lef))
@@ -191,7 +182,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
 export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 
 define get_variables
-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% %TIME_CMD% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)

--- a/flow/test/test_run_command.py
+++ b/flow/test/test_run_command.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+sys.path.append(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts")
+)
+
+import run_command
+
+TIMING_RE = re.compile(
+    r"^Elapsed time: (\S+)\[h:\]min:sec\. "
+    r"CPU time: user (\S+) sys (\S+) \((\d+)%\)\. "
+    r"Peak memory: (\d+)KB\.$",
+    re.MULTILINE,
+)
+
+
+class TestRunCommand(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.log_path = os.path.join(self.tmp_dir.name, "test.log")
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_basic_timing(self):
+        rc = run_command.run(["--log", self.log_path, "--", "sleep", "0.1"])
+        self.assertEqual(rc, 0)
+        with open(self.log_path) as f:
+            content = f.read()
+        m = TIMING_RE.search(content)
+        self.assertIsNotNone(m, f"Timing line not found in: {content!r}")
+
+    def test_output_format(self):
+        run_command.run(["--log", self.log_path, "--", "echo", "hello world"])
+        with open(self.log_path) as f:
+            content = f.read()
+        self.assertIn("hello world", content)
+        m = TIMING_RE.search(content)
+        self.assertIsNotNone(m, f"Timing line not found in: {content!r}")
+        # Verify time fields are parseable floats
+        float(m.group(2))  # user
+        float(m.group(3))  # sys
+
+    def test_log_file_created(self):
+        self.assertFalse(os.path.exists(self.log_path))
+        run_command.run(["--log", self.log_path, "--", "echo", "test"])
+        self.assertTrue(os.path.exists(self.log_path))
+
+    def test_append_mode(self):
+        with open(self.log_path, "w") as f:
+            f.write("pre-existing content\n")
+        run_command.run(["--log", self.log_path, "--append", "--", "echo", "appended"])
+        with open(self.log_path) as f:
+            content = f.read()
+        self.assertIn("pre-existing content", content)
+        self.assertIn("appended", content)
+
+    def test_overwrite_mode(self):
+        with open(self.log_path, "w") as f:
+            f.write("old content\n")
+        run_command.run(["--log", self.log_path, "--", "echo", "new"])
+        with open(self.log_path) as f:
+            content = f.read()
+        self.assertNotIn("old content", content)
+        self.assertIn("new", content)
+
+    def test_tee_output(self):
+        """Verify --tee sends output to stdout as well as the log file."""
+        result = subprocess.run(
+            [
+                sys.executable,
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "..",
+                    "scripts",
+                    "run_command.py",
+                ),
+                "--log",
+                self.log_path,
+                "--tee",
+                "--",
+                "echo",
+                "visible",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertIn("visible", result.stdout)
+        with open(self.log_path) as f:
+            self.assertIn("visible", f.read())
+
+    def test_exit_code_propagation(self):
+        rc = run_command.run(["--log", self.log_path, "--", "false"])
+        self.assertNotEqual(rc, 0)
+
+    def test_exit_code_success(self):
+        rc = run_command.run(["--log", self.log_path, "--", "true"])
+        self.assertEqual(rc, 0)
+
+    def test_peak_memory(self):
+        """Peak memory should be reported and > 0 for a real command."""
+        run_command.run(
+            ["--log", self.log_path, "--", sys.executable, "-c", "x = 'a' * 1000000"]
+        )
+        with open(self.log_path) as f:
+            content = f.read()
+        m = TIMING_RE.search(content)
+        self.assertIsNotNone(m)
+        peak_kb = int(m.group(5))
+        self.assertGreater(peak_kb, 0)
+
+    def test_cpu_time(self):
+        """CPU time fields should be present and parseable."""
+        run_command.run(
+            [
+                "--log",
+                self.log_path,
+                "--",
+                sys.executable,
+                "-c",
+                "sum(range(100000))",
+            ]
+        )
+        with open(self.log_path) as f:
+            content = f.read()
+        m = TIMING_RE.search(content)
+        self.assertIsNotNone(m)
+        user = float(m.group(2))
+        sys_ = float(m.group(3))
+        self.assertGreaterEqual(user, 0)
+        self.assertGreaterEqual(sys_, 0)
+
+    def test_stderr_captured(self):
+        """Stderr from the subprocess should appear in the log."""
+        run_command.run(
+            [
+                "--log",
+                self.log_path,
+                "--",
+                sys.executable,
+                "-c",
+                "import sys; sys.stderr.write('err_msg\\n')",
+            ]
+        )
+        with open(self.log_path) as f:
+            content = f.read()
+        self.assertIn("err_msg", content)
+
+    def test_cross_platform_memory_units(self):
+        """Verify _maxrss_kb normalizes correctly for current platform."""
+        if sys.platform == "darwin":
+            # macOS: bytes -> KB
+            self.assertEqual(run_command._maxrss_kb(1024000), 1000)
+        else:
+            # Linux: already KB
+            self.assertEqual(run_command._maxrss_kb(1000), 1000)
+
+    def test_streaming_flush(self):
+        """Verify log file is written incrementally, not buffered until exit.
+
+        This validates the tail -f use case: users must see output in the
+        log file while the subprocess is still running.
+        """
+        script = (
+            "import sys, time; "
+            "print('line1', flush=True); "
+            "time.sleep(0.5); "
+            "print('line2', flush=True); "
+            "time.sleep(1)"
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "..",
+                    "scripts",
+                    "run_command.py",
+                ),
+                "--log",
+                self.log_path,
+                "--",
+                sys.executable,
+                "-c",
+                script,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Wait a bit for first line to be flushed
+        time.sleep(0.3)
+        with open(self.log_path) as f:
+            content = f.read()
+        self.assertIn(
+            "line1", content, "line1 should appear before subprocess finishes"
+        )
+        proc.wait()
+
+    def test_log_path_in_cmdline(self):
+        """Verify the log path is visible in ps output (for discoverability).
+
+        Users find logs via `ps -Af | grep run_command` or `ps -Af | grep tmp.log`.
+        The log path must appear in /proc/<pid>/cmdline (ps -Af may truncate).
+        """
+        script = "import time; time.sleep(2)"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)),
+                    "..",
+                    "scripts",
+                    "run_command.py",
+                ),
+                "--log",
+                self.log_path,
+                "--",
+                sys.executable,
+                "-c",
+                script,
+            ],
+        )
+        time.sleep(0.3)
+        try:
+            # Read full cmdline from /proc (not truncated like ps -Af)
+            cmdline_path = f"/proc/{proc.pid}/cmdline"
+            if os.path.exists(cmdline_path):
+                with open(cmdline_path) as f:
+                    cmdline = f.read()
+                self.assertIn(
+                    self.log_path,
+                    cmdline,
+                    "Log path should be visible in /proc/<pid>/cmdline",
+                )
+            else:
+                # Fallback for non-Linux: use ps with wide output
+                ps = subprocess.run(
+                    ["ps", "-ww", "-p", str(proc.pid), "-o", "args="],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertIn(self.log_path, ps.stdout)
+        finally:
+            proc.kill()
+            proc.wait()
+
+    def test_no_command_error(self):
+        with self.assertRaises(SystemExit):
+            run_command.run(["--log", self.log_path])
+
+    def test_format_elapsed_minutes_seconds(self):
+        self.assertEqual(run_command._format_elapsed(65.5), "1:05.50")
+
+    def test_format_elapsed_hours(self):
+        self.assertEqual(run_command._format_elapsed(3661.0), "1:01:01.00")
+
+    def test_format_elapsed_subsecond(self):
+        self.assertEqual(run_command._format_elapsed(0.5), "0:00.50")
+
+    def test_genElapsedTime_parses_output(self):
+        """Verify genElapsedTime.py can parse the timing line produced by run_command."""
+        sys.path.insert(
+            0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "util")
+        )
+        import genElapsedTime
+        from io import StringIO
+        from unittest.mock import patch
+
+        log_dir = self.tmp_dir.name
+        log_file = os.path.join(log_dir, "1_test.log")
+        # Run a real command to generate a timing line
+        run_command.run(["--log", log_file, "--", "echo", "hello"])
+        with patch("sys.stdout", new_callable=StringIO) as mock_out:
+            genElapsedTime.scan_logs(["--logDir", log_dir, "--noHeader"])
+        output = mock_out.getvalue()
+        self.assertIn("1_test", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -89,13 +89,13 @@ write_net_rc: $(RESULTS_DIR)/6_net_rc.csv
 
 #$(RESULTS_DIR)/6_net_rc.csv: $(RESULTS_DIR)/4_cts.odb $(RESULTS_DIR)/6_final.spef
 $(RESULTS_DIR)/6_net_rc.csv:
-	($(TIME_CMD) $(OPENROAD_CMD) $(UTILS_DIR)/write_net_rc_script.tcl) 2>&1 | tee $(LOG_DIR)/6_write_net_rc.log
+	$(RUN_CMD) --log $(LOG_DIR)/6_write_net_rc.log --tee -- $(OPENROAD_CMD) $(UTILS_DIR)/write_net_rc_script.tcl
 
 .PHONY: write_segment_rc
 write_segment_rc: $(RESULTS_DIR)/6_segment_rc.csv
 
 $(RESULTS_DIR)/6_segment_rc.csv:
-	($(TIME_CMD) $(OPENROAD_CMD) $(UTILS_DIR)/write_segment_rc_script.tcl) 2>&1 | tee $(LOG_DIR)/6_write_segment_rc.log
+	$(RUN_CMD) --log $(LOG_DIR)/6_write_segment_rc.log --tee -- $(OPENROAD_CMD) $(UTILS_DIR)/write_segment_rc_script.tcl
 
 .PHONY: correlate_rc
 correlate_rc: $(RESULTS_DIR)/6_net_rc.csv
@@ -150,18 +150,19 @@ clean_issues:
 	rm -f vars*.sh vars*.tcl vars*.gdb run-me*.sh
 
 $(RESULTS_DIR)/6_final_only_clk.def: $(RESULTS_DIR)/6_final.def
-	$(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/deleteNonClkNets.tcl
+	$(RUN_CMD) -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deleteNonClkNets.tcl
 
 $(RESULTS_DIR)/6_final_no_power.def: $(RESULTS_DIR)/6_final.def
-	$(TIME_CMD) $(OPENROAD_CMD) $(SCRIPTS_DIR)/deletePowerNets.tcl
+	$(RUN_CMD) -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deletePowerNets.tcl
 
 
 .PHONY: gallery
 gallery: check-klayout $(RESULTS_DIR)/6_final_no_power.def $(RESULTS_DIR)/6_final_only_clk.def
-	($(TIME_CMD) klayout -z -nc -rx -rd gallery_json=util/gallery.json \
+	$(RUN_CMD) --log $(LOG_DIR)/6_1_merge.log --tee -- \
+	        klayout -z -nc -rx -rd gallery_json=util/gallery.json \
 	        -rd results_path=$(RESULTS_DIR) \
 	        -rd tech_file=$(OBJECTS_DIR)/klayout.lyt \
-	        -rm $(UTILS_DIR)/createGallery.py) 2>&1 | tee $(LOG_DIR)/6_1_merge.log
+	        -rm $(UTILS_DIR)/createGallery.py
 
 .PHONY: view_cells
 view_cells:

--- a/flow/util/utils.mk
+++ b/flow/util/utils.mk
@@ -150,10 +150,10 @@ clean_issues:
 	rm -f vars*.sh vars*.tcl vars*.gdb run-me*.sh
 
 $(RESULTS_DIR)/6_final_only_clk.def: $(RESULTS_DIR)/6_final.def
-	$(RUN_CMD) -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deleteNonClkNets.tcl
+	$(RUN_CMD) --tee -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deleteNonClkNets.tcl
 
 $(RESULTS_DIR)/6_final_no_power.def: $(RESULTS_DIR)/6_final.def
-	$(RUN_CMD) -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deletePowerNets.tcl
+	$(RUN_CMD) --tee -- $(OPENROAD_CMD) $(SCRIPTS_DIR)/deletePowerNets.tcl
 
 
 .PHONY: gallery


### PR DESCRIPTION
# The Ballad of TIME_BIN: A Chronicle of Middle-ORFS

*Being a true account, drawn from the git scrolls, of the dragons, the failed harvests, the brief joys, and the petition to the King.*

---

## Prologue: The Land and Its Creatures

In the land of Middle-ORFS, where the great flows run from the mountains of RTL down through the fertile valleys of Synthesis, Floorplan, and Placement to the shining sea of GDS, the peoples had built a good civilization. Their harvests — the builds — fed entire kingdoms. Their treasures — the tapeouts — were the envy of all silicon-kind.

But beneath the mountains there dwelt creatures of ancient malice.

The **Dragon of Ambiguity** (`time`) was the eldest. It had three heads: a Shell Builtin that whispered false promises, a GNU Binary that demanded tribute in the form of `-f` flags, and a BSD Shapeshifter that spoke an entirely foreign tongue. No two heads agreed on anything. Farmers who addressed one head would be answered by another.

Serving the Dragon were its foul spawn: the **Troll of Eval** (`eval "$TIME_CMD ..."`), a brute that could only understand commands if you shouted them twice through a layer of quoting. The **Goblin of Tee** (`2>&1 | tee`), a pipe-dwelling creature that intercepted messages between the workers and their logs, sometimes swallowing errors whole. The **Imp of Stdbuf** (`stdbuf -o L`), a tiny pest summoned only because the Goblin of Tee refused to pass messages promptly. And the **Wraith of Pipefail**, a ghost that haunted every pipeline, ensuring that when things went wrong, they went wrong in the most confusing way possible.

Together, these creatures formed **The Pipeline of Sorrows**, and the peoples of Middle-ORFS had long suffered under their tyranny.

There was also **The Python** -- a great serpent with whom the peoples had negotiated an uneasy detente. The Python was useful, undeniably so. It parsed their metrics, generated their reports, ran their tests. But the Python was not to be trusted entirely. It did dirty deals with the dependencies behind the peoples' backs -- smuggling in `pip install` creatures, spawning virtual environments that vanished at dawn, and occasionally demanding tribute in the form of version upgrades that broke everything. The peoples tolerated the Python because they needed it. The Python tolerated the peoples because they fed it data.

It was, as all detentes are, a relationship built on mutual suspicion and practical necessity.

But there was also Hzeller the Grey.

---

## Chapter I: The Elder Days and the Forging of TIME_CMD

*Year 2021 of the Git Calendar. The realm is young.*

In the earliest age, **Vitor of Bandeira**, Lord of the Southern Makefiles and first steward of the flow, forged the TIME_CMD in the fires of `/usr/bin/time`. It was a format string of great power:

```
Elapsed time: %E[h:]min:sec. CPU time: user %U sys %S (%P). Peak memory: %MKB.
```

"This shall measure our harvests," he declared, "and we shall know precisely how long each field takes to yield."

The first harvest season was promising. Designs flowed. GDS files emerged. But the Dragon of Ambiguity was already stirring.

A humble farmer named **Andreas of Kuster** rode to the castle with alarming news: the format was wrong. Spaces in the wrong places. Words in the wrong order. The harvest records were garbled. Five comments were exchanged at the castle gate before the crisis passed. [A.1]

This was but a tremor before the earthquake.

### The Joyful Interlude: New Designs

Yet not all was darkness. The same season saw a *great treasure* unearthed: new ASAP7 designs — Ethernet, UART, sha3 — were added to the realm. The fields expanded. The people rejoiced. For a brief moment, the Dragon slept. [A.2]

### The Format String Catastrophe

But Vitor, ever ambitious, returned to the forge. "We need CPU seconds in the record," he proclaimed. He changed the format string.

Every parser in the realm broke.

Andreas of Kuster rode forth again — twice — to fix two separate files containing two different regexes that parsed the same format. Patches crossed in the night like ships in fog. [A.3, A.4]

Then came the darkest hour of the Elder Days. Vitor discovered that TIME_CMD, when exported to the environment, *poisoned* the issue files of every vassal who tried to reproduce a bug on a different system. The Dragon's venom had seeped into the very parchment of their bug reports.

"TIME_CMD is not portable," Vitor wrote in a commit message that would echo through the ages. "Do not save it." [A.5]

The peoples learned a hard lesson: the Dragon's name must not be spoken aloud in certain company, lest it summon the BSD Shapeshifter.

---

## Chapter II: The Age of Parsing Grief

*Years 2023-2024. The long middle period of suffering.*

The parsing of `time`'s output fell to the Python-scribes, keepers of the sacred scrolls `genElapsedTime.py` and `genMetrics.py`. These scrolls would be amended twenty-eight times across the age, each amendment a scar upon the land.

### The Colon Wars

**Habibayassin**, a scribe from distant lands, noticed that the sacred parser could not tell hours from minutes. "0:02.08" it read, and declared: *two minutes and eight seconds*.

But nay — it was two seconds and eight hundredths.

A **failed harvest** ensued. Designs that took seconds were recorded as taking minutes. The accounting books of the realm were in chaos.

The scribe filed a report. Then another scribe filed a *different* report. A PR was opened by **Oyvind of Harboe**, a northern lord who had recently taken interest in the flow. The PR was reviewed, found wanting, closed, and superseded by another. Finally **Matt of Liberty**, the King himself, rode forth from the castle to deliver the true fix.

Three PRs to parse a colon. The Dragon of Ambiguity laughed from its cave. [A.6, A.7, A.8]

### The Vanishing Harvests

Matt of Liberty, having gazed into the abyss of the parser, discovered yet another horror: *sub-second harvests vanished entirely*. A design that completed in 0.7 seconds was recorded as having taken no time at all, as if it had never existed. The smallest, fastest designs — the most efficient harvests — were erased from history.

"Handle zero elapsed time," he wrote, with the quiet exhaustion of a king who has seen too much. [A.9, A.10]

### The Exclusion Wars

The parser had a fatal flaw: it searched *all* scrolls for the sacred words "Elapsed time." This worked until the realm expanded.

The **EQY Beasts** came first — verification logs that wandered into the parser's den and confused it into silence. Vitor of Bandeira taught the parser to avert its gaze. [A.11]

Then the **Empty Scrolls** — stages that produced nothing, causing the parser to crash like a cart hitting a wall. Oyvind of Harboe patched this quietly one December morning, the ground frozen outside his northern window. [A.12]

### A Treasure in the Darkness: Hash Logging

Yet amid the grief, there was a gift. In the summer of 2025, Oyvind introduced **hash logging** — content hashes of .odb files printed alongside elapsed times, so that divergent results between local and CI builds could be detected at a glance. It was a *treasure* born of pain, for only someone who had debugged CI divergences for hours would think to add such a thing. [A.18]

### The Lines-After-Elapsed-Time Catastrophe

Then came the **lines-after-the-elapsed-time bug**. Additional output after the sacred timing line would *reset* the parsed values to None, erasing the timing data as if the Dragon had breathed upon it. All records: gone. All peak memory measurements: vanished.

Matt of Liberty returned from the inner chambers to fix this with a single `break` statement. One word. Six characters. It should have been there from the beginning. But the Dragon's children — the Troll, the Goblin, the Imp — had made the code so tangled that no one had seen the gap. [A.13]

Then came the LEC check logs. Another exclusion. The list grew. [A.14]

The parser had become a creature of negation — defined not by what it *did*, but by the ever-growing list of things it must *not* look at.

---

## Chapter III: Hzeller the Grey of Bazel-Gorge

Now we must speak of **Henner of Zeller**, called Hzeller the Grey by those who knew him well.

Hzeller the Grey carried two weapons against the forces of darkness.

The first was his **Staff of Nix** -- a legendary artifact of terrible power. Nix could, in theory, banish *all* dependency creatures at once. It could summon any tool in any version from any era, perfectly reproducible, hermetically sealed. The peoples of Middle-ORFS looked upon the Staff of Nix with a mixture of awe and dread. They *wanted* one. Oh, how they wanted one. They had seen what it could do -- how Hzeller the Grey could conjure an entire build environment from a single incantation, how every dependency was pinned and accounted for, how no troll or goblin could hide in a Nix-built realm.

But the Staff of Nix was not easily mastered. It had a will of its own. It would suddenly pose riddles to its wielder -- questions about flake inputs and overlay compositions and `buildInputs` versus `nativeBuildInputs` -- and if you did not answer promptly and play along, the Staff grew *cantankerous*. It would refuse to evaluate. It would emit error messages in a dialect that no mortal could parse. Many had tried to wield the Staff and been driven back, muttering about "infinite recursion" and "attribute set update at unexpected location."

And so the peoples feared Nix, even as they envied it.

Hzeller the Grey's second weapon was the **Potion of Bazel** -- a magical brew that, when applied to a build, rendered it hermetic and reproducible. Where the Staff of Nix controlled the *environment*, the Potion of Bazel controlled the *build itself*. Every input declared. Every output cached. Every dependency visible and accounted for. The Potion was Hzeller the Grey's weapon of choice against the dependency creatures -- the trolls and goblins that lurked in undeclared `PATH` entries and surprise system packages. Bazel's sandbox was a clean room where no creature could hide.

Or so they thought. For the Dragon of Ambiguity had been hiding in the one place no one had checked: the *absence* of `env time` inside the sandbox.

Henner was a wizard of builds. Where others saw Makefiles, he saw the deep structures of dependency. Where others accepted that `env time` was simply how things worked, Henner saw it for what it was: a *troll squatting in the dependency tree*, ugly and unnecessary, blocking the road for every traveler who wished to build without Docker.

Henner had built bazel-orfs -- a parallel civilization that used the Potion of Bazel instead of Make to orchestrate the flow. It was cleaner, more reproducible, hermetically sealed. But it shared the same roads as Middle-ORFS, and those roads were haunted.

"I noticed that as well," Henner said when the Dragon's latest attack was reported. He said it quietly, as wizards do, but his meaning was clear: *I have seen this evil. I know its true name. And it must be destroyed.*

"Why not use the built-in `time` from Tcl?" he offered -- a measured suggestion, as one might suggest a different path around a mountain.

But the Dragon was too deeply entangled with the Python -- that great serpent with whom the peoples had their uneasy detente. The Tcl path would mean yet another domain crossing -- another border where format strings could be misunderstood, where colons could be misinterpreted, where minutes could be confused with seconds. Better to stay within the serpent's domain, where at least the treachery was *familiar*.

Hzeller the Grey nodded. He understood. The solution must come from within.

---

## Chapter IV: The Shock at Bazel-Gorge

*April 7, 2026. The present day.*

The peoples of bazel-orfs had long run their builds inside Docker containers, where GNU `time` was always present, installed as surely as stone in a mountain. But then came the **Great Dockerless Migration** — a noble effort to shed the Docker dependency, letting Bazel manage everything directly.

It was a season of great harvests. Oyvind had just enabled twelve previously-blocked designs for Bazel builds. He had added bazel-orfs support to *all* public-PDK platforms. The fields were wider than they had ever been. [A.19, A.20]

And then, on the seventh day of April, a traveler named **Arya** arrived at the gates of bazel-orfs with a terrible message:

```
env: 'time': No such file or directory
```

Arya was running Debian 13. Bazel 8.6.0. Everything was correct. But inside the Bazel sandbox — that pristine, hermetic chamber where builds run in isolation — `time` did not exist. It had *never* existed. The sandbox knew nothing of `time`. [A.15]

The Dragon of Ambiguity had been lurking inside the Bazel sandbox all along, invisible, because Docker had always shielded the peoples from its absence. Now, with Docker gone, the Dragon was exposed — or rather, its *absence* was exposed, which was somehow worse.

Oyvind of Harboe stared at his screen. He had *just* finished building `make` from source for Bazel. He had dealt with the mock-array CPU sourcing incident. He had extracted `variables.mk` from the Makefile. And now the Dragon demanded that he build GNU `time` from source too? Package it as a Bazel dependency? Ship a *binary* just to measure how long other binaries took to run?

"One wouldn't think so," he wrote in the issue, "but `time` is ambiguous."

He paused. He looked at the Pipeline of Sorrows in its entirety:

**Make** defines TIME_CMD with a GNU-specific format string. The **Troll of Eval** expands it because it contains spaces. The **Dragon** runs the command and prints to stderr. The **Goblin of Tee** copies stderr to both console and log. The **Imp of Stdbuf** is sometimes needed to unbuffer the Goblin. **Python** parses the text with regexes that have been wrong at least four times. **More Python** parses it *again* with different regexes in a different file. The **Wraith of Pipefail** haunts every pipeline. The Makefile *explicitly excludes* TIME_CMD from variable exports because the Dragon is not portable. Users find their logs by running `ps -Af | grep tee`, searching for the Goblin's footprints.

"I wonder," he wrote slowly, "if this is better solved by removing this dependency entirely."

---

## Chapter V: The Council at the Forge

Hzeller the Grey spoke his piece. The northern lords conferred.

"ORFS ties this into their regression infrastructure, which is always in Python," said Oyvind. "I think the best solution is to stick to one domain -- Python. I think that would reduce this *shocking amount of pain* we get here from switching between domains."

There was an uneasy murmur. The Python -- that great serpent -- was not beloved. Everyone knew it did dirty deals with the dependencies behind their backs. Just last month, Ashnaa of Seth had discovered that the Python had been *leaking file descriptors* in genMetrics.py, hoarding open files like a dragon hoards gold. [A.22] But the Python was *there*. It was already part of the flow. And the alternative -- adding yet another domain crossing, yet another border where formats could be misunderstood -- was worse.

"We don't love the serpent," Oyvind said. "But we have a detente. And a detente with *one* creature is better than open warfare with five."

And so the common folk gathered at the forge. They assembled their evidence -- the twenty-eight commits, the ten pull requests, the four authors who had each independently discovered that parsing the output of a three-headed Dragon with regexes was a Sisyphean task.

They forged a new weapon -- *from the serpent's own scales*.

The weapon was called `run_command.py`. It was 116 lines of Python. It used `time.monotonic()` for wall time, `resource.getrusage()` for CPU time and peak memory, and `subprocess.Popen` with a readline loop that flushed after every line -- so that the peoples could still watch their harvests grow with `tail -f`, that ancient and beloved tradition of staring at log files for hours during long CTS runs.

It slew:
- The **Dragon of Ambiguity** (`env time`) -- replaced by `resource.getrusage()`
- The **Goblin of Tee** (`2>&1 | tee`) -- replaced by Python file I/O with flush
- The **Troll of Eval** (`eval "$TIME_CMD ..."`) -- no longer needed
- The **Imp of Stdbuf** (`stdbuf -o L`) -- Python's readline loop is inherently line-buffered
- Fifteen parenthesized subshell incantations in the Makefile
- The TIME_CMD exclusion curse in the variable export filter

And it had *nineteen unit tests*, including one that verified the log file path was visible in `ps` output, so that the peoples' ancient scrying ritual of `ps -Af | grep tee` could be replaced by the equally effective `ps -Af | grep run_command` or `ps -Af | grep tmp.log`.

The serpent, for its part, seemed pleased with the arrangement. More code in its domain meant more power. But the peoples had learned to live with that. Better one serpent you know than five creatures you can't control.

---

## Chapter VI: The Petition to the King

And so they marched to the castle of Precision Innovation, where **King MaLiberty** held court over the realm.

The King was not a distant ruler. He was a warrior-king — a builder-king — who had fought in the trenches alongside his people. The git scrolls bore witness:

- `93ad8d4bc` — His hand had fixed the colon parsing. He had looked
  upon "0:02.08" and known it was two seconds, not two minutes and
  eight seconds, and he had written the truth into the code.
- `ab171aac5` — His hand had caught the vanishing harvests. He had
  seen sub-second designs erased from history and restored them.
- `f22634158` — His hand had added the `break`. One word. Six
  characters. Saving every timing record from being overwritten by the
  lines that followed.

The King *knew* the Dragon. He had fought it three times and carried the scars.

"Your Majesty," said Oyvind, kneeling. "We have come to petition for the destruction of the Dragon."

The King looked up from his scroll — a `genElapsedTime.py` diff, as it happened. He had *suffered*.

"Show me the evidence," said the King.

They unrolled the git log. Twenty-eight commits. Five years. Four authors including the King himself. The King studied it in silence.

"And your weapon?"

"Pure Python, Your Majesty. Nineteen tests. Same output format. No external dependencies. Works on macOS. The downstream parsers need not change — the format string lives on, but now it is produced by our own hand, not by the Dragon's."

The King nodded slowly. "I will consider it."

He rose from his throne and walked to the window. Below, the CI pipelines of the realm stretched to the horizon — Jenkins jobs, GitHub Actions, Docker images frozen in amber, custom platforms maintained by far lords who had not visited the castle in years.

"Know this," he said. "There are lands beyond our borders. CI systems with ancient configurations. Monitoring dashboards that grep for `tee` in ways we cannot imagine. Platform configurations that have been stable for years *precisely because nobody has touched them*. I must consult with the far lords before I render judgment."

---

## Epilogue: The Waiting

Does the story end here? We do not know.

The petition has been filed. The code has been written. The tests pass -- all twenty-four of them (nineteen new, five existing that prove the format compatibility).

Hzeller the Grey watches from the eastern tower, his Staff of Nix glowing faintly in the dusk, a fresh batch of the Potion of Bazel cooling on his workbench. He has seen the dependencies for what they are -- trolls and goblins squatting in the build tree -- and he knows they must be driven out. But he is patient. He has built Bazel cathedrals before. He knows that the right solution, applied at the right time, is worth more than a hasty fix. And he knows that if the petition fails, he can always brew a stronger potion.

King MaLiberty deliberates. He is wise. He has seen what the common folk have not. He knows of the far kingdoms and their strange customs.

Oyvind of Harboe returns to his fields. He is a good-hearted farmer -- tireless, ingenious, sometimes too clever for his own good. His solutions to the many problems he encounters are always born of real need, forged in the heat of actual failed harvests, not dreamed up in ivory towers. But they are sometimes... *unconventional*. A PR here that gets closed and superseded. A variables.mk extraction there that raises eyebrows before its wisdom becomes clear. He presents each invention to the King with the earnest enthusiasm of a man who has been up since dawn wrestling with a broken build, and the King -- who has seen many such inventions -- examines each one carefully, sometimes approving, sometimes redirecting, always guiding.

This petition is no different. It is born of real pain. It solves a real problem. But the King must weigh it against the needs of the whole realm, not just the northern fields.

And yet, the common folk remain hopeful. For the git history has shown them something important:

**The King has suffered too.**

Three times he rode out to fix the parser. Three times he returned with a patch. He knows the pain. He has parsed the colons. He has counted the minutes that were actually seconds. He has added the `break` that should have been there from the start.

The common folk wait. Oyvind returns to his fields and starts on the next problem -- there is always a next problem, and the sun will not wait. Hzeller the Grey stirs his potion. The Python coils silently in the corner, watching, waiting, doing deals with `pip` when it thinks nobody is looking.

And every time they see:

```
Elapsed time: 0:04.26[h:]min:sec. CPU time: user 4.08 sys 0.17 (99%). Peak memory: 671508KB.
```

They know that somewhere in the distance, nineteen unit tests are keeping watch.

---

*"One does not simply parse the output of `/usr/bin/time`."*
*-- Boromir of Bandeira, shortly before his regex was broken by a format change*

*"I noticed that as well."*
*-- Hzeller the Grey, leaning on the Staff of Nix, before everyone else understood the gravity of the situation*

---

## Appendix A: The Chronicle (git-dated)

All references point to [The-OpenROAD-Project/OpenROAD-flow-scripts](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts) unless otherwise noted.

### A.1 -- Fix /usr/bin/time output formatting (2021-07-29)
- **PR**: [#109](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/109)
- **Commit**: [`e7b140d9e`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/e7b140d9e)
- **Hero**: Andreas of Kuster
- **Dragon**: Format mismatch -- spaces and word order wrong in time output. Five comments at the gate.

### A.2 -- New time format to include CPU seconds (2022-03)
- **Commit**: [`a88a7c03c`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/a88a7c03c)
- **Hero**: Vitor of Bandeira
- **Dragon**: Changed the format string. Broke every downstream parser. A bold move with collateral damage.

### A.3 -- Adjust wall time, cpu and peak memory regex (attempt 1) (2022)
- **Commit**: [`00749e79e`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/00749e79e)
- **Hero**: Andreas of Kuster
- **Dragon**: Had to fix regexes in genMetrics.py after the format change.

### A.4 -- Adjust wall time, cpu and peak memory regex (attempt 2) (2022)
- **Commit**: [`16b0be7c2`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/16b0be7c2)
- **Hero**: Andreas of Kuster
- **Dragon**: Had to fix regexes *again* in a *different* file. Two files, two regexes, same format, both wrong.

### A.5 -- TIME_CMD is not portable, do not save it (2022)
- **Commit**: [`44c455cc8`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/44c455cc8)
- **Hero**: Vitor of Bandeira
- **Dragon**: Exported TIME_CMD poisoned issue files on non-GNU systems. The Dragon's name, written on parchment, summoned the BSD Shapeshifter.

### A.6 -- Elapsed time regression: hours vs minutes (2023-04-20)
- **PR**: [#967](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/967) (closed, superseded)
- **Hero**: Oyvind of Harboe
- **Dragon**: genElapsedTime.py couldn't distinguish hours from minutes. PR opened, reviewed, closed, superseded. A failed harvest.

### A.7 -- util: genElapsedTime module and test adjustments (2023-05-03)
- **PR**: [#1014](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1014)
- **Hero**: Habibayassin
- **Dragon**: Yet another attempt to get the parser right. The colon wars continued.

### A.8 -- Fix genElapsedTime.py: "0:02.08" is 2s not 2m8s (2023-05-03)
- **PR**: [#1036](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1036)
- **Commit**: [`93ad8d4bc`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/93ad8d4bc)
- **Hero**: King MaLiberty himself
- **Dragon**: Three PRs to parse a colon. The King rode forth personally. The Dragon laughed.

### A.9 -- Elapsed time for small designs: sub-second rounds to zero (2023-05-04)
- **Issue**: [#1043](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/1043)
- **Dragon**: The vanishing harvests. Designs completed in 0.7s recorded as 0s. Erased from history.

### A.10 -- Handle zero elapsed time in genElapsedTime.py (2023-05-04)
- **PR**: [#1044](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1044)
- **Commit**: [`ab171aac5`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/ab171aac5)
- **Hero**: King MaLiberty
- **Dragon**: The King's second ride. He restored the vanishing harvests.

### A.11 -- Do not look for elapsed time in eqy files (2024-01-16)
- **PR**: [#1761](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1761)
- **Commit**: [`b947b5c4d`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/b947b5c4d)
- **Hero**: Vitor of Bandeira
- **Dragon**: The Exclusion Wars begin. EQY beasts wandered into the parser's den.

### A.12 -- Fix elapsed time for empty log files (2023-12-20)
- **PR**: [#1716](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1716)
- **Commit**: [`7cd9e14ec`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/7cd9e14ec)
- **Hero**: Oyvind of Harboe
- **Dragon**: Empty scrolls crashed the parser. Fixed one December morning, ground frozen outside.

### A.13 -- genElapsedTime.py: handle lines after the elapsed time line (2025-07-09)
- **PR**: [#3307](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3307)
- **Commit**: [`f22634158`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/f22634158)
- **Hero**: King MaLiberty (third ride)
- **Dragon**: Additional output lines reset parsed timing values to None. Fixed with one `break`. Six characters. Should have been there from the start.

### A.14 -- Exclude lec check log from elapsed time extraction (2026-02-25)
- **PR**: [#3927](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/3927)
- **Commit**: [`31b6b5f54`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/31b6b5f54)
- **Hero**: Jeff Ng
- **Dragon**: Yet another log type. The exclusion list grows. The parser is defined by what it must not see.

### A.15 -- env: 'time': No such file or directory (2026-04-07)
- **Issue**: [The-OpenROAD-Project/bazel-orfs#651](https://github.com/The-OpenROAD-Project/bazel-orfs/issues/651)
- **Reporter**: Arya
- **Council**: Oyvind of Harboe, Hzeller the Grey
- **Dragon**: The final straw. GNU time doesn't exist in the Bazel sandbox. The Dragon was invisible all along -- Docker had been shielding the peoples from its absence.

### A.16 -- Fix gaffe in elapsed seconds summary, account for hours (2023)
- **PR**: [#722](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/722)
- **Commit**: [`f53e1a2de`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/f53e1a2de)
- **Dragon**: Hours were not accounted for in the elapsed seconds summary. The Dragon's three-headed time format strikes again.

### A.17 -- Adding total elapsed time (2023-11-28)
- **PR**: [#1663](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1663)
- **Commit**: [`87e80c4ad`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/87e80c4ad)
- **Treasure**: 6 comments of discussion to add a total row. A small treasure hard-won.

### A.18 -- Hash logging for divergent result detection (2025-07)
- **Commits**: [`c537a7e91`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/c537a7e91), [`a272e75cd`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/a272e75cd)
- **Hero**: Oyvind of Harboe
- **Treasure**: Content hashes of .odb files alongside elapsed times. A gift born of pain -- only one who had debugged CI divergences for hours would think to add it.

### A.19 -- Enable 12 previously-blocked designs for Bazel (2026-04-03)
- **Commit**: [`fede39fa0`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/fede39fa0)
- **Hero**: Oyvind of Harboe
- **Treasure**: A great harvest. Twelve new fields opened for cultivation.

### A.20 -- Add bazel-orfs support to all public-PDK platforms (2026-04-02)
- **Commit**: [`61031d198`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/61031d198)
- **Hero**: Oyvind of Harboe
- **Treasure**: The greatest expansion of the realm in recent memory. All public PDKs supported.

### A.21 -- Simpler to maintain test_genElapsedTime.py (2024)
- **PR**: [#1968](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/1968)
- **Commit**: [`2694cfd1d`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/2694cfd1d)
- **Dragon**: The test file *itself* had become too painful to maintain. When your tests for the parser are as fragile as the parser, you know the Dragon has won a round.

### A.22 -- The Python's file descriptor hoarding (2026-03-28)
- **PR**: [#4066](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4066)
- **Commits**: [`7b03fa0b8`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/7b03fa0b8), [`f094e248d`](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/commit/f094e248d)
- **Hero**: Ashnaa of Seth
- **Serpent**: The Python had been leaking file descriptors in genMetrics.py -- hoarding open files like a dragon hoards gold. A reminder that the detente requires constant vigilance.

## Appendix B: The Body Count

| Hero | Commits | Wounds |
|------|---------|--------|
| Vitor of Bandeira | 36 | Created TIME_CMD, broke it, fixed it, declared it non-portable, fought the EQY beasts |
| Oyvind of Harboe | 27 | Good-hearted farmer. Tireless worker of the land. Ingenious but sometimes flawed solutions. Fixed empty logs, extracted variables.mk, PR closed and superseded, built make from source for Bazel. Always presents his inventions to the King. |
| King MaLiberty | 13 | Three rides: the colon parsing, the vanishing harvests, the lines-after-elapsed-time catastrophe |
| Habibayassin | 4 | Discovered the hours-vs-minutes ambiguity, attempted the fix |
| Andreas of Kuster | 4 | Fixed formatting twice, adjusted regexes twice, both times cleaning up after someone else |
| Jeff Ng | 1 | Added the lec exclusion. One more entry in the ever-growing filter. |
| Hzeller the Grey | 0 (in ORFS) | Built bazel-orfs with the Potion of Bazel. Carries the Staff of Nix. Saw the dependencies for what they were. Spoke truth at the council. |

## Appendix C: The Pipeline of Sorrows (Before)

```
Make (variables.mk)
  | defines TIME_CMD with GNU-specific format string
  | runs TIME_TEST to check if format works
  | falls back silently if it doesn't (output won't parse)
  | exports TIME_CMD (but also excludes it from get_variables)
  v
The Troll of Eval (flow.sh / synth.sh)
  | receives TIME_CMD as environment variable
  | must use eval because TIME_CMD contains spaces and quotes
  | wraps in subshell: ($(TIME_CMD) command) 2>&1 | tee logfile
  v
The Dragon of Ambiguity (env time)
  | must be installed (not available in Bazel sandbox)
  | must be GNU time, not BSD time (different flags)
  | must be found via `env time` (not the shell builtin)
  | writes timing to stderr in a specific format
  v
The Goblin of Tee
  | copies merged stdout+stderr to console AND log file
  | complicates error propagation
  | sometimes needs the Imp of Stdbuf for line buffering
  v
The Wraith of Pipefail
  | haunts every pipeline
  | ensures failures propagate in the most confusing way
  v
Python (genElapsedTime.py)
  | parses "Elapsed time: ..." with string splitting
  | has been wrong about hours vs minutes vs seconds
  | has crashed on empty files, zero times, extra lines
  | maintains a growing exclusion list
  v
Python (genMetrics.py)
  | parses the SAME line with DIFFERENT regexes
  | tries 4 different datetime format strings in sequence
  | sets total_elapsed_seconds to "ERR" on parse failure
  v
JSON metrics
```

## Appendix D: The Pipeline of Hope (After)

```
Make (variables.mk)
  | defines RUN_CMD = $(PYTHON_EXE) $(FLOW_HOME)/scripts/run_command.py
  v
Python (run_command.py)  -- 116 lines, 19 unit tests
  | runs command via subprocess.Popen
  | measures wall time (time.monotonic)
  | measures CPU time + peak memory (resource.getrusage)
  | streams output line-by-line with flush (tail -f works)
  | writes to console AND log file (no tee needed)
  | appends "Elapsed time: ..." in same format
  | works on Linux and macOS
  | no external dependencies
  v
Python (genElapsedTime.py) -- unchanged, parses same format
Python (genMetrics.py) -- unchanged, parses same format
  v
JSON metrics
```

## Appendix E: Dramatis Personae

| Character | Real Person | Role |
|-----------|-------------|------|
| King MaLiberty | Matt Liberty | Maintainer of OpenROAD-flow-scripts. Three-time dragon slayer. |
| Vitor of Bandeira | Vitor Bandeira | First steward. Forged TIME_CMD. Also broke it. |
| Oyvind of Harboe | Oyvind Harboe | Good-hearted farmer. Tireless worker of the land. Ingenious, sometimes flawed solutions he presents to the King for guidance. Builder of the Bazel bridge. |
| Hzeller the Grey | Henner Zeller | Wizard of builds. Carries the Staff of Nix (feared, envied, riddling) and brews the Potion of Bazel against the dependencies. |
| Andreas of Kuster | Andreas Kuster | Humble farmer. Fixed the formatting. Twice. |
| Habibayassin | Habibayassin | Scribe from distant lands. Discovered the colon ambiguity. |
| Jeff Ng | Jeff Ng | Added one more exclusion to the ever-growing list. |
| Arya | Arya (bazel-orfs#651) | Traveler who brought news of the Dragon's absence in the sandbox. |
| The Python | Python 3 | A great serpent. Uneasy detente with the peoples. Useful but treacherous -- does dirty deals with dependencies behind everyone's backs. Hoards file descriptors. |
| The Dragon of Ambiguity | `env time` / GNU time | Three-headed: Shell builtin, GNU binary, BSD shapeshifter. |
| The Troll of Eval | `eval "$TIME_CMD ..."` | Could only understand commands shouted twice through quoting. |
| The Goblin of Tee | `2>&1 \| tee` | Pipe-dweller. Intercepted messages. Sometimes swallowed errors. |
| The Imp of Stdbuf | `stdbuf -o L` | Summoned because the Goblin refused to pass messages promptly. |
| The Wraith of Pipefail | `set -o pipefail` | Ghost. Haunted every pipeline. Not evil per se, but unsettling. |