### PR TITLE
Update gf12 jpeg & gcd metrics

### DIFF
--- a/flow/designs/gf12/gcd/rules-base.json
+++ b/flow/designs/gf12/gcd/rules-base.json
@@ -32,7 +32,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -94.6,
+        "value": -178.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {

--- a/flow/designs/gf12/jpeg/rules-base.json
+++ b/flow/designs/gf12/jpeg/rules-base.json
@@ -28,11 +28,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -58.6,
+        "value": -96.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -13300.0,
+        "value": -18500.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -52,7 +52,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -8780.0,
+        "value": -8510.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -64,7 +64,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 413827,
+        "value": 409584,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {


### PR DESCRIPTION
designs/gf12/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |      -94.6 |     -178.0 | Failing  |

designs/gf12/jpeg/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -58.6 |      -96.0 | Failing  |
| cts__timing__setup__tns                       |   -13300.0 |   -18500.0 | Failing  |
| globalroute__timing__setup__tns               |    -8780.0 |    -8510.0 | Tighten  |
| detailedroute__route__wirelength              |     413827 |     409584 | Tighten  |