### PR TITLE
util: skip log_cmd timing when [clock] is unavailable

### DIFF
--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -7,13 +7,22 @@ proc log_cmd { cmd args } {
   # log the command, escape arguments with spaces
   set log_cmd "$cmd[join [lmap arg $args { format " %s" [expr { [string match {* *} $arg] ? "\"$arg\"" : "$arg" }] }] ""]" ;# tclint-disable-line line-length
   puts $log_cmd
-  set start [clock seconds]
+  # Tcl's `clock` lives in clock.tcl, auto-loaded from TCL_LIBRARY. Hermetic
+  # build environments (e.g. Bazel linking yosys against @tcl_lang) don't
+  # always ship the Tcl library in runfiles, so `clock` may be undefined.
+  # The timing log is cosmetic — skip it when `clock` isn't available.
+  set has_clock [expr { [info commands clock] ne "" }]
+  if { $has_clock } {
+    set start [clock seconds]
+  }
   set result [uplevel 1 [list $cmd {*}$args]]
-  set time [expr { [clock seconds] - $start }]
-  if { $time >= 5 } {
-    # Ideally we'd use a single line, but the command can output text
-    # and we don't want to mix it with the log, so output the time it took afterwards.
-    puts "Took $time seconds: $log_cmd"
+  if { $has_clock } {
+    set time [expr { [clock seconds] - $start }]
+    if { $time >= 5 } {
+      # Ideally we'd use a single line, but the command can output text
+      # and we don't want to mix it with the log, so output the time it took afterwards.
+      puts "Took $time seconds: $log_cmd"
+    }
   }
   return $result
 }


### PR DESCRIPTION
Tcl's clock command lives in clock.tcl, auto-loaded from TCL_LIBRARY. Hermetic build environments (e.g. Bazel linking yosys against the @tcl_lang package) don't always ship the Tcl library directory in runfiles, so Tcl_Init fails and `clock` never gets defined.

log_cmd's clock usage is cosmetic — it prints "Took N seconds" when a command runs longer than 5s. Guard both the start/end `clock seconds` calls with `info commands clock` so log_cmd still runs the underlying command under yosys even when the clock command is missing. No-op in normal environments where clock is available.
