### PR TITLE
flow: Clarify Liberty cell comment

### DIFF
--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -1,4 +1,4 @@
-# Extract cell names
+# Extract Liberty cell names
 proc get_liberty_cell_names { } {
   return [tee -q -s result.string select -list-mod =A:liberty_cell]
 }


### PR DESCRIPTION
## Summary
- Clarify a Tcl utility comment for a second PR workflow test.

## Problem
- A fresh branch from the latest `master` is needed to validate PR creation behavior.

## Solution
- Update one comment in `flow/scripts/util.tcl` from `Extract cell names` to `Extract Liberty cell names`.

## Impact
- Has no runtime, QoR, dependency, or UI impact.
- Changes only a comment.

## Testing
- Not run because this is a comment-only test change.

## Reviewer Notes
- This PR is intentionally minimal and exists for PR workflow testing.

## Related
- Related: None.
