### PR TITLE
fixed verific check error

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -238,7 +238,7 @@ __docker_build()
                 sed -i '/flow\/platforms/d' .dockerignore
         fi
         options=""
-        if [ -n "${WITH_VERIFIC}" ]; then
+        if [ ${WITH_VERIFIC} -eq 1 ]; then
                 cp -r "${VERIFIC_SRC}" tools/verific
                 options="-buildArgs=--build-arg verificPath=tools/verific"
         fi


### PR DESCRIPTION
I was getting this error:
```
$ ./build_openroad.sh
[INFO FLW-0028] Compiling with 32 threads.                                                                                                                                                                                                                    
[INFO FLW-0027] Saving logs to build_openroad.log                                                                                                                                                                                                             
[INFO FLW-0028] ./build_openroad.sh                                                                                                                                                                                                                           
[INFO FLW-0002] Updating git submodules.                                                                                                                                                                                                                      
[INFO FLW-0000] Using docker build method.                                                                                                                                                                                                                    
[INFO FLW-0020] Building docker image for OpenROAD Flow.                                                                                                                                                                                                      
cp: cannot stat '': No such file or directory
```
The script was checking for WITH_VERIFIC as not a numeral value, while it is one. and it's working now. 