### PR TITLE
flow/util/generate_klayout_tech: write absolute LEF paths for Bazel sandbox

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -200,7 +200,6 @@ do-klayout:
 		--template $(KLAYOUT_TECH_FILE) \
 		--output $(OBJECTS_DIR)/klayout.lyt \
 		--lef-files $(OBJECTS_DIR)/klayout_tech.lef $(SC_LEF) $(ADDITIONAL_LEFS) \
-		--reference-dir $(RESULTS_DIR) \
 		--map-files $(wildcard $(FLOW_HOME)/platforms/$(PLATFORM)/*map)
 
 $(OBJECTS_DIR)/klayout_wrap.lyt: $(KLAYOUT_TECH_FILE) $(OBJECTS_DIR)/klayout_tech.lef
@@ -212,8 +211,7 @@ do-klayout_wrap:
 	$(PYTHON_EXE) $(UTILS_DIR)/generate_klayout_tech.py \
 		--template $(KLAYOUT_TECH_FILE) \
 		--output $(OBJECTS_DIR)/klayout_wrap.lyt \
-		--lef-files $(OBJECTS_DIR)/klayout_tech.lef $(WRAP_LEFS) \
-		--reference-dir $(OBJECTS_DIR)/def
+		--lef-files $(OBJECTS_DIR)/klayout_tech.lef $(WRAP_LEFS)
 
 $(WRAPPED_LEFS):
 	mkdir -p $(OBJECTS_DIR)/lef $(OBJECTS_DIR)/def

--- a/flow/test/test_generate_klayout_tech.py
+++ b/flow/test/test_generate_klayout_tech.py
@@ -120,9 +120,7 @@ class TestGenerateKlayoutTech(unittest.TestCase):
             template_lyt=self.template,
             output_lyt=self.output,
             lef_files=[lef_path],
-            reference_dir=self.results_dir,
             map_files=[],
-            use_relative_paths=True,
         )
 
         with open(self.output) as f:
@@ -152,9 +150,7 @@ class TestGenerateKlayoutTech(unittest.TestCase):
             template_lyt=self.template,
             output_lyt=self.output,
             lef_files=[lef_path],
-            reference_dir=self.results_dir,
             map_files=[map_path],
-            use_relative_paths=False,
         )
 
         with open(self.output) as f:
@@ -181,9 +177,7 @@ class TestGenerateKlayoutTech(unittest.TestCase):
             template_lyt=self.template,
             output_lyt=self.output,
             lef_files=lef_files,
-            reference_dir=self.results_dir,
             map_files=[],
-            use_relative_paths=True,
         )
 
         with open(self.output) as f:

--- a/flow/test/test_generate_klayout_tech.py
+++ b/flow/test/test_generate_klayout_tech.py
@@ -130,12 +130,13 @@ class TestGenerateKlayoutTech(unittest.TestCase):
 
         self.assertIn("<lef-files>", content)
         self.assertNotIn("original.lef", content)
-        # Path should be relative to results_dir
-        expected_rel = os.path.relpath(
-            os.path.realpath(lef_path),
-            os.path.realpath(self.results_dir),
-        )
-        self.assertIn(expected_rel, content)
+        # LEF paths are written as plain abspath (not relpath, not realpath):
+        # klayout's Layout.read resolves relative <lef-files> entries
+        # against the realpath of the DEF being merged, which under a
+        # Bazel sandbox is the bare execroot -- the in-flight sibling
+        # files only exist in the per-action sandbox.  Absolute paths
+        # bypass the relative-resolution dance.
+        self.assertIn(os.path.abspath(lef_path), content)
 
     def test_with_map_files(self):
         with open(self.template, "w") as f:

--- a/flow/test/test_generate_klayout_tech.py
+++ b/flow/test/test_generate_klayout_tech.py
@@ -160,7 +160,10 @@ class TestGenerateKlayoutTech(unittest.TestCase):
         with open(self.output) as f:
             content = f.read()
 
-        self.assertIn(os.path.realpath(map_path), content)
+        # Same abspath semantics as LEFs: map files are also written as
+        # plain absolute paths so klayout doesn't resolve them relative
+        # to the bare-execroot realpath of the input DEF.
+        self.assertIn(os.path.abspath(map_path), content)
         self.assertNotIn("original.map", content)
 
     def test_multiple_lef_files(self):

--- a/flow/util/generate_klayout_tech.py
+++ b/flow/util/generate_klayout_tech.py
@@ -51,16 +51,15 @@ def generate_klayout_tech(
     with open(template_lyt, "r") as f:
         content = f.read()
 
-    # Both modes use relative paths from reference_dir, matching the
-    # original sed-based behavior which always uses realpath --relative-to.
-    resolved_lefs = [
-        os.path.relpath(os.path.realpath(f), os.path.realpath(reference_dir))
-        for f in lef_files
-    ]
+    # Compute relpath without realpath(): under a Bazel sandbox, bazel-out/
+    # entries are symlinks to the bare execroot; realpath follows them and
+    # makes the generated LYT reference files at the bare-execroot path,
+    # where in-flight outputs do not exist during action execution.
+    resolved_lefs = [os.path.relpath(f, reference_dir) for f in lef_files]
 
     content = replace_lef_files(content, resolved_lefs)
 
-    resolved_maps = [os.path.realpath(f) for f in map_files]
+    resolved_maps = [os.path.abspath(f) for f in map_files]
     content = replace_map_files(content, resolved_maps)
 
     with open(output_lyt, "w") as f:

--- a/flow/util/generate_klayout_tech.py
+++ b/flow/util/generate_klayout_tech.py
@@ -51,11 +51,17 @@ def generate_klayout_tech(
     with open(template_lyt, "r") as f:
         content = f.read()
 
-    # Compute relpath without realpath(): under a Bazel sandbox, bazel-out/
-    # entries are symlinks to the bare execroot; realpath follows them and
-    # makes the generated LYT reference files at the bare-execroot path,
-    # where in-flight outputs do not exist during action execution.
-    resolved_lefs = [os.path.relpath(f, reference_dir) for f in lef_files]
+    # Write absolute (not relative, not realpath'd) LEF paths into the LYT.
+    # Klayout's Layout.read(def, layout_options) follows the symlinked input
+    # DEF to its realpath at the bare execroot and resolves relative
+    # <lef-files> entries from there.  Sibling intermediates like
+    # objects/klayout_tech.lef don't exist at the bare execroot during
+    # action execution -- they're only at the per-action sandbox -- so
+    # resolution fails with errno=2.  Plain abspath (NOT realpath, which
+    # would chase Bazel input-file symlinks back out to the bare execroot)
+    # keeps klayout pointed at the in-sandbox file.  reference_dir is now
+    # unused for LEFs.
+    resolved_lefs = [os.path.abspath(f) for f in lef_files]
 
     content = replace_lef_files(content, resolved_lefs)
 

--- a/flow/util/generate_klayout_tech.py
+++ b/flow/util/generate_klayout_tech.py
@@ -34,8 +34,8 @@ def generate_klayout_tech(
     template_lyt,
     output_lyt,
     lef_files,
-    map_files,
     reference_dir=None,
+    map_files=None,
     use_relative_paths=False,
 ):
     """Generate a klayout .lyt file from a platform template.
@@ -44,10 +44,10 @@ def generate_klayout_tech(
         template_lyt: Path to the platform .lyt template file.
         output_lyt: Path to write the generated .lyt file.
         lef_files: List of LEF file paths to include.
-        map_files: List of map file paths.
         reference_dir: Unused. Accepted for backward compatibility with
             callers (e.g. flow/Makefile) that still pass it from when
             paths were resolved relative to this directory.
+        map_files: List of map file paths.
         use_relative_paths: Unused. Same backward-compat rationale as
             reference_dir -- paths are always written as plain abspath
             now, regardless of this flag.
@@ -69,7 +69,7 @@ def generate_klayout_tech(
 
     content = replace_lef_files(content, resolved_lefs)
 
-    resolved_maps = [os.path.abspath(f) for f in map_files]
+    resolved_maps = [os.path.abspath(f) for f in (map_files or [])]
     content = replace_map_files(content, resolved_maps)
 
     with open(output_lyt, "w") as f:

--- a/flow/util/generate_klayout_tech.py
+++ b/flow/util/generate_klayout_tech.py
@@ -34,9 +34,9 @@ def generate_klayout_tech(
     template_lyt,
     output_lyt,
     lef_files,
-    reference_dir,
     map_files,
-    use_relative_paths,
+    reference_dir=None,
+    use_relative_paths=False,
 ):
     """Generate a klayout .lyt file from a platform template.
 
@@ -44,9 +44,13 @@ def generate_klayout_tech(
         template_lyt: Path to the platform .lyt template file.
         output_lyt: Path to write the generated .lyt file.
         lef_files: List of LEF file paths to include.
-        reference_dir: Directory to compute relative paths from.
         map_files: List of map file paths.
-        use_relative_paths: If True, compute paths relative to reference_dir.
+        reference_dir: Unused. Accepted for backward compatibility with
+            callers (e.g. flow/Makefile) that still pass it from when
+            paths were resolved relative to this directory.
+        use_relative_paths: Unused. Same backward-compat rationale as
+            reference_dir -- paths are always written as plain abspath
+            now, regardless of this flag.
     """
     with open(template_lyt, "r") as f:
         content = f.read()
@@ -59,8 +63,8 @@ def generate_klayout_tech(
     # action execution -- they're only at the per-action sandbox -- so
     # resolution fails with errno=2.  Plain abspath (NOT realpath, which
     # would chase Bazel input-file symlinks back out to the bare execroot)
-    # keeps klayout pointed at the in-sandbox file.  reference_dir is now
-    # unused for LEFs.
+    # keeps klayout pointed at the in-sandbox file.  reference_dir and
+    # use_relative_paths are both ignored.
     resolved_lefs = [os.path.abspath(f) for f in lef_files]
 
     content = replace_lef_files(content, resolved_lefs)
@@ -85,8 +89,12 @@ def main():
     )
     parser.add_argument(
         "--reference-dir",
-        required=True,
-        help="Directory for computing relative paths",
+        required=False,
+        default=None,
+        help=(
+            "Unused; accepted for backward compatibility. LEF / map paths "
+            "are written as plain abspath regardless of this directory."
+        ),
     )
     parser.add_argument(
         "--map-files", nargs="*", default=[], help="Map files to include"
@@ -94,7 +102,10 @@ def main():
     parser.add_argument(
         "--use-relative-paths",
         action="store_true",
-        help="Use paths relative to reference-dir",
+        help=(
+            "Unused; accepted for backward compatibility. LEF / map paths "
+            "are written as plain abspath regardless of this flag."
+        ),
     )
     args = parser.parse_args()
 

--- a/flow/util/generate_klayout_tech.py
+++ b/flow/util/generate_klayout_tech.py
@@ -30,27 +30,14 @@ def replace_map_files(content, map_files):
     return content
 
 
-def generate_klayout_tech(
-    template_lyt,
-    output_lyt,
-    lef_files,
-    reference_dir=None,
-    map_files=None,
-    use_relative_paths=False,
-):
+def generate_klayout_tech(template_lyt, output_lyt, lef_files, map_files=None):
     """Generate a klayout .lyt file from a platform template.
 
     Args:
         template_lyt: Path to the platform .lyt template file.
         output_lyt: Path to write the generated .lyt file.
         lef_files: List of LEF file paths to include.
-        reference_dir: Unused. Accepted for backward compatibility with
-            callers (e.g. flow/Makefile) that still pass it from when
-            paths were resolved relative to this directory.
         map_files: List of map file paths.
-        use_relative_paths: Unused. Same backward-compat rationale as
-            reference_dir -- paths are always written as plain abspath
-            now, regardless of this flag.
     """
     with open(template_lyt, "r") as f:
         content = f.read()
@@ -63,8 +50,7 @@ def generate_klayout_tech(
     # action execution -- they're only at the per-action sandbox -- so
     # resolution fails with errno=2.  Plain abspath (NOT realpath, which
     # would chase Bazel input-file symlinks back out to the bare execroot)
-    # keeps klayout pointed at the in-sandbox file.  reference_dir and
-    # use_relative_paths are both ignored.
+    # keeps klayout pointed at the in-sandbox file.
     resolved_lefs = [os.path.abspath(f) for f in lef_files]
 
     content = replace_lef_files(content, resolved_lefs)
@@ -88,24 +74,7 @@ def main():
         "--lef-files", nargs="*", default=[], help="LEF files to include"
     )
     parser.add_argument(
-        "--reference-dir",
-        required=False,
-        default=None,
-        help=(
-            "Unused; accepted for backward compatibility. LEF / map paths "
-            "are written as plain abspath regardless of this directory."
-        ),
-    )
-    parser.add_argument(
         "--map-files", nargs="*", default=[], help="Map files to include"
-    )
-    parser.add_argument(
-        "--use-relative-paths",
-        action="store_true",
-        help=(
-            "Unused; accepted for backward compatibility. LEF / map paths "
-            "are written as plain abspath regardless of this flag."
-        ),
     )
     args = parser.parse_args()
 
@@ -113,9 +82,7 @@ def main():
         template_lyt=args.template,
         output_lyt=args.output,
         lef_files=args.lef_files,
-        reference_dir=args.reference_dir,
         map_files=args.map_files,
-        use_relative_paths=args.use_relative_paths,
     )
 
 


### PR DESCRIPTION
## Summary

`flow/util/generate_klayout_tech.py` used to emit LEF entries into the
generated `.lyt` as paths relative to `reference_dir`, with the file
first canonicalised via `os.path.realpath`.  Both choices break the
`orfs_gds` step when ORFS runs under a Bazel sandbox:

1. `realpath()` follows symlinks. Inside a Bazel sandbox, `bazel-out/`
   is symlinked back to the bare execroot, so paths get rewritten to
   the execroot location — which doesn't carry the per-action sibling
   files that exist only in the per-action sandbox.

2. Even after dropping `realpath()`, klayout's `Layout.read(def,
   layout_options)` resolves the `<lef-files>` relative entries against
   the *realpath* of the DEF it's merging — which is again the bare
   execroot. Sibling intermediates like `objects/klayout_tech.lef` only
   exist in the per-action sandbox, so resolution fails with errno=2:

   ```
   RuntimeError: Unable to open file:
     .../sandbox/.../execroot/_main/flow/designs/sky130hd/.../tech.lef
   ```

Plain `abspath` (no symlink following) writes the in-sandbox absolute
LEF path into the LYT, which klayout then opens directly with no
relative-resolution dance. Same fix is applied to the .map paths a
few lines below.

Test (`flow/test/test_generate_klayout_tech.py::test_with_template`)
is updated to assert `os.path.abspath(lef_path)` instead of the prior
`os.path.relpath`-against-realpath form.

## Test plan

- [x] Existing `flow/test/test_generate_klayout_tech.py` (13 tests)
      passes against the new behaviour.
- [ ] Existing classic-make flows that consume the generated LYT
      still work — paths going abspath rather than relpath should be
      a strict superset of what klayout accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)