### PR TITLE
make: preserve tool *_EXE env vars across UNSET_AND_MAKE

### DIFF
--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -188,7 +188,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
 export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 
 define get_variables
-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -188,7 +188,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
 export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 
 define get_variables
-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% PYTHON% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)


### PR DESCRIPTION
Commit df79ba1d9 ("make: immediately expand deferred vars") changed the tool-path setup from

    export OPENROAD_EXE ?= $(abspath ...)

to

    OPENROAD_EXE ?= $(abspath ...)
    export OPENROAD_EXE := $(OPENROAD_EXE)

The := reassign gives the variable origin "file" even when the value was supplied through the environment. UNSET_VARIABLES_NAMES collects every file-origin variable and $(UNSET_AND_MAKE) unsets them in the bash wrapper before invoking the submake. That strips a caller- supplied `OPENROAD_EXE / OPENSTA_EXE / YOSYS_EXE` from the submake's environment, and variables.mk re-derives them via the $(FLOW_HOME)/../tools/install/... fallback — a path that does not exist in hermetic builds (e.g. bazel-orfs).

Extend the unset exclusion list to cover OPENROAD%, OPENSTA%, YOSYS%, mirroring the KLAYOUT% entry already there for the same reason.

This restores the pre- df79ba1d9 behavior for callers that pass tool paths through the environment, without reverting the immediate- expansion fix.