### PR TITLE
synth: apply SYNTH_BLACKBOXES to loaded RTLIL after checkpoint read

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -291,6 +291,7 @@ configuration file.
 | <a name="SYNTH_ARGS"></a>SYNTH_ARGS| Optional synthesis variables for yosys.| |
 | <a name="SYNTH_BLACKBOXES"></a>SYNTH_BLACKBOXES| List of cells treated as a black box by Yosys. With Bazel, this can be used to run synthesis in parallel for the large modules of the design. Non-existant modules are ignored silently, useful when listing modules statically, even if modules come and go dynamically.| |
 | <a name="SYNTH_CANONICALIZE_TCL"></a>SYNTH_CANONICALIZE_TCL| Specifies a Tcl script with commands to run as part of the synth canonicalize step.| |
+| <a name="SYNTH_CHECKPOINT"></a>SYNTH_CHECKPOINT| Path to a Yosys RTLIL checkpoint to read in place of the default canonicalization checkpoint at the start of synth.tcl. Intended for parallel synthesis flows that reuse a checkpoint taken after coarse synthesis and `keep_hierarchy` have already been decided, so each partition skips that common prefix. Leave unset for the normal flow.| |
 | <a name="SYNTH_GUT"></a>SYNTH_GUT| Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.| 0|
 | <a name="SYNTH_HDL_FRONTEND"></a>SYNTH_HDL_FRONTEND| Select an alternative language frontend to ingest the design. Available option is "slang". If the variable is empty, design is read with the Yosys read_verilog command.| |
 | <a name="SYNTH_HIERARCHICAL"></a>SYNTH_HIERARCHICAL| Enable to Synthesis hierarchically, otherwise considered flat synthesis.| 0|
@@ -349,6 +350,7 @@ configuration file.
 - [SYNTH_ARGS](#SYNTH_ARGS)
 - [SYNTH_BLACKBOXES](#SYNTH_BLACKBOXES)
 - [SYNTH_CANONICALIZE_TCL](#SYNTH_CANONICALIZE_TCL)
+- [SYNTH_CHECKPOINT](#SYNTH_CHECKPOINT)
 - [SYNTH_GUT](#SYNTH_GUT)
 - [SYNTH_HDL_FRONTEND](#SYNTH_HDL_FRONTEND)
 - [SYNTH_HIERARCHICAL](#SYNTH_HIERARCHICAL)

--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -32,7 +32,11 @@ proc get_dfflegalize_args { file_path } {
 }
 
 source $::env(SCRIPTS_DIR)/synth_preamble.tcl
-read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+if { [env_var_exists_and_non_empty SYNTH_CHECKPOINT] } {
+  read_checkpoint $::env(SYNTH_CHECKPOINT)
+} else {
+  read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
+}
 
 hierarchy -check -top $::env(DESIGN_NAME)
 

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -1240,6 +1240,12 @@
       "synth"
     ]
   },
+  "SYNTH_CHECKPOINT": {
+    "description": "Path to a Yosys RTLIL checkpoint to read in place of the default canonicalization checkpoint at the start of synth.tcl. Intended for parallel synthesis flows that reuse a checkpoint taken after coarse synthesis and `keep_hierarchy` have already been decided, so each partition skips that common prefix. Leave unset for the normal flow.\n",
+    "stages": [
+      "synth"
+    ]
+  },
   "SYNTH_GUT": {
     "default": 0,
     "description": "Load design and remove all internal logic before doing synthesis. This is useful when creating a mock .lef abstract that has a smaller area than the amount of logic would allow. bazel-orfs uses this to mock SRAMs, for instance.\n",

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -256,6 +256,16 @@ SYNTH_BLACKBOXES:
     statically, even if modules come and go dynamically.
   stages:
     - synth
+SYNTH_CHECKPOINT:
+  description: >
+    Path to a Yosys RTLIL checkpoint to read in place of the default
+    canonicalization checkpoint at the start of synth.tcl.
+    Intended for parallel synthesis flows that reuse a checkpoint taken after
+    coarse synthesis and `keep_hierarchy` have already been decided, so each
+    partition skips that common prefix.
+    Leave unset for the normal flow.
+  stages:
+    - synth
 SYNTH_NETLIST_FILES:
   description: >
     Skips synthesis and uses the supplied netlist files. If the netlist files


### PR DESCRIPTION
The preamble already registers SYNTH_BLACKBOXES at the HDL-read stage, but when synth.tcl is entered via a pre-loaded RTLIL checkpoint (see SYNTH_CHECKPOINT) the preamble is not involved, so the blackbox list needs a second application point on the loaded netlist.

Run the same list through `blackbox` between read_checkpoint and hierarchy -check. Wrap each in `catch` so stale names from a static list don't fail the flow — matches the existing "non-existent modules are ignored silently" documentation for the variable.

The variable's doc entry already notes Bazel parallel synth; extended to call out the post-checkpoint apply point for completeness.