### PR TITLE
Improve macOS build support with dependencies validation

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -253,8 +253,64 @@ __docker_build()
 __local_build()
 {
         if [[ "$OSTYPE" == "darwin"* ]]; then
-                export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk)/bin:$PATH"
-                export CMAKE_PREFIX_PATH=$(brew --prefix or-tools)
+                        
+                _bison=$(brew --prefix bison 2>/dev/null || true)
+                _flex=$(brew --prefix flex 2>/dev/null || true)
+                _ortools=$(brew --prefix or-tools 2>/dev/null || true)
+
+                if [[ -z "$_bison" || ! -d "$_bison/bin" ]]; then
+                        echo "[ERROR] bison not found or broken. Run: brew install bison" >&2
+                        exit 1
+                fi
+                if [[ -z "$_flex" || ! -d "$_flex/bin" ]]; then
+                        echo "[ERROR] flex not found or broken. Run: brew install flex" >&2
+                        exit 1
+                fi
+                if [[ -z "$_ortools" || ! -d "$_ortools/lib" || ! -d "$_ortools/include" ]]; then
+                        echo "[ERROR] or-tools not found or broken. Run: brew install or-tools" >&2
+                        exit 1
+                fi
+
+                export PATH="$_bison/bin:$_flex/bin:$PATH"
+                export CMAKE_PREFIX_PATH="${_ortools}"
+
+                _qt5=$(brew --prefix qt@5 2>/dev/null || true)
+                if [[ -z "$_qt5" || ! -d "$_qt5/lib" ]]; then
+                        echo "[ERROR] qt@5 not found or broken. Run: brew install qt@5" >&2
+                        exit 1
+                fi
+                
+                cmakeOptions+=" -DQt5_DIR=$_qt5/lib/cmake/Qt5"
+
+                _tcl8=$(brew --prefix tcl-tk@8 2>/dev/null || true)     
+                if [[ -z "$_tcl8" || ! -d "$_tcl8/lib" || ! -d "$_tcl8/include" ]]; then
+                        echo "[ERROR] tcl-tk@8 not found or broken. Run: brew install tcl-tk@8" >&2
+                        exit 1
+                fi
+                
+                cmakeOptions+=" -DTCL_LIBRARY=$_tcl8/lib/libtcl8.6.dylib"
+
+                cmakeOptions+=" -DTCL_INCLUDE_PATH=$_tcl8/include"
+                cmakeOptions+=" -DFLEX_INCLUDE_DIR=$_flex/include"
+
+                cmakeOptions+=" -DCMAKE_CXX_FLAGS=-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED"
+
+                _icu="$(brew --prefix icu4c 2>/dev/null || true)"
+                if [[ -z "$_icu" || ! -d "$_icu/lib" ]]; then
+                        echo "[ERROR] icu4c not found or broken. Run: brew install icu4c" >&2
+                        exit 1
+                fi
+
+                export LDFLAGS="-L$_icu/lib"
+                export CPPFLAGS="-I$_icu/include" 
+                export PKG_CONFIG_PATH="$_icu/lib/pkgconfig"
+
+                _extra_lib_paths=("/opt/homebrew/lib")
+
+                _joined_paths="$(IFS=:; echo "${_extra_lib_paths[*]}")"
+
+                export LIBRARY_PATH="${_joined_paths}${LIBRARY_PATH:+:$LIBRARY_PATH}"
+                echo "[INFO] General LIBRARY_PATH=$LIBRARY_PATH"
         fi
         if [[ -f "/opt/rh/rh-python38/enable" ]]; then
                 set +u

--- a/dev_env.sh
+++ b/dev_env.sh
@@ -10,6 +10,7 @@ function __setpaths() {
 
     if [[ "$OSTYPE" == "darwin"* ]]; then
         export CMAKE_PREFIX_PATH="$(brew --prefix or-tools)"
+        export QT_QPA_PLATFORM=cocoa
     fi
 }
 __setpaths

--- a/env.sh
+++ b/env.sh
@@ -17,7 +17,7 @@ function __setpaths() {
 
   if [[ "$OSTYPE" == "darwin"* ]]; then
     export PATH="/Applications/KLayout/klayout.app/Contents/MacOS:$PATH"
-    export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk)/bin:$PATH"
+    export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk@8)/bin:$PATH"
   fi
 
   export FLOW_HOME=$DIR/flow

--- a/env.sh
+++ b/env.sh
@@ -18,6 +18,7 @@ function __setpaths() {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     export PATH="/Applications/KLayout/klayout.app/Contents/MacOS:$PATH"
     export PATH="$(brew --prefix bison)/bin:$(brew --prefix flex)/bin:$(brew --prefix tcl-tk@8)/bin:$PATH"
+    export QT_QPA_PLATFORM=cocoa
   fi
 
   export FLOW_HOME=$DIR/flow

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -37,10 +37,23 @@ _installPipCommon() {
         set -u
     fi
     local pkgs="pandas numpy firebase_admin click pyyaml yamlfix"
-    if [[ $(id -u) == 0 ]]; then
-        pip3 install --no-cache-dir -U $pkgs
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if [[ "$EUID" -eq 0 ]]; then
+            echo "Error: Do NOT run with sudo."
+            exit 1
+        fi
+        if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+            pip3 install --no-cache-dir -U $pkgs
+        else
+            echo "Error: Activate a virtual environment on macOS."
+            exit 1
+        fi
     else
-        pip3 install --no-cache-dir --user -U $pkgs
+        if [[ $(id -u) == 0 ]]; then
+            pip3 install --no-cache-dir -U $pkgs
+        else
+            pip3 install --no-cache-dir --user -U $pkgs
+        fi
     fi
 }
 

--- a/flow/scripts/synth.sh
+++ b/flow/scripts/synth.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -u -eo pipefail
 mkdir -p $RESULTS_DIR $LOG_DIR $REPORTS_DIR $OBJECTS_DIR
+touch $2
 $YOSYS_EXE -V > $(realpath $2)
 $PYTHON_EXE "$SCRIPTS_DIR/run_command.py" --log "$(realpath $2)" --append --tee -- \
   $YOSYS_EXE $YOSYS_FLAGS -c $1

--- a/setup.sh
+++ b/setup.sh
@@ -35,6 +35,18 @@ elif grep -q "^+" "$tmpfile"; then
   exit 1
 fi
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [[ ! -d "$DIR/.venv" ]]; then
+    echo "Creating Python virtual environment at $DIR/.venv"
+    python3 -m venv "$DIR/.venv"
+  fi
+
+  echo "Activating virtual environment"
+  source "$DIR/.venv/bin/activate"
+
+  python -m pip install --upgrade pip
+fi
+
 "$DIR/etc/DependencyInstaller.sh" -base
 if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"


### PR DESCRIPTION
This PR improves macOS support to the OpenROAD-flow-scripts build process.

ref #4022

- **build_openroad.sh**: 
  - bison, flex, or-tools, qt@5, tcl-tk@8, icu4c
  - Added CMake options for macOS builds
  - Proper error handling if dependencies are missing
  
- **setup.sh**: 
  - Support for Python virtual environments (.venv)
  - Pip configuration for macOS environments
  
- **etc/DependencyInstaller.sh**: 
  - Enhanced Homebrew package validation
  - Better error messaging and dependency checks
  
- **dev_env.sh**: Added `QT_QPA_PLATFORM=cocoa` for Qt on macOS

- **flow/scripts/synth.sh**: Fixed log file creation issue

- **env.sh**: Updated tcl-tk formula reference to tcl-tk@8

<img width="1920" height="1050" alt="Screenshot 2026-04-12 at 4 03 52 PM" src="https://github.com/user-attachments/assets/a30da501-ced5-45d9-8c8e-7814dec14d44" />

