### PR TITLE
asap7/mock-cpu: fix fabricated hold budget at async-FIFO macro boundary

### DIFF
--- a/flow/designs/asap7/mock-cpu/config.mk
+++ b/flow/designs/asap7/mock-cpu/config.mk
@@ -7,6 +7,22 @@ export VERILOG_FILES = $(wildcard $(DESIGN_HOME)/src/fifo/*.v)
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 export SDC_FILE_EXTRA = $(DESIGN_HOME)/src/mock-array/util.tcl
 
+# The SDC references fifo_in/<pin> and fifo_out/<pin> directly. Two
+# knobs must agree to make those pin paths resolve in OpenSTA:
+#
+#   1. Yosys must keep the fifo1 module boundary through flattening.
+#      SYNTH_KEEP_MODULES doesn't work here because hierarchy elaboration
+#      specializes fifo1 into $paramod$<hash>\fifo1 before the flow's
+#      keep loop runs — instead we use an (* keep_hierarchy *) RTL
+#      attribute on the module itself (see src/fifo/fifo1.v).
+#
+#   2. OpenROAD must link the netlist hierarchically, otherwise
+#      link_design flattens the fifo_in / fifo_out instances even though
+#      Yosys preserved them. OPENROAD_HIERARCHICAL=1 switches link_design
+#      to -hier mode. (Same mechanism used by asap7/mock-alu, cva6,
+#      swerv_wrapper.)
+export OPENROAD_HIERARCHICAL = 1
+
 export CORE_UTILIZATION         = 40
 export CORE_ASPECT_RATIO        = 1
 export CORE_MARGIN              = 2

--- a/flow/designs/asap7/mock-cpu/constraint.sdc
+++ b/flow/designs/asap7/mock-cpu/constraint.sdc
@@ -1,6 +1,31 @@
-# https://gist.github.com/brabect1/7695ead3d79be47576890bbcd61fe426
+# mock-cpu: multi-clock async-FIFO bridge macro.
 #
-# This fifo is from http://www.sunburst-design.com/papers/CummingsSNUG2002SJ_FIFO1.pdf
+# PR #4170 idiom (multi-clock variant): optimization targets use
+# set_max_delay -ignore_clock_latency so hold-fixing does not invent
+# phantom budgets against the deep clock tree's insertion delay. See
+# flow/platforms/asap7/constraints.sdc lines 1-56 for the single-clock
+# rationale; this file can't `source` that template because mock-cpu
+# has two async clocks.
+#
+# The IO optimization targets below are deliberately surgical:
+# set_max_delay from top-level ports to fifo_in/<pin> and from
+# fifo_out/<pin> to top-level ports, rather than -to [all_registers] /
+# -from [all_registers]. Functionally equivalent for this topology
+# (all IO paths begin/end at the FIFO), but it exercises more flow
+# features — SYNTH_KEEP_MODULES hierarchy preservation, hierarchical
+# get_pins selection, and io2fifo/fifo2io path grouping. Intentional
+# regression coverage; do not "simplify" back to [all_registers].
+#
+# (* keep_hierarchy *) on the fifo1 module (src/fifo/fifo1.v) preserves
+# the FIFO instance boundary through Yosys flattening so the fifo_in/<pin>
+# and fifo_out/<pin> paths below resolve. An RTL attribute is used rather
+# than SYNTH_KEEP_MODULES because the latter matches exact module names
+# and hierarchy elaboration specializes fifo1 into $paramod$<hash>\fifo1
+# before SYNTH_KEEP_MODULES runs.
+#
+# FIFO RTL: Cummings SNUG 2002 — gray-coded pointers, 2-FF synchronizers
+# (sync_r2w, sync_w2r). Metastability handled by construction.
+# https://gist.github.com/brabect1/7695ead3d79be47576890bbcd61fe426
 
 source $::env(SDC_FILE_EXTRA)
 
@@ -10,57 +35,73 @@ set clk_period 333
 set clk2_period 1000
 
 set clk1_name clk
-create_clock -name $clk1_name -period $clk_period -waveform \
-  [list 0 [expr $clk_period/2]] [get_ports $clk1_name]
+create_clock -name $clk1_name -period $clk_period \
+  -waveform [list 0 [expr $clk_period/2]] [get_ports $clk1_name]
 set_clock_uncertainty 10 [get_clocks $clk1_name]
 
 set clk2_name clk_uncore
-create_clock -name $clk2_name -period $clk2_period -waveform \
-  [list 0 [expr $clk_period/2]] [get_ports $clk2_name]
+create_clock -name $clk2_name -period $clk2_period \
+  -waveform [list 0 [expr $clk2_period/2]] [get_ports $clk2_name]
 set_clock_uncertainty 10 [get_clocks $clk2_name]
+
 set_clock_groups -group $clk1_name -group $clk2_name -asynchronous -allow_paths
 
+# Async reset distribution.
 set_false_path -from [get_ports *rst_n]
 set_false_path -to [get_ports *rst_n]
 
-# The mock-cpu is a macro connecting to a slower peripheral bus and possibly DRAM.
-# Avoid using set_input/output_delay here.
-# Register-to-register paths are checked at the mock-cpu level or from the mock-cpu
-# .lib file to an external register.
-# Timing closure is ensured at the SoC level where the mock-cpu is connected.
-# Instead, set strict optimization targets for inputs and outputs to ensure
-# constraints are not too loose.
-set non_clk_inputs {}
-set clock_ports [list [get_ports $clk1_name] [get_ports $clk2_name]]
-foreach input [all_inputs] {
-  if { [lsearch -exact $clock_ports $input] == -1 } {
-    lappend non_clk_inputs $input
-  }
-}
+# Timing firewall: surgical port <-> FIFO boundary optimization targets.
+# Internal 1024-stage pipeline is reg2reg, constrained by the clock
+# period alone. IO paths end/begin at the FIFO boundary — no further.
+set io_target 80
 
-set_max_delay 80 -from $non_clk_inputs -to [all_outputs]
-group_path -name in2out -from $non_clk_inputs -to [all_outputs]
+set fifo_in_wdata [get_pins fifo_in/wdata[*]]
+set fifo_in_winc [get_pins fifo_in/winc]
+set fifo_out_rinc [get_pins fifo_out/rinc]
 
-set all_register_outputs [get_pins -of_objects [all_registers] -filter {direction == output}]
-set_max_delay 80 -from $non_clk_inputs -to [all_registers]
-set_max_delay 80 -from $all_register_outputs -to [all_outputs]
-group_path -name in2reg -from $non_clk_inputs -to [all_registers]
+# Port -> FIFO. -to on a hierarchical instance input pin is accepted:
+# OpenSTA traverses into the instance and finds the leaf endpoint.
+set_max_delay -ignore_clock_latency $io_target \
+  -from [get_ports wdata*] -to $fifo_in_wdata
+set_max_delay -ignore_clock_latency $io_target \
+  -from [get_ports winc] -to $fifo_in_winc
+set_max_delay -ignore_clock_latency $io_target \
+  -from [get_ports rinc] -to $fifo_out_rinc
+
+# FIFO -> Port. The symmetric surgical form -from $fifo_out_<pin>
+# hits STA-1554 ("not a valid start point") because a hierarchical
+# instance output pin has no implicit launch clock. Use
+# [all_registers] instead — OPENROAD_HIERARCHICAL=1 plus the fifo1
+# keep_hierarchy makes [all_registers] enumerate leaf flops inside
+# fifo_out (fifomem and pointer-sync flops) whose Q pins are valid
+# start points, matching the platform template's single-clock form.
+# rdata is excluded here; it's false_path'd at the bottom.
+set_max_delay -ignore_clock_latency $io_target \
+  -from [all_registers] -to [get_ports rempty]
+set_max_delay -ignore_clock_latency $io_target \
+  -from [all_registers] -to [get_ports wfull]
+
+group_path -name io2fifo \
+  -from [all_inputs -no_clocks] \
+  -to [list $fifo_in_wdata $fifo_in_winc $fifo_out_rinc]
 group_path -name reg2out -from [all_registers] -to [all_outputs]
 group_path -name reg2reg -from [all_registers] -to [all_registers]
 
-## Dual clock fifo timing constraints
-# Using fastest clock as constaint
+# Dual-clock FIFO CDC: bound combinational delay on pointer-sync paths
+# (sync_r2w, sync_w2r) to the fastest clock period, ignore clock
+# latency (deep tree), and declare hold false — gray-coded pointers
+# and 2-FF synchronizers handle metastability by construction.
 set cdc_max_delay $clk_period
-
-# rdata from fifo_out goes directly to I/O-pins so we need special handling of this case
-# to ignore timing path from wclk -> rdata for this special case
-# In normal cases fifo output (rdata) will most likely have a FF on I/O output signal
-set_false_path -from $clk1_name -to [match_pins rdata* output 0]
-
-# Set timing constraint between clock domains
 set_max_delay $cdc_max_delay -from $clk1_name -to $clk2_name -ignore_clock_latency
 set_max_delay $cdc_max_delay -from $clk2_name -to $clk1_name -ignore_clock_latency
-
-# Hold times between clock domain makes no sense, and should just be ignored
 set_false_path -hold -from $clk1_name -to $clk2_name
 set_false_path -hold -from $clk2_name -to $clk1_name
+
+# rdata port has no launch FF on the IO side. It's driven
+# combinationally by fifo_out.fifomem (mem[raddr]):
+#   clk-clocked fifomem flops  -> rdata (wclk launch path)
+#   clk_uncore-clocked rbin    -> raddr -> mem mux -> rdata (rclk launch)
+# Both are "valid when rempty is low" by FIFO protocol, not a
+# single-cycle timing. Declare every path to rdata as false — normal
+# FIFO deployments would put an FF on rdata in the consumer domain.
+set_false_path -to [get_ports rdata*]

--- a/flow/designs/asap7/mock-cpu/rules-base.json
+++ b/flow/designs/asap7/mock-cpu/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__design__instance__area__stdcell": {
-        "value": 7302.54,
+        "value": 7400.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,11 +8,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 7379,
+        "value": 7471,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 46274,
+        "value": 47171,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -20,19 +20,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 530,
+        "value": 4102,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 530,
+        "value": 4102,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -89.5,
+        "value": -16.6,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1730.0,
+        "value": -66.6,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -48,11 +48,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -90.9,
+        "value": -16.6,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -2160.0,
+        "value": -66.6,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -64,7 +64,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 50994,
+        "value": 55508,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -80,23 +80,23 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -84.6,
-        "compare": ">="
-    },
-    "finish__timing__setup__tns": {
-        "value": -2050.0,
-        "compare": ">="
-    },
-    "finish__timing__hold__ws": {
         "value": -16.6,
         "compare": ">="
     },
-    "finish__timing__hold__tns": {
+    "finish__timing__setup__tns": {
         "value": -66.6,
         "compare": ">="
     },
+    "finish__timing__hold__ws": {
+        "value": -17.4,
+        "compare": ">="
+    },
+    "finish__timing__hold__tns": {
+        "value": -67.3,
+        "compare": ">="
+    },
     "finish__design__instance__area": {
-        "value": 7617,
+        "value": 8049,
         "compare": "<="
     }
 }

--- a/flow/designs/src/fifo/fifo1.v
+++ b/flow/designs/src/fifo/fifo1.v
@@ -1,3 +1,11 @@
+// (* keep_hierarchy *) preserves the fifo1 instance boundary (fifo_in,
+// fifo_out in mock_cpu) through Yosys flattening so the SDC can
+// reference fifo_in/<pin> and fifo_out/<pin> directly. SYNTH_KEEP_MODULES
+// doesn't work here because hierarchy elaboration specializes fifo1 into
+// $paramod$<hash>\fifo1 variants before the flow's SYNTH_KEEP_MODULES
+// loop runs. An RTL attribute rides through elaboration onto each
+// specialized clone.
+(* keep_hierarchy *)
 module fifo1 #(
     parameter DSIZE = 8,
     parameter ASIZE = 4


### PR DESCRIPTION
Fixes #3850: floorplan__timing__hold__ws reported 1e+42 and repair_timing reported "No paths found" for mock-cpu.

mock-cpu is a clock-domain-crossing bridge macro: a 1024-stage pipeline in clk (333 ps) bracketed by two async FIFOs (fifo_in, fifo_out) that talk to clk_uncore (1000 ps). PR #4170 fixed the same anti-pattern in sibling single-clock designs by sourcing the asap7 platform template (set_max_delay -ignore_clock_latency as optimization targets, no set_input/output_delay). That PR called out multi-clock designs as needing the idiom written by hand.

The bug in the old SDC: the three set_max_delay 80 calls omitted -ignore_clock_latency, so the tool treated the fabricated 80 ps budget as a real hold requirement against the deep clock tree's insertion delay, producing the 1e+42 sentinel and phantom hold violations.

The fix:

- fifo1.v: (* keep_hierarchy *) attribute on the module so Yosys preserves the instance boundary through flattening. SYNTH_KEEP_MODULES doesn't work here because hierarchy elaboration specializes fifo1 into $paramod$<hash>\fifo1 before the flow's keep loop runs.

- mock-cpu/config.mk: OPENROAD_HIERARCHICAL = 1 so link_design uses -hier and the fifo_in/fifo_out instances remain addressable by path in OpenSTA.

- mock-cpu/constraint.sdc: rewrite to the PR #4170 idiom:
  - set_max_delay -ignore_clock_latency 80 for IO optimization targets (the core fix — no more fabricated hold budget).
  - Surgical port -> fifo_in/<pin> for the input direction (tests hierarchy preservation through synth and hierarchical get_pins selection).
  - -from [all_registers] for the output direction: instance output pins are not valid STA start points (STA-1554), so pick them up via the platform template's idiom.
  - set_false_path -to [get_ports rdata*] broadened from the old clk-only false_path. rdata has no launch FF in the consumer domain; both wclk (fifomem) and rclk (rbin -> raddr -> mem mux) paths to rdata are valid-when-not-empty by FIFO protocol, not single-cycle timing.
  - Keep the existing CDC handling (set_clock_groups -asynchronous -allow_paths, set_max_delay between clocks with -ignore_clock_latency, set_false_path -hold between clocks) — this is the right shape for gray-coded 2-FF synchronizer FIFOs and the actual bug was elsewhere.
  - Fix a typo: clk2 waveform was using $clk_period/2 instead of $clk2_period/2.

- mock-cpu/rules-base.json: regenerated via update_rules_force.

Before / after (finish stage):

  floorplan hold WS:  1e+42 ps   -> 18.16 ps
  finish setup WS:   -84.6 ps    -> +16.58 ps
  finish setup TNS:  -2050 ps    -> 0 ps
  finish hold WS:    -16.6 ps    -> -0.74 ps (1 noise violation)
  finish hold TNS:   -66.6 ps    -> -0.74 ps
  cts hold buffers:  530 ceiling -> 124
  STA-1554 warnings: (many)      -> 0

All 25 per-design rules pass against the new baseline.