### PR TITLE
Support SLANG_PLUGIN_PATH env var for custom slang plugin location

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -273,6 +273,7 @@ configuration file.
 | <a name="SKIP_REPAIR_TIE_FANOUT"></a>SKIP_REPAIR_TIE_FANOUT| Skip repair_tie_fanout at floorplan step.| 0|
 | <a name="SKIP_REPORT_METRICS"></a>SKIP_REPORT_METRICS| If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds.| 0|
 | <a name="SKIP_VT_SWAP"></a>SKIP_VT_SWAP| Do not perform VT swap to improve QoR (default: do VT swap).| |
+| <a name="SLANG_PLUGIN_PATH"></a>SLANG_PLUGIN_PATH| Path to the slang plugin for Yosys. This can be a full path to a custom-built plugin (e.g. for Bazel builds) or just the plugin name.| slang|
 | <a name="SLEW_MARGIN"></a>SLEW_MARGIN| Specifies a slew margin when fixing max slew violations. This option allows you to overfix.| |
 | <a name="SWAP_ARITH_OPERATORS"></a>SWAP_ARITH_OPERATORS| Improve timing QoR by swapping ALU and MULT arithmetic operators.| |
 | <a name="SYNTH_ARGS"></a>SYNTH_ARGS| Optional synthesis variables for yosys.| |
@@ -326,6 +327,7 @@ configuration file.
 - [PRE_SYNTH_TCL](#PRE_SYNTH_TCL)
 - [SDC_FILE](#SDC_FILE)
 - [SDC_GUT](#SDC_GUT)
+- [SLANG_PLUGIN_PATH](#SLANG_PLUGIN_PATH)
 - [SYNTH_ARGS](#SYNTH_ARGS)
 - [SYNTH_BLACKBOXES](#SYNTH_BLACKBOXES)
 - [SYNTH_CANONICALIZE_TCL](#SYNTH_CANONICALIZE_TCL)

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -44,7 +44,11 @@ proc read_design_sources { } {
   }
 
   if { [env_var_equals SYNTH_HDL_FRONTEND slang] } {
-    plugin -i slang
+    if { [info exists ::env(SLANG_PLUGIN_PATH)] } {
+      plugin -i $::env(SLANG_PLUGIN_PATH)
+    } else {
+      plugin -i slang
+    }
 
     set slang_args [list \
       -D SYNTHESIS --keep-hierarchy --compat=vcs --ignore-assertions --top $::env(DESIGN_NAME) \

--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -44,11 +44,7 @@ proc read_design_sources { } {
   }
 
   if { [env_var_equals SYNTH_HDL_FRONTEND slang] } {
-    if { [info exists ::env(SLANG_PLUGIN_PATH)] } {
-      plugin -i $::env(SLANG_PLUGIN_PATH)
-    } else {
-      plugin -i slang
-    }
+    plugin -i $::env(SLANG_PLUGIN_PATH)
 
     set slang_args [list \
       -D SYNTHESIS --keep-hierarchy --compat=vcs --ignore-assertions --top $::env(DESIGN_NAME) \

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -238,6 +238,13 @@ SYNTH_HDL_FRONTEND:
     command.
   stages:
     - synth
+SLANG_PLUGIN_PATH:
+  description: >
+    Path to the slang plugin for Yosys. This can be a full path to a
+    custom-built plugin (e.g. for Bazel builds) or just the plugin name.
+  default: slang
+  stages:
+    - synth
 SYNTH_SLANG_ARGS:
   description: >
     Additional arguments passed to the slang frontend during synthesis.


### PR DESCRIPTION
When SYNTH_HDL_FRONTEND=slang, the plugin load is hardcoded as `plugin -i slang`.  This adds a check for SLANG_PLUGIN_PATH, falling back to the current behavior when unset.

This enables Bazel-built slang plugins to be loaded from a custom path, which is needed for downstream consumers that build yosys-slang from source.