### PR TITLE
Update designs/gf12/ca53/rules-base.json

### DIFF
--- a/flow/designs/gf12/ca53/rules-base.json
+++ b/flow/designs/gf12/ca53/rules-base.json
@@ -1,4 +1,14 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "N/A",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "b6f8ea66f3c6e3acaa00d44dd0b50c5f80dbaaef",
+        "compare": "==",
+        "level": "warning"
+    },
     "constraints__clocks__count": {
         "value": 1,
         "compare": "=="
@@ -24,11 +34,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -538.0,
+        "value": -100.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1660.0,
+        "value": -400.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -44,7 +54,7 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -215.0,
+        "value": -100.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
@@ -88,7 +98,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -2440.0,
+        "value": -4350.0,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -538.0 |     -100.0 | Tighten  |
| cts__timing__setup__tns                       |    -1660.0 |     -400.0 | Tighten  |
| globalroute__timing__setup__ws                |     -215.0 |     -100.0 | Tighten  |
| finish__timing__hold__tns                     |    -2440.0 |    -4350.0 | Failing  |