### PR TITLE
Clarify detailed-route metrics for antenna repair reroutes

### DIFF
--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -57,14 +57,21 @@ if {
   !$::env(SKIP_ANTENNA_REPAIR_POST_DRT) &&
   [env_var_exists_and_non_empty MAX_REPAIR_ANTENNAS_ITER_DRT]
 } {
-  set repair_antennas_iters 1
-  if { [repair_antennas] } {
-    detailed_route {*}$all_args
-  }
+  set repair_antennas_iters 0
+  set repair_antennas_count -1
+  utl::set_metrics_stage "detailedroute__drt__repair_antennas__pre_repair__{}"
   while { [check_antennas] && $repair_antennas_iters < $::env(MAX_REPAIR_ANTENNAS_ITER_DRT) } {
-    repair_antennas
+    utl::set_metrics_stage "detailedroute__drt__repair_antennas__iter_${repair_antennas_iters}__{}"
+    set repair_antennas_count [repair_antennas]
     detailed_route {*}$all_args
     incr repair_antennas_iters
+  }
+  utl::set_metrics_stage "detailedroute__{}"
+  if { $repair_antennas_count == -1 } {
+    # Preserve the top-level diode count metric even when no post-DRT repair is needed.
+    repair_antennas
+  } else {
+    utl::metric_int "antenna_diodes_count" $repair_antennas_count
   }
 } else {
   utl::metric_int "antenna_diodes_count" -1

--- a/flow/scripts/detail_route.tcl
+++ b/flow/scripts/detail_route.tcl
@@ -59,14 +59,15 @@ if {
 } {
   set repair_antennas_iters 0
   set repair_antennas_count -1
-  utl::set_metrics_stage "detailedroute__drt__repair_antennas__pre_repair__{}"
+  utl::push_metrics_stage "detailedroute__{}__pre_repair"
   while { [check_antennas] && $repair_antennas_iters < $::env(MAX_REPAIR_ANTENNAS_ITER_DRT) } {
-    utl::set_metrics_stage "detailedroute__drt__repair_antennas__iter_${repair_antennas_iters}__{}"
+    utl::push_metrics_stage "detailedroute__{}__repair_iter_${repair_antennas_iters}"
     set repair_antennas_count [repair_antennas]
     detailed_route {*}$all_args
+    utl::pop_metrics_stage
     incr repair_antennas_iters
   }
-  utl::set_metrics_stage "detailedroute__{}"
+  utl::pop_metrics_stage
   if { $repair_antennas_count == -1 } {
     # Preserve the top-level diode count metric even when no post-DRT repair is needed.
     repair_antennas


### PR DESCRIPTION
## What does this PR do?
Fixes #3651 
This change makes detailed-route metrics easier to interpret when post-DRT antenna repair triggers additional reroutes.

Previously, repeated reroutes could write to the same plain detailed-route metric keys, which made it unclear which value represented the final route and which values came from antenna-repair iterations.

With this update:
- the first antenna check after detailed routing is recorded under a `pre_repair` stage
- each repair-driven reroute is recorded under its own `iter_N` stage
- the normal top-level detailed-route metrics remain intact for downstream ORFS metadata checks

This keeps the metrics unambiguous without breaking existing consumers that still expect the top-level `detailedroute__antenna_diodes_count` field.

## Validation

Validated with:
- `python3 -m unittest discover -s flow/test -p 'test_*.py'`
**Expected output:**
```bash
python3 -m unittest discover -s flow/test -p 'test_*.py'

.......................
----------------------------------------------------------------------
Ran 39 tests in 0.049s

OK
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
	/tmp/a.gds
	/tmp/b.gds
	/tmp/c.gds
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
	/tmp/cells.gds
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] GDS_ALLOW_EMPTY=pad_.*
[ERROR] LEF Cell 'other_cell' has no matching GDS/OAS cell. Cell will be empty.
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] GDS_ALLOW_EMPTY=pad_.*
[WARNING] LEF Cell 'pad_io_cell' ignored. Matches GDS_ALLOW_EMPTY.
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[ERROR] LEF Cell 'missing_gds' has no matching GDS/OAS cell. Cell will be empty.
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[ERROR] Found orphan cell 'orphan_cell'
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Reporting cells prior to loading DEF ...
[INFO] All LEF cells have matching GDS/OAS cells
[INFO] No orphan cells in the final layout
[INFO] Merging 'seal_ring' as child of 'test_design'
/var/folders/g0/0tdm2_hj22l7kp855lz7xp9w0000gn/T/tmp8nvfygkg
```
- `make DESIGN_CONFIG=./designs/sky130hd/gcd/config.mk clean_route route metadata-generate metadata-check`
**Expected output:**
```bash
make DESIGN_CONFIG=./designs/sky130hd/gcd/config.mk clean_route route metadata-generate metadata-check

[INFO DRT-0198] Complete detail routing.
Total wire length = 8466 um.
Total wire length on LAYER li1 = 0 um.
Total wire length on LAYER met1 = 4104 um.
Total wire length on LAYER met2 = 3951 um.
Total wire length on LAYER met3 = 299 um.
Total wire length on LAYER met4 = 110 um.
Total wire length on LAYER met5 = 0 um.
Total number of vias = 2678.

[INFO ANT-0002] Found 0 net violations.
[INFO ANT-0001] Found 0 pin violations.
[INFO GRT-0012] Found 0 antenna violations.
[INFO ANT-0002] Found 0 net violations.
[INFO ANT-0001] Found 0 pin violations.

write_db ./results/sky130hd/gcd/base/5_2_route.odb

/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 /Users/alokkumardalei/Desktop/open-road-flowscripts/OpenROAD-flow-scripts/flow/util/genMetrics.py -d gcd \
        -p sky130hd \
        -v base \
        --logs ./logs/sky130hd/gcd/base \
        --reports ./reports/sky130hd/gcd/base \
        --results ./results/sky130hd/gcd/base \
        -o ./reports/sky130hd/gcd/base/metadata.json 2>&1 \
        | tee /Users/alokkumardalei/Desktop/open-road-flowscripts/OpenROAD-flow-scripts/flow/reports/sky130hd/gcd/base/metadata-generate.log

[WARN] Tag synth__design__instance__count__stdcell not found in ./reports/sky130hd/gcd/base/synth_stat.txt. Will use N/A.
[WARN] Tag finish__runtime__total not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.
[WARN] Tag finish__cpu__total not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.
[WARN] Tag finish__mem__peak not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.
[WARN] Tag synth__runtime__total not found in ./logs/sky130hd/gcd/base/1_2_yosys.log. Will use N/A.
[WARN] Tag synth__cpu__total not found in ./logs/sky130hd/gcd/base/1_2_yosys.log. Will use N/A.
[WARN] Tag synth__mem__peak not found in ./logs/sky130hd/gcd/base/1_2_yosys.log. Will use N/A.
[WARN] Tag floorplan__runtime__total not found in ./logs/sky130hd/gcd/base/2_1_floorplan.log. Will use N/A.
[WARN] Tag floorplan__cpu__total not found in ./logs/sky130hd/gcd/base/2_1_floorplan.log. Will use N/A.
[WARN] Tag floorplan__mem__peak not found in ./logs/sky130hd/gcd/base/2_1_floorplan.log. Will use N/A.
[WARN] Tag globalplace_skip_io__runtime__total not found in ./logs/sky130hd/gcd/base/3_1_place_gp_skip_io.log. Will use N/A.
[WARN] Tag globalplace_skip_io__cpu__total not found in ./logs/sky130hd/gcd/base/3_1_place_gp_skip_io.log. Will use N/A.
[WARN] Tag globalplace_skip_io__mem__peak not found in ./logs/sky130hd/gcd/base/3_1_place_gp_skip_io.log. Will use N/A.
[WARN] Tag globalplace_io__runtime__total not found in ./logs/sky130hd/gcd/base/3_2_place_iop.log. Will use N/A.
[WARN] Tag globalplace_io__cpu__total not found in ./logs/sky130hd/gcd/base/3_2_place_iop.log. Will use N/A.
[WARN] Tag globalplace_io__mem__peak not found in ./logs/sky130hd/gcd/base/3_2_place_iop.log. Will use N/A.
[WARN] Tag globalplace__runtime__total not found in ./logs/sky130hd/gcd/base/3_3_place_gp.log. Will use N/A.
[WARN] Tag globalplace__cpu__total not found in ./logs/sky130hd/gcd/base/3_3_place_gp.log. Will use N/A.
[WARN] Tag globalplace__mem__peak not found in ./logs/sky130hd/gcd/base/3_3_place_gp.log. Will use N/A.
[WARN] Tag placeopt__runtime__total not found in ./logs/sky130hd/gcd/base/3_4_place_resized.log. Will use N/A.
[WARN] Tag placeopt__cpu__total not found in ./logs/sky130hd/gcd/base/3_4_place_resized.log. Will use N/A.
[WARN] Tag placeopt__mem__peak not found in ./logs/sky130hd/gcd/base/3_4_place_resized.log. Will use N/A.
[WARN] Tag detailedplace__runtime__total not found in ./logs/sky130hd/gcd/base/3_5_place_dp.log. Will use N/A.
[WARN] Tag detailedplace__cpu__total not found in ./logs/sky130hd/gcd/base/3_5_place_dp.log. Will use N/A.
[WARN] Tag detailedplace__mem__peak not found in ./logs/sky130hd/gcd/base/3_5_place_dp.log. Will use N/A.
[WARN] Tag cts__runtime__total not found in ./logs/sky130hd/gcd/base/4_1_cts.log. Will use N/A.
[WARN] Tag cts__cpu__total not found in ./logs/sky130hd/gcd/base/4_1_cts.log. Will use N/A.
[WARN] Tag cts__mem__peak not found in ./logs/sky130hd/gcd/base/4_1_cts.log. Will use N/A.
[WARN] Tag globalroute__runtime__total not found in ./logs/sky130hd/gcd/base/5_1_grt.log. Will use N/A.
[WARN] Tag globalroute__cpu__total not found in ./logs/sky130hd/gcd/base/5_1_grt.log. Will use N/A.
[WARN] Tag globalroute__mem__peak not found in ./logs/sky130hd/gcd/base/5_1_grt.log. Will use N/A.
[WARN] Overwriting Tag finish__runtime__total
[WARN] Tag finish__runtime__total not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.
[WARN] Overwriting Tag finish__cpu__total
[WARN] Tag finish__cpu__total not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.
[WARN] Overwriting Tag finish__mem__peak
[WARN] Tag finish__mem__peak not found in ./logs/sky130hd/gcd/base/6_report.log. Will use N/A.

/Library/Frameworks/Python.framework/Versions/3.12/bin/python3 /Users/alokkumardalei/Desktop/open-road-flowscripts/OpenROAD-flow-scripts/flow/util/checkMetadata.py \
        -m ./reports/sky130hd/gcd/base/metadata.json \
        -r ./designs/sky130hd/gcd//rules-base.json 2>&1 \
        | tee /Users/alokkumardalei/Desktop/open-road-flowscripts/OpenROAD-flow-scripts/flow/reports/sky130hd/gcd/base/metadata-check.log

[INFO] synth__design__instance__area__stdcell pass test: 2641.2832 <= 2760
[INFO] constraints__clocks__count pass test: 1 == 1
[INFO] placeopt__design__instance__area pass test: 4055.14 <= 4161
[INFO] placeopt__design__instance__count__stdcell pass test: 483 <= 506
[INFO] detailedplace__design__violations pass test: 0 == 0
[INFO] cts__design__instance__count__setup_buffer pass test: 26 <= 44
[INFO] cts__design__instance__count__hold_buffer pass test: 0 <= 42
[INFO] cts__timing__setup__ws pass test: -1.71908 >= -2.27
[INFO] cts__timing__setup__tns pass test: -77.9556 >= -95.5
[INFO] cts__timing__hold__ws pass test: 0.490061 >= -0.055
[INFO] cts__timing__hold__tns pass test: 0 >= -0.22
[INFO] globalroute__antenna_diodes_count pass test: 0 <= 100
[INFO] globalroute__timing__setup__ws pass test: -1.91062 >= -2.42
[INFO] globalroute__timing__setup__tns pass test: -86.3301 >= -99.7
[INFO] globalroute__timing__hold__ws pass test: 0.541119 >= -0.055
[INFO] globalroute__timing__hold__tns pass test: 0 >= -0.22
[INFO] detailedroute__route__wirelength pass test: 8466 <= 9945
[INFO] detailedroute__route__drc_errors pass test: 0 <= 0
[INFO] detailedroute__antenna__violating__nets pass test: 0 <= 0
[INFO] detailedroute__antenna_diodes_count pass test: 0 <= 100
[INFO] finish__timing__setup__ws pass test: -1.80295 >= -2.28
[INFO] finish__timing__setup__tns pass test: -81.2492 >= -92.8
[INFO] finish__timing__hold__ws pass test: 0.541146 >= -0.055
[INFO] finish__timing__hold__tns pass test: 0 >= -0.22
[INFO] finish__design__instance__area pass test: 4904.7 <= 5797
Metadata check warnings: 0
All metadata rules passed (25 rules)
```

I also verified the multi-iteration repair path with the OpenROAD `ibex_sky130hd` test, which produced separate `iter_0`, `iter_1`, and `iter_2` route metrics as expected.
