### PR TITLE
update sky130hs layer resistance with segment-based regression results

### DIFF
--- a/flow/platforms/sky130hs/setRC.tcl
+++ b/flow/platforms/sky130hs/setRC.tcl
@@ -1,12 +1,9 @@
-# correlateRC.py gcd,ibex,aes,jpeg,chameleon,riscv32i,chameleon_hier
-# cap units pf/um
-set_layer_rc -layer li1 -capacitance 1.499e-04 -resistance 7.176e-02
-set_layer_rc -layer met1 -capacitance 1.72375E-04 -resistance 8.929e-04
-set_layer_rc -layer met2 -capacitance 1.36233E-04 -resistance 8.929e-04
-set_layer_rc -layer met3 -capacitance 2.14962E-04 -resistance 1.567e-04
-set_layer_rc -layer met4 -capacitance 1.48128E-04 -resistance 1.567e-04
-set_layer_rc -layer met5 -capacitance 1.54087E-04 -resistance 1.781e-05
-# end correlate
+set_layer_rc -layer li1 -capacitance 1.499e-04 -resistance 6.81778E-02
+set_layer_rc -layer met1 -capacitance 1.72375E-04 -resistance 1.20566E-03
+set_layer_rc -layer met2 -capacitance 1.36233E-04 -resistance 1.22133E-03
+set_layer_rc -layer met3 -capacitance 2.14962E-04 -resistance 1.66286E-04
+set_layer_rc -layer met4 -capacitance 1.48128E-04 -resistance 1.68095E-04
+set_layer_rc -layer met5 -capacitance 1.54087E-04 -resistance 1.83574E-05
 
 set_layer_rc -via mcon -resistance 9.249146E-3
 set_layer_rc -via via -resistance 4.5E-3


### PR DESCRIPTION
For #4243.

### Correlation Data

**Mode:** segment
**Designs (5):** aes, gcd, ibex, jpeg, riscv32i.
**OR Version:** bfd6383488 (nightly 7015)
**Units:** R [kΩ/μm], C [pF/μm]

The resistance values that we were using weren't actually precise. Probably something off with the net-based regression script. The resistance fits obtained with the new segment-based regression have perfect (1.00) R².

I cleaned up the setRC.tcl script so that the data w.r.t. the correlation is tracked here rather than having comments in the file.