### PR TITLE
WDT32: Add reset to wden_p to fix WDOV X-propagation after reset

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = ../../The-OpenROAD-Project/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
-	url = https://github.com/The-OpenROAD-Project/OpenROAD.git
+	url = ../OpenROAD.git
 [submodule "tools/yosys-slang"]
 	path = tools/yosys-slang
 	url = https://github.com/povik/yosys-slang.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = ../../The-OpenROAD-Project/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
-	url = ../OpenROAD.git
+	url = https://github.com/The-OpenROAD-Project/OpenROAD.git
 [submodule "tools/yosys-slang"]
 	path = tools/yosys-slang
 	url = https://github.com/povik/yosys-slang.git

--- a/flow/designs/src/chameleon/IPs/WDT32.v
+++ b/flow/designs/src/chameleon/IPs/WDT32.v
@@ -40,8 +40,9 @@ module WDT32 (
 	end
 	
 	reg wden_p;
-	always @(posedge clk) 
-	  wden_p <= WDEN;
+	always @(posedge clk or posedge rst)
+	  if (rst) wden_p <= 1'b0;
+	  else     wden_p <= WDEN;
 
 	always @(posedge clk or posedge rst)
 	begin

--- a/flow/designs/src/chameleon_hier/rtl/IPs/WDT32.v
+++ b/flow/designs/src/chameleon_hier/rtl/IPs/WDT32.v
@@ -40,8 +40,9 @@ module WDT32 (
 	end
 	
 	reg wden_p;
-	always @(posedge clk) 
-	  wden_p <= WDEN;
+	always @(posedge clk or posedge rst)
+        if (rst) wden_p <= 1'b0;
+        else     wden_p <= WDEN;
 
 	always @(posedge clk or posedge rst)
 	begin


### PR DESCRIPTION
### 1. SUMMARY

This PR fixes a reset inconsistency in the `wden_p` register within the WDT32 module that leads to simulation/synthesis mismatch during startup. The issue affects how the `WDOV` signal is computed immediately after reset due to an uninitialized register.
Primary changes are in `flow/designs/src/chameleon/IPs/WDT32.v` within the WDT32 module.

---

### 2. FIX

```verilog
// Before
always @(posedge clk)
  wden_p <= WDEN;

// After
always @(posedge clk or posedge rst)
  if (rst) wden_p <= 1'b0;
  else     wden_p <= WDEN;
```

---

### 3. VERIFICATION

Simulated reset sequence with `WDEN=1` asserted during reset and observed `WDOV` behavior after deassertion. The signal no longer transitions to `X` and remains stable at `0` until valid conditions are met. Behavior now matches synthesis, eliminating mismatch and X-propagation.
