### PR TITLE
synth: expand SYNTH_RETIME_MODULES list into separate select args

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -122,7 +122,7 @@ exec -- $::env(PYTHON_EXE) $::env(SCRIPTS_DIR)/mem_dump.py \
   --max-bits $::env(SYNTH_MEMORY_MAX_BITS) $::env(RESULTS_DIR)/mem.json
 
 if { [env_var_exists_and_non_empty SYNTH_RETIME_MODULES] } {
-  select $::env(SYNTH_RETIME_MODULES)
+  select {*}$::env(SYNTH_RETIME_MODULES)
   opt -fast -full
   memory_map
   opt -full


### PR DESCRIPTION
Tcl's `$var` substitution passes the whole value as a single argument, so `select $::env(SYNTH_RETIME_MODULES)` with a space-separated module list becomes `select "a b c"` — one bogus pattern that matches no module, silently disabling retime. Use `{*}` list-expansion so each pattern in the env var arrives as its own `select` argument.