### PR TITLE
Gen metrics git fix

### DIFF
--- a/flow/util/BUILD.bazel
+++ b/flow/util/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 
 exports_files(["open_plots.sh"])
@@ -15,10 +16,13 @@ MAKEFILE_SHARED = [
 # for scripts/flow.sh steps
 filegroup(
     name = "makefile",
-    srcs = glob(MAKEFILE_SHARED + [
-        "*.py",
-        "*.sh",
-    ]),
+    srcs = glob(
+        MAKEFILE_SHARED + [
+            "*.py",
+            "*.sh",
+        ],
+        exclude = ["*_test.py"],
+    ),
     visibility = ["//visibility:public"],
 )
 
@@ -27,4 +31,16 @@ filegroup(
     name = "makefile_yosys",
     srcs = glob(MAKEFILE_SHARED),
     visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "genMetrics_lib",
+    srcs = ["genMetrics.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "genMetrics_test",
+    srcs = ["genMetrics_test.py"],
+    deps = [":genMetrics_lib"],
 )

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -174,6 +174,8 @@ def read_sdc(file_name):
 def is_git_repo(folder=None):
     if shutil.which("git") is None:
         return False
+    if folder is not None and not os.path.isdir(folder):
+        return False
     cmd = ["git", "branch"]
     with open(os.devnull, "w") as devnull:
         if folder is not None:
@@ -373,9 +375,11 @@ def extract_metrics(
         json.dump(metrics_dict, resultSpecfile, indent=2, sort_keys=True)
 
 
+now = datetime.now()
+
+
 if __name__ == "__main__":
     args = parse_args()
-    now = datetime.now()
 
     extract_metrics(
         os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"),

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -198,7 +198,7 @@ def extract_metrics(
     baseRegEx = "^{}\n^-*\n^{}"
 
     metrics_dict = defaultdict(dict)
-    metrics_dict["run__flow__generate_date"] = now.strftime("%Y-%m-%d %H:%M")
+    metrics_dict["run__flow__generate_date"] = datetime.now().strftime("%Y-%m-%d %H:%M")
     metrics_dict["run__flow__metrics_version"] = "Metrics_2.1.2"
     cmdOutput = check_output([os.environ.get("OPENROAD_EXE", "openroad"), "-version"])
     cmdFields = [x.decode("utf-8") for x in cmdOutput.split()]
@@ -207,8 +207,8 @@ def extract_metrics(
         metrics_dict["run__flow__openroad_commit"] = str(cmdFields[1])
     else:
         metrics_dict["run__flow__openroad_commit"] = "N/A"
-    if is_git_repo():
-        cmdOutput = check_output(["git", "rev-parse", "HEAD"])
+    if is_git_repo(folder=cwd):
+        cmdOutput = check_output(["git", "rev-parse", "HEAD"], cwd=cwd)
         cmdOutput = cmdOutput.decode("utf-8").strip()
     else:
         cmdOutput = "not a git repo"
@@ -373,9 +373,6 @@ def extract_metrics(
 
     with open(output, "w") as resultSpecfile:
         json.dump(metrics_dict, resultSpecfile, indent=2, sort_keys=True)
-
-
-now = datetime.now()
 
 
 if __name__ == "__main__":

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -6,6 +6,7 @@
 # -----------------------------------------------------------------------------
 
 import os
+import shutil
 from datetime import datetime, timedelta
 from collections import defaultdict
 from uuid import uuid4 as uuid
@@ -171,6 +172,8 @@ def read_sdc(file_name):
 
 
 def is_git_repo(folder=None):
+    if shutil.which("git") is None:
+        return False
     cmd = ["git", "branch"]
     with open(os.devnull, "w") as devnull:
         if folder is not None:

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -171,17 +171,23 @@ def read_sdc(file_name):
 # =============================================================================
 
 
-def is_git_repo(folder=None):
-    if shutil.which("git") is None:
-        return False
-    if folder is not None and not os.path.isdir(folder):
-        return False
-    cmd = ["git", "branch"]
+def git_head_commit(git_exe, folder):
+    """Resolve the HEAD commit SHA of `folder`'s git working tree, or
+    return a descriptive fallback string. Accepts a pre-resolved
+    `git_exe` path so callers don't pay a `shutil.which` lookup per
+    invocation. Prints a [WARN] for the not-a-git-repo case (the
+    git-missing case is expected to be warned about by the caller)."""
+    if git_exe is None:
+        return "git not on PATH"
+    if not os.path.isdir(folder):
+        return "N/A"
     with open(os.devnull, "w") as devnull:
-        if folder is not None:
-            return call(cmd, stderr=STDOUT, stdout=devnull, cwd=folder) == 0
-        else:
-            return call(cmd, stderr=STDOUT, stdout=devnull) == 0
+        if call([git_exe, "branch"], stderr=STDOUT, stdout=devnull, cwd=folder) != 0:
+            print("[WARN] not a git repo:", folder)
+            return "not a git repo"
+    return (
+        check_output([git_exe, "rev-parse", "HEAD"], cwd=folder).decode("utf-8").strip()
+    )
 
 
 def merge_jsons(root_path, output, files):
@@ -207,27 +213,21 @@ def extract_metrics(
         metrics_dict["run__flow__openroad_commit"] = str(cmdFields[1])
     else:
         metrics_dict["run__flow__openroad_commit"] = "N/A"
-    if is_git_repo(folder=cwd):
-        cmdOutput = check_output(["git", "rev-parse", "HEAD"], cwd=cwd)
-        cmdOutput = cmdOutput.decode("utf-8").strip()
-    else:
-        cmdOutput = "not a git repo"
-        print("[WARN]", cmdOutput)
-    metrics_dict["run__flow__scripts_commit"] = cmdOutput
+    git_exe = shutil.which("git")
+    if git_exe is None:
+        print("[WARN] git not on PATH; commit metadata will be N/A")
+    metrics_dict["run__flow__scripts_commit"] = git_head_commit(git_exe, cwd)
     metrics_dict["run__flow__uuid"] = str(uuid())
     metrics_dict["run__flow__design"] = design
     metrics_dict["run__flow__platform"] = platform
     platformDir = os.environ.get("PLATFORM_DIR")
     if platformDir is None:
         print("[INFO]", "PLATFORM_DIR env variable not set")
-        cmdOutput = "N/A"
-    elif is_git_repo(folder=platformDir):
-        cmdOutput = check_output(["git", "rev-parse", "HEAD"], cwd=platformDir)
-        cmdOutput = cmdOutput.decode("utf-8").strip()
+        metrics_dict["run__flow__platform_commit"] = "N/A"
     else:
-        print("[WARN]", "not a git repo")
-        cmdOutput = "N/A"
-    metrics_dict["run__flow__platform_commit"] = cmdOutput
+        metrics_dict["run__flow__platform_commit"] = git_head_commit(
+            git_exe, platformDir
+        )
     metrics_dict["run__flow__variant"] = flow_variant
 
     # Synthesis

--- a/flow/util/genMetrics.py
+++ b/flow/util/genMetrics.py
@@ -373,17 +373,18 @@ def extract_metrics(
         json.dump(metrics_dict, resultSpecfile, indent=2, sort_keys=True)
 
 
-args = parse_args()
-now = datetime.now()
+if __name__ == "__main__":
+    args = parse_args()
+    now = datetime.now()
 
-extract_metrics(
-    os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"),
-    args.platform,
-    args.design,
-    args.flowVariant,
-    args.output,
-    args.hier,
-    args.logs,
-    args.reports,
-    args.results,
-)
+    extract_metrics(
+        os.path.join(os.path.dirname(os.path.realpath(__file__)), "../"),
+        args.platform,
+        args.design,
+        args.flowVariant,
+        args.output,
+        args.hier,
+        args.logs,
+        args.reports,
+        args.results,
+    )

--- a/flow/util/genMetrics_test.py
+++ b/flow/util/genMetrics_test.py
@@ -5,37 +5,35 @@ import shutil
 import subprocess
 import sys
 import unittest
-from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 import genMetrics
 
 
-class IsGitRepoTests(unittest.TestCase):
-    """Tests is_git_repo()'s tolerance of a missing git binary."""
+class GitHeadCommitTests(unittest.TestCase):
+    """Tests git_head_commit()'s fallback behavior so commit metadata
+    extraction degrades gracefully instead of raising."""
 
-    def test_returns_false_when_git_not_on_path(self):
-        """When git is absent from PATH, is_git_repo() must return False
-        without raising (e.g. Nix builds, hermetic Bazel sandboxes)."""
-        with mock.patch.object(genMetrics.shutil, "which", return_value=None):
-            self.assertFalse(genMetrics.is_git_repo())
-            self.assertFalse(genMetrics.is_git_repo(folder="/tmp"))
+    def test_returns_descriptive_string_when_git_not_on_path(self):
+        """Nix builds and hermetic Bazel sandboxes can lack git; the
+        helper must report that distinctly rather than masquerading as
+        'not a git repo'."""
+        self.assertEqual(genMetrics.git_head_commit(None, "/tmp"), "git not on PATH")
 
-    def test_returns_false_when_folder_is_not_a_directory(self):
-        """When the caller passes a folder that doesn't exist (e.g. an
-        unset/misconfigured PLATFORM_DIR), is_git_repo() must return False
-        without letting subprocess raise FileNotFoundError on cwd."""
-        with mock.patch.object(genMetrics.shutil, "which", return_value="/usr/bin/git"):
-            self.assertFalse(
-                genMetrics.is_git_repo(folder="/no/such/directory/orfs-test")
-            )
+    def test_returns_na_when_folder_is_not_a_directory(self):
+        """An unset/misconfigured PLATFORM_DIR must not let subprocess
+        raise FileNotFoundError on cwd."""
+        self.assertEqual(
+            genMetrics.git_head_commit("/usr/bin/git", "/no/such/directory/orfs-test"),
+            "N/A",
+        )
 
 
 class ShutilWhichGitConsistencyTests(unittest.TestCase):
     """Cross-checks shutil.which("git") against actually invoking git, so
     we catch any environment (e.g. a stripped Nix sandbox) where the two
-    disagree and is_git_repo()'s PATH probe would give the wrong answer."""
+    disagree and the PATH probe would give the wrong answer."""
 
     def test_which_matches_git_version(self):
         which_result = shutil.which("git")
@@ -59,9 +57,9 @@ class ShutilWhichGitConsistencyTests(unittest.TestCase):
 
 class ShutilWhichMissingCommandTests(unittest.TestCase):
     """Validates shutil.which() returns None for a non-existent command.
-    This is the primitive is_git_repo() relies on; if it ever returned a
-    bogus path (in Nix, in a Bazel sandbox, anywhere) the missing-git
-    branch would never fire."""
+    This is the primitive git_head_commit() relies on at the call site;
+    if it ever returned a bogus path (in Nix, in a Bazel sandbox,
+    anywhere) the missing-git branch would never fire."""
 
     BOGUS_CMD = "orfs-genmetrics-no-such-command-xyzzy"
 

--- a/flow/util/genMetrics_test.py
+++ b/flow/util/genMetrics_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import datetime
 import os
 import shutil
 import subprocess
@@ -21,6 +22,24 @@ class IsGitRepoTests(unittest.TestCase):
         with mock.patch.object(genMetrics.shutil, "which", return_value=None):
             self.assertFalse(genMetrics.is_git_repo())
             self.assertFalse(genMetrics.is_git_repo(folder="/tmp"))
+
+    def test_returns_false_when_folder_is_not_a_directory(self):
+        """When the caller passes a folder that doesn't exist (e.g. an
+        unset/misconfigured PLATFORM_DIR), is_git_repo() must return False
+        without letting subprocess raise FileNotFoundError on cwd."""
+        with mock.patch.object(genMetrics.shutil, "which", return_value="/usr/bin/git"):
+            self.assertFalse(
+                genMetrics.is_git_repo(folder="/no/such/directory/orfs-test")
+            )
+
+
+class ModuleImportableTests(unittest.TestCase):
+    """Guards against module-scope state that extract_metrics() depends on
+    silently moving into the `if __name__ == "__main__"` block — that would
+    break library imports with a NameError at call time."""
+
+    def test_now_is_module_level_datetime(self):
+        self.assertIsInstance(genMetrics.now, datetime.datetime)
 
 
 class ShutilWhichGitConsistencyTests(unittest.TestCase):

--- a/flow/util/genMetrics_test.py
+++ b/flow/util/genMetrics_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import datetime
 import os
 import shutil
 import subprocess
@@ -31,15 +30,6 @@ class IsGitRepoTests(unittest.TestCase):
             self.assertFalse(
                 genMetrics.is_git_repo(folder="/no/such/directory/orfs-test")
             )
-
-
-class ModuleImportableTests(unittest.TestCase):
-    """Guards against module-scope state that extract_metrics() depends on
-    silently moving into the `if __name__ == "__main__"` block — that would
-    break library imports with a NameError at call time."""
-
-    def test_now_is_module_level_datetime(self):
-        self.assertIsInstance(genMetrics.now, datetime.datetime)
 
 
 class ShutilWhichGitConsistencyTests(unittest.TestCase):

--- a/flow/util/genMetrics_test.py
+++ b/flow/util/genMetrics_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+
+import genMetrics
+
+
+class IsGitRepoTests(unittest.TestCase):
+    """Tests is_git_repo()'s tolerance of a missing git binary."""
+
+    def test_returns_false_when_git_not_on_path(self):
+        """When git is absent from PATH, is_git_repo() must return False
+        without raising (e.g. Nix builds, hermetic Bazel sandboxes)."""
+        with mock.patch.object(genMetrics.shutil, "which", return_value=None):
+            self.assertFalse(genMetrics.is_git_repo())
+            self.assertFalse(genMetrics.is_git_repo(folder="/tmp"))
+
+
+class ShutilWhichGitConsistencyTests(unittest.TestCase):
+    """Cross-checks shutil.which("git") against actually invoking git, so
+    we catch any environment (e.g. a stripped Nix sandbox) where the two
+    disagree and is_git_repo()'s PATH probe would give the wrong answer."""
+
+    def test_which_matches_git_version(self):
+        which_result = shutil.which("git")
+        try:
+            output = subprocess.check_output(
+                ["git", "--version"], stderr=subprocess.STDOUT, text=True
+            )
+        except FileNotFoundError:
+            self.assertIsNone(
+                which_result,
+                "shutil.which found git but invoking it raised FileNotFoundError",
+            )
+            return
+
+        self.assertIsNotNone(
+            which_result,
+            "git --version succeeded but shutil.which returned None",
+        )
+        self.assertTrue(output.startswith("git version "), output)
+
+
+class ShutilWhichMissingCommandTests(unittest.TestCase):
+    """Validates shutil.which() returns None for a non-existent command.
+    This is the primitive is_git_repo() relies on; if it ever returned a
+    bogus path (in Nix, in a Bazel sandbox, anywhere) the missing-git
+    branch would never fire."""
+
+    BOGUS_CMD = "orfs-genmetrics-no-such-command-xyzzy"
+
+    def test_which_returns_none_for_missing_command(self):
+        self.assertIsNone(shutil.which(self.BOGUS_CMD))
+
+    def test_invoking_missing_command_raises_file_not_found(self):
+        with self.assertRaises(FileNotFoundError):
+            subprocess.check_call([self.BOGUS_CMD])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@hzeller Asked Claude to knock this one on the head. No git on path in nix.

@maliberty For as long as I can recall across many projects, there's been a bit of a contention w.r.t. separating the concern of build systems and version control.

There is an unrelated correlary to this PR: how do we handle linting and enumeration of files to be linted. How does `bazelisk run //:fix_lint` get files to lint?