### PR TITLE
feat(docker): collect tool LICENSE files into install dir

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
 # Build working directories
+tools/OpenROAD/build/
+tools/yosys-slang/build/
+tools/kepler-formal/build/
 
 # Build files
 build_openroad.log

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -51,7 +51,8 @@ EOF
 RUN find /OpenROAD-flow-scripts/tools \( -name "*LICENSE*" -o -name "*LICENSES*" \) \
     | grep -v '/OpenROAD/src/sta/' \
     | grep -v '/AutoTuner/' \
-    | while read -r f; do \
+    | grep -v '^/OpenROAD-flow-scripts/tools/install/' \
+    | while IFS= read -r f; do \
         rel="${f#/OpenROAD-flow-scripts/tools/}"; \
         mkdir -p "/OpenROAD-flow-scripts/tools/install/licenses/$(dirname "$rel")"; \
         cp -r "$f" "/OpenROAD-flow-scripts/tools/install/licenses/$rel"; \

--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -45,6 +45,18 @@ if [ -n "${verificPath}" ]; then
 fi
 EOF
 
+# Collect LICENSE files from tool source trees into the install directory so
+# they are available in the final image. tools/OpenROAD/src/sta is excluded
+# because it is covered by a separate commercial license agreement.
+RUN find /OpenROAD-flow-scripts/tools \( -name "*LICENSE*" -o -name "*LICENSES*" \) \
+    | grep -v '/OpenROAD/src/sta/' \
+    | grep -v '/AutoTuner/' \
+    | while read -r f; do \
+        rel="${f#/OpenROAD-flow-scripts/tools/}"; \
+        mkdir -p "/OpenROAD-flow-scripts/tools/install/licenses/$(dirname "$rel")"; \
+        cp -r "$f" "/OpenROAD-flow-scripts/tools/install/licenses/$rel"; \
+    done
+
 FROM orfs-base
 
 # The order for copying the directories is based on the frequency of changes (ascending order),


### PR DESCRIPTION
Copy LICENSE files from tool source trees into tools/install/licenses/ so they are included in the final image. Excludes tools/OpenROAD/src/sta.

Fixes: https://github.com/The-OpenROAD-Project/AutoTuner/issues/146

Repro:
```
docker run --rm license-test:latest find /work/install/licenses -type f | sort
```

Output:
```
/work/install/licenses/kepler-formal/thirdparty/naja/thirdparty/naja-verilog/LICENSE           
/work/install/licenses/kepler-formal/thirdparty/naja/thirdparty/naja-verilog/LICENSES/Apache-2.0.txt
/work/install/licenses/kepler-formal/thirdparty/naja/thirdparty/naja-verilog/LICENSES/CC0-1.0.txt   
/work/install/licenses/kepler-formal/thirdparty/naja/thirdparty/naja-verilog/thirdparty/googletest/LICENSE
/work/install/licenses/kepler-formal/thirdparty/naja/thirdparty/spdlog-1.17.0/LICENSE                     
/work/install/licenses/kepler-formal/thirdparty/yaml-cpp/LICENSE                                          
/work/install/licenses/kepler-formal/thirdparty/yaml-cpp/test/googletest-1.13.0/LICENSE                   
/work/install/licenses/yosys-slang/LICENSE                                                                
/work/install/licenses/yosys-slang/third_party/fmt/LICENSE                                                
/work/install/licenses/yosys-slang/third_party/slang/LICENSE                                              
/work/install/licenses/yosys-slang/third_party/slang/LICENSES/BSL-1.0.txt                                 
/work/install/licenses/yosys-slang/third_party/slang/LICENSES/MIT.txt                                     
/work/install/licenses/yosys/abc/src/misc/btor/LICENSE.txt                                                
/work/install/licenses/yosys/abc/src/misc/bzlib/LICENSE                                                   
/work/install/licenses/yosys/abc/src/sat/bsat2/LICENSE                                                    
/work/install/licenses/yosys/abc/src/sat/cadical/LICENSE                                                  
/work/install/licenses/yosys/abc/src/sat/kissat/LICENSE                                                   
/work/install/licenses/yosys/abc/src/sat/satoko/LICENSE                                                   
/work/install/licenses/yosys/libs/cxxopts/LICENSE                                                         
/work/install/licenses/yosys/libs/minisat/LICENSE 
```