### PR TITLE
platforms: gf180: endcap_cpp is deprecated

### DIFF
--- a/flow/designs/gf180/uart-blocks/tapcell.tcl
+++ b/flow/designs/gf180/uart-blocks/tapcell.tcl
@@ -1,5 +1,4 @@
 tapcell \
-  -endcap_cpp "12" \
   -distance 100 \
   -tapcell_master $::env(TIE_CELL) \
   -endcap_master $::env(ENDCAP_CELL) \

--- a/flow/platforms/gf180/openROAD/tapcell.tcl
+++ b/flow/platforms/gf180/openROAD/tapcell.tcl
@@ -1,5 +1,4 @@
 tapcell \
-  -endcap_cpp "12" \
   -distance 100 \
   -tapcell_master $::env(TIE_CELL) \
   -endcap_master $::env(ENDCAP_CELL)


### PR DESCRIPTION
   [WARNING TAP-0014] endcap_cpp option is deprecated.
    
Remove this deprecated option, since it's not used in
OpenROAD's tapcell module anymore.
    
Also clean up the uart-blocks design for gf180.