### PR TITLE
flow: pass CTS_DPL_DISPLACEMENT to post-CTS detailed_placement

### DIFF
--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -46,7 +46,7 @@ set_placement_padding -global \
   -left $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT) \
   -right $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
 
-set dpl_args {}
+set dpl_args [env_var_or_empty CTS_DPL_DISPLACEMENT]
 append_env_var dpl_args USE_NEGOTIATION -use_negotiation 0
 set result [catch { log_cmd detailed_placement {*}$dpl_args } msg]
 if { $result != 0 } {


### PR DESCRIPTION
## Summary

- Seed `dpl_args` in `flow/scripts/cts.tcl` from `env_var_or_empty CTS_DPL_DISPLACEMENT` instead of the empty list, so the post-CTS `detailed_placement` call can receive extra flags (e.g. `-max_displacement <row> <site>`) via env var instead of needing a forked script.
- When `CTS_DPL_DISPLACEMENT` is unset, `env_var_or_empty` returns `""` and `{*}$dpl_args` expands to nothing — fully backward compatible with the previous `{}` initialization.

## Test plan

- [ ] CI green
- [ ] With `CTS_DPL_DISPLACEMENT` unset, post-CTS detailed_placement behaves identically (no flag added).
- [ ] With `CTS_DPL_DISPLACEMENT="-max_displacement 5 5"`, the flag reaches `detailed_placement`.