### PR TITLE
fix segment-based RC regression score computation

### DIFF
--- a/flow/util/correlateRC.py
+++ b/flow/util/correlateRC.py
@@ -18,6 +18,22 @@ import matplotlib.pyplot as plt
 
 LAYER_HEADER_RE = re.compile("^([^\\(]+)\\(([^\\)]+)\\)$")
 
+# Helper functions
+# =============================================================================
+
+
+# sklearn's default baseline model for scoring the fit i.e., measuring R² is
+# "predict the mean" which is not the proper model for our regressions since
+# both R and C are through-origin fits - the R² computation doesn't behave
+# well for var(y) ≈ 0 - so we compute R² manually with a "predict zero"
+# baseline model.
+def compute_through_origin_fit_score(model, inputs, observed):
+    sum_squared_observed = (observed**2).sum()
+    if sum_squared_observed == 0:
+        raise ValueError("Cannot score fit: all observed values are zero.")
+    return 1.0 - ((observed - model.predict(inputs)) ** 2).sum() / sum_squared_observed
+
+
 # Parse and validate arguments
 # =============================================================================
 
@@ -410,8 +426,8 @@ if args.mode == "segment":
         resistances,
         capacitances_ff,
     ) in layer_models.items():
-        r_sq_res = res_model.score(lengths, resistances)
-        r_sq_cap = cap_model.score(lengths, capacitances_ff)
+        r_sq_res = compute_through_origin_fit_score(res_model, lengths, resistances)
+        r_sq_cap = compute_through_origin_fit_score(cap_model, lengths, capacitances_ff)
         print("{:<12s} | {:>8.4f} | {:>8.4f}".format(layer_name, r_sq_res, r_sq_cap))
     print("-" * 34)
     print("")

--- a/flow/util/correlateRC.py
+++ b/flow/util/correlateRC.py
@@ -30,8 +30,9 @@ LAYER_HEADER_RE = re.compile("^([^\\(]+)\\(([^\\)]+)\\)$")
 def compute_through_origin_fit_score(model, inputs, observed):
     sum_squared_observed = (observed**2).sum()
     if sum_squared_observed == 0:
-        raise ValueError("Cannot score fit: all observed values are zero.")
-    return 1.0 - ((observed - model.predict(inputs)) ** 2).sum() / sum_squared_observed
+        return "No data"
+    score = 1.0 - ((observed - model.predict(inputs)) ** 2).sum() / sum_squared_observed
+    return f"{score:.4f}"
 
 
 # Parse and validate arguments
@@ -428,7 +429,7 @@ if args.mode == "segment":
     ) in layer_models.items():
         r_sq_res = compute_through_origin_fit_score(res_model, lengths, resistances)
         r_sq_cap = compute_through_origin_fit_score(cap_model, lengths, capacitances_ff)
-        print("{:<12s} | {:>8.4f} | {:>8.4f}".format(layer_name, r_sq_res, r_sq_cap))
+        print("{:<12s} | {:>8s} | {:>8s}".format(layer_name, r_sq_res, r_sq_cap))
     print("-" * 34)
     print("")
 


### PR DESCRIPTION
### Context 
When running the regression for **sky130hs/aes** I got a crazy negative score for the **li1** layer resistance fit.

This design had a few geometrically identical small segments on this layer that are a result of a pin access maneuver to allow reaching an instance's pin:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5ab7e338-f615-4a39-8d5c-a7e24ae0c3c8" />

It turns out that **sklearn**'s default baseline model for scoring the fit i.e., measuring R² is "predict the mean" which is not the proper model for our regressions since both R and C are through-origin fits - the R² computation doesn't behave well for near-zero variance. A more proper approach would be to compute R² with a "predict zero" baseline model.

### Changes

Compute the fit score manually using a helper function that uses "predict zero" baseline model rather than **.score**.

### Observations

- I didn't change how net mode scores its fit.
- The fit itself won't change with this PR, just the score value.
- The scores will change slightly even for cases in which the value was already "correct" as we're measuring against a different baseline.