### PR TITLE
synth: blackbox SYNTH_BLACKBOXES modules before hierarchy check

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -38,6 +38,32 @@ if { [env_var_exists_and_non_empty SYNTH_CHECKPOINT] } {
   read_checkpoint $::env(RESULTS_DIR)/1_1_yosys_canonicalize.rtlil
 }
 
+# When this synthesis run is one partition of a parallel split (driven by
+# an external orchestrator), `SYNTH_BLACKBOXES` lists modules outside this
+# partition.  Blackboxing them before the hierarchy check lets each
+# partition load the same canonical RTLIL checkpoint while only synthesising
+# its own subhierarchy.  Names not present in the loaded design are skipped
+# silently so the same list can be passed to every partition.
+#
+# This deliberately differs from the SYNTH_BLACKBOXES handling in
+# synth_preamble.tcl's `read_design_sources`, and the difference is correct
+# in both places — do not "harmonise" the two:
+#   * Order: here the design is already elaborated (read from RTLIL), so
+#     `blackbox` operates on resolved modules and must run before the
+#     hierarchy check.  In synth_preamble.tcl the verilog frontend uses
+#     `read_verilog -defer`, so `hierarchy -check -top` must run first to
+#     elaborate from the top before `blackbox` sees a populated module table.
+#   * Catch: here a missing name is expected because the same list is
+#     reused across partitions, and only this partition's portion exists in
+#     the checkpoint.  In synth_preamble.tcl a single design is being
+#     synthesised, so an unknown name is almost certainly a user typo and
+#     should fail loudly — `blackbox $m` without `catch` is intentional.
+if { [env_var_exists_and_non_empty SYNTH_BLACKBOXES] } {
+  foreach m $::env(SYNTH_BLACKBOXES) {
+    catch { blackbox $m }
+  }
+}
+
 hierarchy -check -top $::env(DESIGN_NAME)
 
 if { $::env(SYNTH_GUT) } {


### PR DESCRIPTION
Re-opening of #4211 after measuring the cost of the alternative.

## Summary

Adds a checkpoint-based code path for `SYNTH_BLACKBOXES` to `synth.tcl` and aligns the existing source-based path in `synth_preamble.tcl` so all flows behave identically (use `catch`, blackbox before `hierarchy -check -top`).

## Why this is needed: parallel partition synthesis with slang

When `--keep-hierarchy` is used (required for partition flows that preserve internal hierarchy), the slang frontend mangles module names by their elaboration path so different parameterizations get distinct names — `Foo` instantiated at `top.unit.foo` becomes `Foo$top.unit.foo` in the elaborated RTLIL. The parent design references those mangled names.

A "per-partition canonicalize from RTL" approach therefore **can't** just elaborate `Foo` as a fresh top — that would emit a module named `Foo`, but the parent design instantiates `Foo$top.unit.foo`, and the link fails.

The orchestrator pattern instead is: canonicalize the full design **once** (so all parameterized instances get their elaborated names), and each partition then loads that shared checkpoint and blackboxes the modules outside its scope. Every partition reads the same canonical RTLIL and only synthesises its own subhierarchy.

The same `SYNTH_BLACKBOXES` list can be reused across all partitions because unknown names are skipped silently with `catch { blackbox $m }` instead of erroring.

## Cost evidence

Measured on an test case I can't share (46 partitions, ~3,500 s of synth CPU compressed into ~5 min wall via 12× parallelism): the shared canonicalize is 7 s (read_liberty 2 s + opt_clean 1.9 s + read_slang 1.5 s + misc) — **necessary** for slang to consistently mangle parameterised names across partitions, not optional bookkeeping.

## Test plan

- [x] No behaviour change when `SYNTH_BLACKBOXES` is unset
- [x] DCO + Tclint + variables.yaml tests pass on the previous PR (#4211) iteration
- [ ] CI green