### PR TITLE
flow: platforms: {gf180,sky130}: allow PDK path overrides via weak assignment

### DIFF
--- a/flow/platforms/gf180/config.mk
+++ b/flow/platforms/gf180/config.mk
@@ -13,12 +13,12 @@ export PROCESS                                = 180
 #----------------------------------------------------
 # OpenROAD
 #----------------------------------------------------
-export TECH_LEF                               = $(PLATFORM_DIR)/lef/gf180mcu_$(METAL_OPTION)_$(KVALUE)K_$(TRACK_OPTION)_tech.lef
+export TECH_LEF                              ?= $(PLATFORM_DIR)/lef/gf180mcu_$(METAL_OPTION)_$(KVALUE)K_$(TRACK_OPTION)_tech.lef
 
 export SC_LEF                                ?= $(PLATFORM_DIR)/lef/gf180mcu_$(METAL_OPTION)_$(KVALUE)K_$(TRACK_OPTION)_sc.lef
 
-export GDS_FILES                              = $(wildcard $(PLATFORM_DIR)/gds/$(TRACK_OPTION)/*.gds) \
-                                                $(ADDITIONAL_GDS)
+export GDS_FILES                             ?= $(wildcard $(PLATFORM_DIR)/gds/$(TRACK_OPTION)/*.gds)
+export GDS_FILES                             += $(ADDITIONAL_GDS)
 
 # Dont use cells 
 export DONT_USE_CELLS                         = *_1
@@ -118,17 +118,17 @@ export RCX_RC_CORNER                          = $($(CORNER)_RCX_RC_CORNER)
 #----------------------------------------------------------------------------------------------------
 # standard cell section
 #----------------------------------------------------------------------------------------------------
-export BC_LIB_FILES                           = $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__ff_n40C_5v50.lib.gz)
-export BC_TEMPERATURE                         = -40c
-export BC_VOLTAGE                             = 5.5
+export BC_LIB_FILES                          ?= $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__ff_n40C_5v50.lib.gz)
+export BC_TEMPERATURE                        ?= -40c
+export BC_VOLTAGE                            ?= 5.5
 
-export WC_LIB_FILES                           = $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__ss_125C_4v50.lib.gz)
-export WC_TEMPERATURE                         = 125c
-export WC_VOLTAGE                             = 4.5
+export WC_LIB_FILES                          ?= $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__ss_125C_4v50.lib.gz)
+export WC_TEMPERATURE                        ?= 125c
+export WC_VOLTAGE                            ?= 4.5
 
-export TC_LIB_FILES                           = $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__tt_025C_5v00.lib.gz)
-export TC_TEMPERATURE                         = 25c
-export TC_VOLTAGE                             = 5.0
+export TC_LIB_FILES                          ?= $(abspath $(PLATFORM_DIR)/lib/gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__tt_025C_5v00.lib.gz)
+export TC_TEMPERATURE                        ?= 25c
+export TC_VOLTAGE                            ?= 5.0
 
 # ----------------------------------------------------------------------------------------------------
 # now, set files from user setting CORNER

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -4,13 +4,13 @@ export PROCESS = 130
 #-----------------------------------------------------
 # Tech/Libs
 # ----------------------------------------------------
-export TECH_LEF = $(PLATFORM_DIR)/lef/sky130_fd_sc_hd.tlef
-export SC_LEF = $(PLATFORM_DIR)/lef/sky130_fd_sc_hd_merged.lef
+export TECH_LEF ?= $(PLATFORM_DIR)/lef/sky130_fd_sc_hd.tlef
+export SC_LEF ?= $(PLATFORM_DIR)/lef/sky130_fd_sc_hd_merged.lef
 
-export LIB_FILES = $(PLATFORM_DIR)/lib/sky130_fd_sc_hd__tt_025C_1v80.lib \
-                     $(ADDITIONAL_LIBS)
-export GDS_FILES = $(wildcard $(PLATFORM_DIR)/gds/*.gds) \
-                     $(ADDITIONAL_GDS)
+export LIB_FILES ?= $(PLATFORM_DIR)/lib/sky130_fd_sc_hd__tt_025C_1v80.lib
+export LIB_FILES += $(ADDITIONAL_LIBS)
+export GDS_FILES ?= $(wildcard $(PLATFORM_DIR)/gds/*.gds)
+export GDS_FILES += $(ADDITIONAL_GDS)
 
 # Dont use cells to ease congestion
 # Specify at least one filler cell if none

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -4,13 +4,13 @@ export PROCESS = 130
 #-----------------------------------------------------
 # Tech/Libs
 # ----------------------------------------------------
-export TECH_LEF = $(PLATFORM_DIR)/lef/sky130_fd_sc_hs.tlef
-export SC_LEF = $(PLATFORM_DIR)/lef/sky130_fd_sc_hs_merged.lef
+export TECH_LEF ?= $(PLATFORM_DIR)/lef/sky130_fd_sc_hs.tlef
+export SC_LEF ?= $(PLATFORM_DIR)/lef/sky130_fd_sc_hs_merged.lef
 
-export LIB_FILES = $(PLATFORM_DIR)/lib/sky130_fd_sc_hs__tt_025C_1v80.lib \
-                     $(ADDITIONAL_LIBS)
-export GDS_FILES = $(wildcard $(PLATFORM_DIR)/gds/*.gds) \
-                     $(ADDITIONAL_GDS)
+export LIB_FILES ?= $(PLATFORM_DIR)/lib/sky130_fd_sc_hs__tt_025C_1v80.lib
+export LIB_FILES += $(ADDITIONAL_LIBS)
+export GDS_FILES ?= $(wildcard $(PLATFORM_DIR)/gds/*.gds)
+export GDS_FILES += $(ADDITIONAL_GDS)
 
 # Dont use cells to ease congestion
 # Specify at least one filler cell if none


### PR DESCRIPTION
Convert TECH_LEF, SC_LEF, LIB_FILES, and GDS_FILES from strong (`=`) to weak (`?=`) assignment so users can substitute a custom PDK version by setting these variables before including the platform config, without modifying ORFS-provided files.
