### PR TITLE
update ihp layer resistance with segment-based regression results

### DIFF
--- a/flow/platforms/ihp-sg13g2/setRC.tcl
+++ b/flow/platforms/ihp-sg13g2/setRC.tcl
@@ -1,10 +1,9 @@
-# correlation result (aes, gcd, ibex, riscv32i, spi)
-# Metal1 capacitance fixed up from -1.1e-05 to 1e-10 as a minuscule positive value
 set_layer_rc -layer Metal1 -resistance 8.54576E-03 -capacitance 1e-10
-set_layer_rc -layer Metal2 -resistance 2.53519E-03 -capacitance 1.69121E-04
-set_layer_rc -layer Metal3 -resistance 1.54329E-03 -capacitance 1.82832E-04
-set_layer_rc -layer Metal4 -resistance 6.31424E-04 -capacitance 1.66454E-04
-set_layer_rc -layer Metal5 -resistance 6.84051E-04 -capacitance 8.57431E-05
+set_layer_rc -layer Metal2 -resistance 4.40000E-04 -capacitance 1.69121E-04
+set_layer_rc -layer Metal3 -resistance 4.40000E-04 -capacitance 1.82832E-04
+set_layer_rc -layer Metal4 -resistance 4.39998E-04 -capacitance 1.66454E-04
+set_layer_rc -layer Metal5 -resistance 4.40004E-04 -capacitance 8.57431E-05
+
 set_wire_rc -signal -resistance 2.07259E-03 -capacitance 1.73072E-04
 set_wire_rc -clock -resistance 2.48603E-03 -capacitance 1.44812E-04
 


### PR DESCRIPTION
For #4243.

### Correlation Data

**Mode:** segment
**Designs (7):** aes, gcd, i2c-gpio-expander, ibex, jpeg, riscv32i, spi.
**OR Version:** bfd6383488 (nightly 7017)
**Units:** R [kΩ/μm], C [pF/μm]

The resistance values that we were using weren't actually precise. Probably something off with the net-based regression script. The resistance fits obtained with the new segment-based regression have perfect (1.00) R². The fact that the resistance values came out the same for the layers with routing is not a coincidence - it matches the RCX RESOVER table rules.

I cleaned up the setRC.tcl script so that the data w.r.t. the correlation is tracked here rather than having comments in the file.

### Observations Regarding Metal1
 - No regression data - the old values were kept.
