### PR TITLE
Add all PDKs and export variables.yaml in Bazel build

### DIFF
--- a/flow/BUILD.bazel
+++ b/flow/BUILD.bazel
@@ -1,5 +1,10 @@
 load("@bazel-orfs//:openroad.bzl", "orfs_pdk")
 
+exports_files(
+    ["scripts/variables.yaml"],
+    visibility = ["//visibility:public"],
+)
+
 # files shared between scripts/synth.sh and scripts/flow.sh steps
 MAKEFILE_SHARED = [
     "scripts/*.py",
@@ -16,6 +21,7 @@ filegroup(
         "scripts/*.script",
         "scripts/util.tcl",
         "scripts/synth*.tcl",
+        "scripts/synth*.v",
         "platforms/common/**/*.v",
     ]) + [
         "//flow/util:makefile_yosys",
@@ -46,25 +52,40 @@ filegroup(
         for ext in [
             "gds",
             "lef",
-            "lib",
+            "lyp",
             "lyt",
             "mk",
             "rules",
             "tcl",
             "v",
         ] + {
-            "sky130hd": ["tlef"],
-            "asap7": [
-                "lib.gz",
-                "sdc",
-            ],
+            "asap7": ["cfg", "json", "lib.gz", "sdc"],
+            "gf180": ["cfg", "layermap", "lyt_generic"],
+            "ihp-sg13g2": ["json"],
+            "nangate45": ["cfg"],
+            "sky130hd": ["json", "tlef"],
+            "sky130hs": ["json", "tlef"],
         }.get(pdk, [])
     ] + [
         "platforms/common/**/*.v",
+    ]),
+    libs = glob([
+        "platforms/{pdk}/**/*.{ext}".format(
+            pdk = pdk,
+            ext = ext,
+        )
+        for ext in {
+            "asap7": ["lib", "lib.gz"],
+            "gf180": ["lib.gz"],
+        }.get(pdk, ["lib"])
     ]),
     config = ":platforms/{pdk}/config.mk".format(pdk = pdk),
     visibility = ["//visibility:public"],
 ) for pdk in [
     "asap7",
+    "gf180",
+    "ihp-sg13g2",
+    "nangate45",
     "sky130hd",
+    "sky130hs",
 ]]


### PR DESCRIPTION
Add orfs_pdk definitions for gf180, ihp-sg13g2, nangate45, and sky130hs.  These platform directories already exist but were not exposed to Bazel consumers (only asap7 and sky130hd were defined).

Also:
- Export scripts/variables.yaml for external variable metadata access
- Add synth*.v to makefile_yosys glob (picks up synth_wrap_operators-booth.v)
- Add lyp, cfg, json, layermap, lyt_generic extensions per PDK
- Separate lib/lib.gz into libs attribute (gf180 has only .lib.gz)