### PR TITLE
synth: match slang \$-suffixed module names in SYNTH_KEEP_MODULES

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -44,7 +44,9 @@ if { $::env(SYNTH_GUT) } {
 
 if { [env_var_exists_and_non_empty SYNTH_KEEP_MODULES] } {
   foreach module $::env(SYNTH_KEEP_MODULES) {
-    select -module $module
+    # Match the module and any `$`-suffixed canonical names the slang
+    # frontend generates for parameterized instances.
+    select "$module" "$module\\\$*"
     setattr -mod -set keep_hierarchy 1
     select -clear
   }

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -45,7 +45,7 @@ if { $::env(SYNTH_GUT) } {
 if { [env_var_exists_and_non_empty SYNTH_KEEP_MODULES] } {
   foreach module $::env(SYNTH_KEEP_MODULES) {
     # Two patterns so both frontends work:
-    #  - `$module` matches the bare name produced by verilog/verific.
+    #  - `$module` matches the bare name produced by verilog.
     #  - `$module\$*` matches the `$`-suffixed canonical names the
     #    slang frontend generates for parameterized instances
     #    (e.g. `\foo$1`); yosys's match_ids retries the pattern with

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -44,9 +44,12 @@ if { $::env(SYNTH_GUT) } {
 
 if { [env_var_exists_and_non_empty SYNTH_KEEP_MODULES] } {
   foreach module $::env(SYNTH_KEEP_MODULES) {
-    # Match the module and any `$`-suffixed canonical names the slang
-    # frontend generates for parameterized instances.
-    select "$module" "$module\\\$*"
+    # Match the module and any `$`-suffixed canonical names that the
+    # slang frontend generates for parameterized instances. `%u` unions
+    # the two selections, so if either pattern matches nothing (a
+    # warning, not an error) the other still applies -- preserving the
+    # non-slang case where only the bare name exists.
+    select "$module" "$module\\\$*" %u
     setattr -mod -set keep_hierarchy 1
     select -clear
   }

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -44,12 +44,20 @@ if { $::env(SYNTH_GUT) } {
 
 if { [env_var_exists_and_non_empty SYNTH_KEEP_MODULES] } {
   foreach module $::env(SYNTH_KEEP_MODULES) {
-    # Match the module and any `$`-suffixed canonical names that the
-    # slang frontend generates for parameterized instances. `%u` unions
-    # the two selections, so if either pattern matches nothing (a
-    # warning, not an error) the other still applies -- preserving the
-    # non-slang case where only the bare name exists.
-    select "$module" "$module\\\$*" %u
+    # Two patterns so both frontends work:
+    #  - `$module` matches the bare name produced by verilog/verific.
+    #  - `$module\$*` matches the `$`-suffixed canonical names the
+    #    slang frontend generates for parameterized instances
+    #    (e.g. `\foo$1`); yosys's match_ids retries the pattern with
+    #    the id's leading `\` stripped, so no `\`-prefix is needed
+    #    here -- see tools/yosys/passes/cmds/select.cc match_ids().
+    # Multiple patterns on one `select` are unioned at the end of the
+    # command (select.cc: `while (work_stack.size() > 1) union`), so
+    # when a pattern matches nothing it degrades to a warning and the
+    # other pattern still applies -- no regression for non-slang.
+    # `-module <name>` would error if the module doesn't exist, which
+    # is why we use bare patterns instead.
+    select "$module" "$module\\\$*"
     setattr -mod -set keep_hierarchy 1
     select -clear
   }


### PR DESCRIPTION
The slang HDL frontend produces `\$`-suffixed canonical RTLIL names for parameterized module instantiations, so `select -module <name>` misses them and `keep_hierarchy` silently doesn't get applied.

Replace with a two-pattern `select` that matches both the bare name and `<name>\$*`. The second pattern matches nothing when no `\$`-suffix names exist, so the builtin and verific frontends are unchanged.