### PR TITLE
flow: move eliminate_dead_logic into synth_odb.tcl

### DIFF
--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -32,10 +32,6 @@ proc report_unused_masters { } {
 
 report_unused_masters
 
-# Eliminate dead logic
-eliminate_dead_logic
-
-
 #Run check_setup
 puts "\n=========================================================================="
 puts "Floorplan check_setup"
@@ -116,6 +112,22 @@ if { [env_var_exists_and_non_empty FASTROUTE_TCL] } {
 
 source_env_var_if_exists FOOTPRINT_TCL
 
+# The transforms below (repair_tie_fanout, replace_arith_modules,
+# remove_buffers, repair_timing_helper) look like synthesis-stage
+# operations: they all act on the netlist and don't touch placement.
+# But they DO depend on having a floorplan in place — initialize_floorplan
+# above placed the bterms on the die boundary and set_routing_layers
+# configured the layer stack used for parasitic estimation. Without that
+# context, top-level ports look like they're at (0,0) and timing analysis
+# misjudges paths into/out of I/O.
+#
+# PR #4187 tried moving this block to synth_odb.tcl. It regressed setup
+# TNS by 1.7-46x on I/O-heavy designs (asap7/aes-block 2.5x, asap7/jpeg_lvt
+# 37x, asap7/swerv_wrapper 46x finish-hold-TNS, nangate45/ariane133 1.7x)
+# while leaving internal-logic-dominated designs like asap7/ibex
+# unchanged. The move was reverted; only eliminate_dead_logic stayed in
+# synth_odb.tcl because it is a pure netlist transform that doesn't
+# depend on placement or routing-layer context.
 if { !$::env(SKIP_REPAIR_TIE_FANOUT) } {
   # This needs to come before any call to remove_buffers.  You could have one
   # tie driving multiple buffers that drive multiple outputs.

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -22,7 +22,7 @@ source_step_tcl PRE SYNTH
 # stay in floorplan.tcl — moving them here was tried in PR #4187 and
 # regressed setup TNS by 1.7-46x on I/O-heavy designs (asap7/aes-block,
 # asap7/jpeg_lvt, asap7/swerv_wrapper, nangate45/ariane133).
-eliminate_dead_logic
+log_cmd eliminate_dead_logic
 
 source_step_tcl POST SYNTH
 orfs_write_db $::env(RESULTS_DIR)/1_synth.odb

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -4,6 +4,26 @@ erase_non_stage_variables synth
 load_design 1_2_yosys.v 1_2_yosys.sdc
 source_step_tcl PRE SYNTH
 
+# Eliminate dead logic before writing the synthesis odb so that
+# 1_synth.odb already reflects the live design.
+#
+# This matters for parallel synthesis flows (e.g., MegaBoom) where yosys
+# only sees a slice of the design at a time and cannot prune logic that
+# is dead only when looking at the whole design. In those flows this
+# step can eliminate vast quantities of debug logic — for MegaBoom it
+# has historically removed ~50% of the design.
+#
+# eliminate_dead_logic is a pure netlist transform: it does not need a
+# die area, bterm placement or routing layers, so it is safe to run
+# here. Other synthesis-looking transforms in floorplan.tcl
+# (repair_tie_fanout, replace_arith_modules, remove_buffers,
+# repair_timing_helper) DO depend on floorplan-stage context (bterm
+# locations from initialize_floorplan, routing-layer setup) and must
+# stay in floorplan.tcl — moving them here was tried in PR #4187 and
+# regressed setup TNS by 1.7-46x on I/O-heavy designs (asap7/aes-block,
+# asap7/jpeg_lvt, asap7/swerv_wrapper, nangate45/ariane133).
+eliminate_dead_logic
+
 source_step_tcl POST SYNTH
 orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
 # Canonicalize 1_synth.sdc. The original SDC_FILE provided by


### PR DESCRIPTION
## Summary

- Move `eliminate_dead_logic` from `floorplan.tcl` into `synth_odb.tcl` so `1_synth.odb` reflects the live design.
- Add a docstring above the remaining synthesis-looking transforms in `floorplan.tcl` (`repair_tie_fanout`, `replace_arith_modules`, `remove_buffers`, `repair_timing_helper`) explaining why they cannot follow: synthesis is not I/O-pin-aware, and these calls depend on `initialize_floorplan` having placed bterms on the die boundary and `set_routing_layers` having set up the layer stack used for parasitic estimation.

## Why only `eliminate_dead_logic`

`eliminate_dead_logic` is a pure netlist transform — it does not read pin locations or routing layers, so the move is safe. It also matters for parallel synthesis flows (e.g., MegaBoom) where yosys only sees a slice of the design and cannot prune logic that is dead only when viewed whole; in those flows this step has historically pruned ~50% of the design.

## Why the other four stay in `floorplan.tcl`

This was attempted in #4187 (closed). Empirical result vs. master/1387 (deterministic baseline across multiple master CI runs):

| design | metric | master/1387 | with PR #4187 (build #8) | Δ |
|---|---|---:|---:|---|
| asap7/aes-block | cts setup TNS | −4119 ps | −10309 ps | 2.5× worse |
| asap7/jpeg_lvt | grt setup TNS | −26 ps | −951 ps | 37× worse |
| asap7/swerv_wrapper | finish hold TNS | −194 ps | −9009 ps | 46× worse |
| nangate45/ariane133 | cts setup TNS | −478 ps | −819 ps | 1.7× worse |
| asap7/ibex | cts setup TNS | −961 ps | −975 ps | unchanged |

I/O-heavy designs regress materially when timing-aware transforms run before bterm placement and routing-layer setup; internal-logic-dominated designs are unaffected. Splitting `eliminate_dead_logic` (which is pure netlist) from the rest of the block (which is timing-aware) keeps the only safe move from #4187 and documents the constraint inline so the next attempt avoids the same pitfall.

## Test plan

- [ ] CI green on the public design matrix.
- [ ] `1_synth.odb` instance count for asap7/ibex drops to its post-pruning value (no surprise instance-count drop between synth and floorplan).
- [ ] No QoR change vs. master on the public matrix (within run-to-run noise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)