### PR TITLE
fix make issue missing variables

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -61,13 +61,14 @@ if { $::env(CTS_SNAPSHOTS) } {
 }
 
 if { !$::env(SKIP_CTS_REPAIR_TIMING) } {
-  if { $::env(LEC_CHECK) } {
+  set lec_enabled [lec_check_enabled]
+  if { $lec_enabled } {
     write_lec_verilog 4_before_rsz_lec.v
   }
 
   repair_timing_helper
 
-  if { $::env(LEC_CHECK) } {
+  if { $lec_enabled } {
     write_lec_verilog 4_after_rsz_lec.v
     run_lec_test 4_rsz 4_before_rsz_lec.v 4_after_rsz_lec.v
   }

--- a/flow/scripts/lec_check.tcl
+++ b/flow/scripts/lec_check.tcl
@@ -1,3 +1,11 @@
+proc lec_check_enabled { } {
+  return [expr {
+    [env_var_equals LEC_CHECK 1]
+    && [info exists ::env(KEPLER_FORMAL_EXE)]
+    && [file executable $::env(KEPLER_FORMAL_EXE)]
+  }]
+}
+
 proc write_lec_verilog { filename } {
   set remove_cells [find_physical_only_masters]
   if { [env_var_exists_and_non_empty REMOVE_CELLS_FOR_LEC] } {

--- a/flow/scripts/variables.mk
+++ b/flow/scripts/variables.mk
@@ -201,7 +201,7 @@ export RESULTS_V = $(notdir $(sort $(wildcard $(RESULTS_DIR)/*.v)))
 export GDS_MERGED_FILE = $(RESULTS_DIR)/6_1_merged.$(STREAM_SYSTEM_EXT)
 
 define get_variables
-$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD% OPENSTA% PYTHON% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
+$(foreach V, $(.VARIABLES),$(if $(filter-out $(1), $(origin $V)), $(if $(filter-out .% %QT_QPA_PLATFORM% KLAYOUT% OPENROAD_EXE OPENROAD_ARGS OPENROAD_CMD OPENROAD_NO_EXIT_CMD OPENROAD_GUI_CMD OPENROAD_WEB_CMD OPENROAD_IS_VALID OPENSTA% PYTHON% YOSYS% GENERATE_ABSTRACT_RULE% do-step% do-copy% OPEN_GUI% OPEN_GUI_SHORTCUT% SUB_MAKE% UNSET_VARS% export%, $(V)), $V$ )))
 endef
 
 export UNSET_VARIABLES_NAMES := $(call get_variables,command% line environment% default automatic)


### PR DESCRIPTION
Lately I have been stumbling on two different issues when executing artifacts generated with make issue. This PR fixes both.

They are: 

- `[ERROR GUI-0070] can't read "::env(OPENROAD_HIERARCHICAL)": no such variable`
- `[ERROR GUI-0070] can't read "::env(KEPLER_FORMAL_EXE)": no such variable`

OPENROAD_HIERARCHICAL is excluded from the check with `OPENROAD%`, so it was converted into explicit exclusions.

KEPLER_FORMAL_EXE is correctly stripped from the tarball, but LEC_CHECK=1 is exported, run-me tries to call kepler-formal without knowing where it is. Added a `lec_check_enabled` helper that gates on both.