### PR TITLE
autotuner: add unit tests for parse_flow_variables and parse_tunable_variables

### DIFF
--- a/flow/test/test_autotuner.sh
+++ b/flow/test/test_autotuner.sh
@@ -13,6 +13,9 @@ cd ../
 ./tools/AutoTuner/installer.sh
 . ./tools/AutoTuner/setup.sh
 
+echo "Running Autotuner utility tests"
+python3 -m unittest tools.AutoTuner.test.test_utils
+
 echo "Running Autotuner smoke tune test"
 python3 -m unittest tools.AutoTuner.test.smoke_test_tune.${PLATFORM_WITHOUT_DASHES}TuneSmokeTest.test_tune
 

--- a/tools/AutoTuner/test/test_utils.py
+++ b/tools/AutoTuner/test/test_utils.py
@@ -1,0 +1,153 @@
+#############################################################################
+##
+## BSD 3-Clause License
+##
+## Copyright (c) 2026, Precision Innovations Inc.
+## All rights reserved.
+##
+## Redistribution and use in source and binary forms, with or without
+## modification, are permitted provided that the following conditions are met:
+##
+## * Redistributions of source code must retain the above copyright notice, this
+##   list of conditions and the following disclaimer.
+##
+## * Redistributions in binary form must reproduce the above copyright notice,
+##   this list of conditions and the following disclaimer in the documentation
+##   and/or other materials provided with the distribution.
+##
+## * Neither the name of the copyright holder nor the names of its
+##   contributors may be used to endorse or promote products derived from
+##   this software without specific prior written permission.
+##
+## THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+## AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+## IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+## ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+## LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+## CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+## SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+## INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+## CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+## ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+## POSSIBILITY OF SUCH DAMAGE.
+##
+###############################################################################
+
+import os
+import sys
+import tempfile
+import unittest
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+src_dir = os.path.join(cur_dir, "../src")
+sys.path.insert(0, src_dir)
+
+from autotuner import utils
+
+
+class ParseFlowVariablesTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.flow_dir = os.path.join(self.tmp_dir.name, "flow")
+        self.scripts_dir = os.path.join(self.flow_dir, "scripts")
+        os.makedirs(self.scripts_dir)
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def _write_file(self, path, contents):
+        with open(path, "w") as file:
+            file.write(contents)
+
+    def test_parse_flow_variables_from_scripts_and_vars_tcl(self):
+        self._write_file(
+            os.path.join(self.scripts_dir, "floorplan.tcl"),
+            """
+            set util $::env(core_utilization)
+            set margin $env(CORE_MARGIN)
+            """,
+        )
+        self._write_file(
+            os.path.join(self.scripts_dir, "route.tcl"),
+            """
+            if {$::env(FASTROUTE_TCL) != ""} {
+              puts $::env(FASTROUTE_TCL)
+            }
+            """,
+        )
+        self._write_file(
+            os.path.join(self.flow_dir, "vars.tcl"),
+            """
+            set ::env(PLACE_DENSITY) 0.7
+            """,
+        )
+
+        with patch.object(
+            utils.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=0),
+        ) as run:
+            variables = utils.parse_flow_variables(self.tmp_dir.name, "sky130hd")
+
+        run.assert_called_once_with(
+            ["make", "-C", self.flow_dir, "vars", "PLATFORM=sky130hd"],
+            capture_output=True,
+        )
+        self.assertEqual(
+            variables,
+            {
+                "CORE_UTILIZATION",
+                "CORE_MARGIN",
+                "FASTROUTE_TCL",
+                "PLACE_DENSITY",
+            },
+        )
+
+    def test_parse_flow_variables_exits_when_make_fails(self):
+        with patch.object(
+            utils.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=2),
+        ):
+            with patch("sys.stdout", new=StringIO()) as stdout:
+                with self.assertRaises(SystemExit):
+                    utils.parse_flow_variables(self.tmp_dir.name, "sky130hd")
+
+        self.assertIn("[ERROR TUN-0018]", stdout.getvalue())
+
+    def test_parse_flow_variables_exits_when_vars_tcl_is_missing(self):
+        with patch.object(
+            utils.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=0),
+        ):
+            with patch("sys.stdout", new=StringIO()) as stdout:
+                with self.assertRaises(SystemExit):
+                    utils.parse_flow_variables(self.tmp_dir.name, "sky130hd")
+
+        self.assertIn("[ERROR TUN-0019]", stdout.getvalue())
+
+
+class ParseTunableVariablesTest(unittest.TestCase):
+    def test_parse_tunable_variables_returns_only_tunable_keys(self):
+        variables_yaml = {
+            "CORE_UTILIZATION": {"tunable": 1},
+            "PLACE_DENSITY": {"tunable": 1},
+            "GENERATE_ARTIFACTS_ON_FAILURE": {"default": 0},
+            "DETAILED_METRICS": {"tunable": 0},
+        }
+
+        with patch("builtins.open", mock_open(read_data="unused")) as open_mock:
+            with patch.object(utils.yaml, "safe_load", return_value=variables_yaml):
+                variables = utils.parse_tunable_variables()
+
+        open_mock.assert_called_once()
+        self.assertEqual(variables, {"CORE_UTILIZATION", "PLACE_DENSITY"})
+        self.assertIsInstance(variables, set)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Two helper functions in `tools/AutoTuner/src/autotuner/utils.py` had explicit `TODO: Tests.` comments with no accompanying tests:

- `parse_flow_variables` (line 186) — parses environment variables from Tcl scripts and a generated `vars.tcl` file
- `parse_tunable_variables` (line 221) — reads `variables.yaml` and returns the set of variables marked as tunable

Note: `parse_flow_variables` was the original validation approach in `parse_config` before being superseded by `parse_tunable_variables` in `4458cacb`. The function remains defined with an explicit TODO and is tested here for completeness.

These functions are on the critical path: `parse_tunable_variables` is called by `parse_config` on every tuning run to validate which variables are allowed.

## Changes

- `tools/AutoTuner/test/test_utils.py` — new test file covering both functions
- `flow/test/test_autotuner.sh` — invoke the new tests before the smoke tests

## Test coverage

### `parse_flow_variables`

| Test | What it covers |
|---|---|
| `test_parse_flow_variables_from_scripts_and_vars_tcl` | Happy path: reads `scripts/*.tcl` and `vars.tcl`, extracts env vars via regex, normalises to uppercase, verifies `make vars` call signature |
| `test_parse_flow_variables_exits_when_make_fails` | `make` returns non-zero → prints `[ERROR TUN-0018]` and exits |
| `test_parse_flow_variables_exits_when_vars_tcl_is_missing` | `make` succeeds but `vars.tcl` is absent → prints `[ERROR TUN-0019]` and exits |

### `parse_tunable_variables`

| Test | What it covers |
|---|---|
| `test_parse_tunable_variables_returns_only_tunable_keys` | Returns only keys with `tunable=1`; excludes `tunable=0` and keys with no `tunable` field |

`subprocess.run` and `yaml.safe_load` are mocked at the module level so no Makefile or real `variables.yaml` is required. A real temporary filesystem is used for the Tcl file parsing to exercise the actual glob/regex/file-read path.