### PR TITLE
update asap7 layer resistance with segment-based regression results

### DIFF
--- a/flow/platforms/asap7/setRC.tcl
+++ b/flow/platforms/asap7/setRC.tcl
@@ -1,12 +1,11 @@
-# correlation result (aes, cva6, ibex, riscv32i)
-# M1 capacitance fixed up from -4.8e-02 to 1e-10 as a minuscule positive value
 set_layer_rc -layer M1 -resistance 7.04175E-02 -capacitance 1e-10
-set_layer_rc -layer M2 -resistance 4.62311E-02 -capacitance 1.84542E-01
-set_layer_rc -layer M3 -resistance 3.63251E-02 -capacitance 1.53955E-01
-set_layer_rc -layer M4 -resistance 2.03083E-02 -capacitance 1.89434E-01
-set_layer_rc -layer M5 -resistance 1.93005E-02 -capacitance 1.71593E-01
-set_layer_rc -layer M6 -resistance 1.18619E-02 -capacitance 1.76146E-01
-set_layer_rc -layer M7 -resistance 1.25311E-02 -capacitance 1.47030E-01
+set_layer_rc -layer M2 -resistance 2.97126E-02 -capacitance 1.84542E-01
+set_layer_rc -layer M3 -resistance 3.12872E-02 -capacitance 1.53955E-01
+set_layer_rc -layer M4 -resistance 1.80365E-02 -capacitance 1.89434E-01
+set_layer_rc -layer M5 -resistance 1.89936E-02 -capacitance 1.71593E-01
+set_layer_rc -layer M6 -resistance 1.18797E-02 -capacitance 1.76146E-01
+set_layer_rc -layer M7 -resistance 1.25097E-02 -capacitance 1.47030E-01
+
 set_wire_rc -signal -resistance 3.23151E-02 -capacitance 1.73323E-01
 set_wire_rc -clock -resistance 5.13971E-02 -capacitance 1.44549E-01
 


### PR DESCRIPTION
For #4243.

### Correlation Data

**Mode:** segment
**Designs (18):** aes, aes-block, aes_lvt, aes-mbff, cva6, ethmac, ethmac_lvt, gcd, gcd-ccs, ibex, jpeg, jpeg_lvt, mock-alu, mock-cpu, riscv32i, riscv32i-mock-sram, swerv_wrapper, uart.
**OR Version:** e077b67
**Units:** R [Ω/μm], C [ff/μm]

The resistance values that we were using weren't actually precise. Probably something off with the net-based regression script. The resistance fits obtained with new segment-based regression have perfect (1.00) R².

I cleaned up the setRC.tcl script so that the data w.r.t. the correlation is tracked here rather than having comments in the file.

### Observations Regarding M1
 - There was no regression data for this layer.
 - Capacitance was kept fixed at 1E-10 as a minuscule positive value.
