### PR TITLE
flow: scripts: include filler cells in CDL netlist for LVS accuracy

### DIFF
--- a/flow/scripts/cdl.tcl
+++ b/flow/scripts/cdl.tcl
@@ -2,4 +2,5 @@ source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables final
 load_design 6_final.odb 6_final.sdc
 
-write_cdl -masters $::env(CDL_FILE) $::env(RESULTS_DIR)/6_final.cdl
+write_cdl -masters $::env(CDL_FILE) -include_fillers \
+  $::env(RESULTS_DIR)/6_final.cdl


### PR DESCRIPTION
Pass -include_fillers to write_cdl so filler cells appear in the exported CDL netlist. Without this, LVS tools may flag filler instances as unresolved.

This change is required to run LVS tests with the IHP PDK.