### PR TITLE
QSPI_XIP_CTRL: Fix missing default assignment for HREADYOUT in st_rw state

### DIFF
--- a/flow/designs/src/chameleon/IPs/QSPI_XIP_CTRL.v
+++ b/flow/designs/src/chameleon/IPs/QSPI_XIP_CTRL.v
@@ -95,7 +95,7 @@ module QSPI_XIP_CTRL(
                             else HREADYOUT <= 1'b0;
                 st_rw   :   if(HTRANS[1] & HSEL & HREADY & c_hit) HREADYOUT <= 1'b1;
                             else if(HTRANS[1] & HSEL & HREADY & ~c_hit) HREADYOUT <= 1'b0;
-                            //else HREADYOUT <= 1'b1;
+                            else HREADYOUT <= 1'b1;
             endcase
         
 


### PR DESCRIPTION
### 1. SUMMARY

This PR fixes a missing default assignment for `HREADYOUT` in the `st_rw` state, which could cause it to hold a stale value. The change ensures correct ready signaling when no active transfer is present.
Primary changes are in `flow/designs/src/chameleon/IPs/QSPI_XIP_CTRL.v` within the `QSPI_XIP_CTRL` module.

---

### 2. FIX

```verilog
// Before
else if(HTRANS[1] & HSEL & HREADY & ~c_hit) HREADYOUT <= 1'b0;
// else HREADYOUT <= 1'b1;

// After
else if(HTRANS[1] & HSEL & HREADY & ~c_hit) HREADYOUT <= 1'b0;
else HREADYOUT <= 1'b1;
```

---

### 3. VERIFICATION

Simulated AHB transactions covering hit, miss, and idle conditions in `st_rw`. Previously, `HREADYOUT` could remain low after a stall; after the fix, it correctly returns to `1` when no transfer is active. Behavior is now consistent with protocol expectations and other FSM states.
