### PR TITLE
fix: strip Bazel runfiles env vars before spawning subprocesses

### DIFF
--- a/flow/scripts/run_command.py
+++ b/flow/scripts/run_command.py
@@ -18,6 +18,7 @@ infrastructure expects.
 """
 
 import argparse
+import os
 import resource
 import subprocess
 import sys
@@ -85,7 +86,14 @@ def run(argv: list[str] | None = None) -> int:
         log_file = open(args.log, "a" if args.append else "w")
 
     wall_start = time.monotonic()
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("RUNFILES_DIR", "RUNFILES_MANIFEST_FILE")
+    }
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
+    )
 
     try:
         for line in iter(proc.stdout.readline, b""):

--- a/flow/scripts/run_command.py
+++ b/flow/scripts/run_command.py
@@ -86,11 +86,9 @@ def run(argv: list[str] | None = None) -> int:
         log_file = open(args.log, "a" if args.append else "w")
 
     wall_start = time.monotonic()
-    env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in ("RUNFILES_DIR", "RUNFILES_MANIFEST_FILE")
-    }
+    env = os.environ.copy()
+    for var in ("RUNFILES_DIR", "RUNFILES_MANIFEST_FILE", "RUNFILES_MANIFEST_ONLY"):
+        env.pop(var, None)
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env
     )


### PR DESCRIPTION
The rules_python bootstrap wrapper sets RUNFILES_DIR to its own runfiles tree. When run_command.py spawned OpenROAD, it inherited that variable and looked for Tcl init files in the Python runfiles instead of its own, causing "application-specific initialization failed" in Bazel builds.