### PR TITLE
synth: blackbox SYNTH_BLACKBOXES modules before hierarchy check

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -38,6 +38,18 @@ if { [env_var_exists_and_non_empty SYNTH_CHECKPOINT] } {
   read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
 }
 
+# When this synthesis run is one partition of a parallel split (driven by
+# an external orchestrator), `SYNTH_BLACKBOXES` lists modules outside this
+# partition.  Blackboxing them before the hierarchy check lets each
+# partition load the same canonical RTLIL checkpoint while only synthesising
+# its own subhierarchy.  Names not present in the loaded design are skipped
+# silently so the same list can be passed to every partition.
+if { [env_var_exists_and_non_empty SYNTH_BLACKBOXES] } {
+  foreach m $::env(SYNTH_BLACKBOXES) {
+    catch { blackbox $m }
+  }
+}
+
 hierarchy -check -top $::env(DESIGN_NAME)
 
 if { $::env(SYNTH_GUT) } {


### PR DESCRIPTION
## Summary

Adds an optional `SYNTH_BLACKBOXES` env var that, when set, blackboxes the listed modules before `hierarchy -check`.

Intended for external orchestrators that drive parallel partition synthesis: every partition loads the same canonical RTLIL checkpoint, then blackboxes the modules that belong to other partitions so it only synthesises its own subhierarchy.

Names not present in the loaded design are skipped silently (`catch {blackbox $m}`), so the same list can be reused across all partitions without per-partition filtering. No behaviour change when the env var is unset.

This block is currently carried as a vendored modification of `synth.tcl` in `bazel-orfs`. Upstreaming it lets `bazel-orfs` drop the vendored copy and source `flow/scripts/synth.tcl` directly from ORFS.

## Test plan

- [x] No behaviour change when `SYNTH_BLACKBOXES` is unset (the `if` block is skipped)
- [ ] CI green