### PR TITLE
ci: support per-user PAT for staging PR authorship

### DIFF
--- a/.github/workflows/github-actions-on-label-create.yml
+++ b/.github/workflows/github-actions-on-label-create.yml
@@ -51,11 +51,37 @@ jobs:
         deployToken: ${{ secrets.STAGING_GITHUB_TOKEN }}
         force: true
 
+    - id: resolve_key
+      name: Compute per-user secret key
+      env:
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      run: |
+        key=$(echo "$PR_AUTHOR" | tr 'a-z-' 'A-Z_')
+        echo "key=$key" >> "$GITHUB_OUTPUT"
+
+    - id: resolve_token
+      name: Pick per-user PAT or fall back to bot token
+      env:
+        USER_PAT: ${{ secrets[format('PAT_{0}', steps.resolve_key.outputs.key)] }}
+        BOT_TOKEN: ${{ secrets.STAGING_GITHUB_TOKEN }}
+      run: |
+        if [ -n "$USER_PAT" ]; then
+          echo "::add-mask::$USER_PAT"
+          echo "token=$USER_PAT" >> "$GITHUB_OUTPUT"
+          echo "source=user-pat" >> "$GITHUB_OUTPUT"
+          echo "Using per-user PAT for PR creation"
+        else
+          echo "::add-mask::$BOT_TOKEN"
+          echo "token=$BOT_TOKEN" >> "$GITHUB_OUTPUT"
+          echo "source=bot-fallback" >> "$GITHUB_OUTPUT"
+          echo "No per-user PAT found; falling back to bot token"
+        fi
+
     - id: send_pr
       name: Create PR if needed.
       uses: The-OpenROAD-Project/actions/send_pr@main
       env:
-        STAGING_GITHUB_TOKEN: ${{ secrets.STAGING_GITHUB_TOKEN }}
+        STAGING_GITHUB_TOKEN: ${{ steps.resolve_token.outputs.token }}
 
     - name: Linking to PR using deployment.
       uses: The-OpenROAD-Project/actions/link_pr@main


### PR DESCRIPTION
The staging PR opened by github-actions-on-label-create.yml is currently authored by the bot account behind STAGING_GITHUB_TOKEN, hiding the real contributor on the staging side. Add a token-resolution step that, when the PR author has stored a personal access token as repository secret PAT_<LOGIN> (uppercase, '-' -> '_'), uses it to call the PR-creation API so the staging PR is authored by them. Falls back to the bot token when no per-user PAT is configured, preserving today's behavior.