### PR TITLE
gha: use commit sha instead of version/tag

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -5,5 +5,5 @@ jobs:
   lint:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: psf/black@stable
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: psf/black@87928e6d6761a4a6d22250e1fee5601b3998086e  # 26.5.1

--- a/.github/workflows/github-actions-cron-test-installer.yml
+++ b/.github/workflows/github-actions-cron-test-installer.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/github-actions-cron-update-OR.yml
+++ b/.github/workflows/github-actions-cron-update-OR.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code recursively
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
       - name: Pull changes in OpenROAD submodule
@@ -24,7 +24,7 @@ jobs:
           git pull
       - if: "steps.remote-update.outputs.has_update != ''"
         name: Create Draft PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ github.token }}
           signoff: true

--- a/.github/workflows/github-actions-cron-update-yosys.yml
+++ b/.github/workflows/github-actions-cron-update-yosys.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code recursively
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           submodules: recursive
           fetch-depth: 0
@@ -28,7 +28,7 @@ jobs:
           git checkout ${latesttag}
       - if: "steps.remote-update.outputs.has_update != ''"
         name: Create Draft PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ github.token }}
           signoff: true

--- a/.github/workflows/github-actions-cron-util-test.yml
+++ b/.github/workflows/github-actions-cron-util-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: recursive

--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/github-actions-manual-update-rules.yml
+++ b/.github/workflows/github-actions-manual-update-rules.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out repository code recursively
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
       - name: Install Python Packages

--- a/.github/workflows/github-actions-on-push.yml
+++ b/.github/workflows/github-actions-on-push.yml
@@ -11,6 +11,6 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: run security_scan_on_push
         uses: The-OpenROAD-Project/actions/security_scan_on_push@main

--- a/.github/workflows/github-actions-publish-docker-images.yml
+++ b/.github/workflows/github-actions-publish-docker-images.yml
@@ -30,24 +30,24 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     timeout-minutes: 600
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set environment variables
         run: echo "IMAGE=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Login to GitHub Container Registry (GHCR)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: gha
           password: ${{ github.token }}
 
       - name: Build and export codespaces image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           push: true
@@ -64,7 +64,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: recursive
@@ -74,11 +74,11 @@ jobs:
           echo "IMAGE_DEPS=ghcr.io/$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')-dev/${{ matrix.os[0] }}" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Login to GitHub Container Registry (GHCR)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: gha
@@ -88,7 +88,7 @@ jobs:
         run: cp tools/OpenROAD/etc/DependencyInstaller.sh etc/InstallerOpenROAD.sh
 
       - name: Build and export dependencies image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: etc
           push: true
@@ -108,12 +108,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: false
 
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
           submodules: recursive
@@ -125,18 +125,18 @@ jobs:
           echo "NUM_THREADS=$(nproc)" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
       - name: Login to GitHub Container Registry (GHCR)
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: gha
           password: ${{ github.token }}
 
       - name: Build and export ORFS image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           push: true

--- a/.github/workflows/github-actions-quarterly-tag.yml
+++ b/.github/workflows/github-actions-quarterly-tag.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Determine tag name
         id: tag

--- a/.github/workflows/github-actions-stale.yml
+++ b/.github/workflows/github-actions-stale.yml
@@ -18,7 +18,7 @@ jobs:
       actions: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:
           days-before-stale: 60
           days-before-close: 21

--- a/.github/workflows/github-actions-update-rules.yml
+++ b/.github/workflows/github-actions-update-rules.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out repository code recursively
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Git prep
@@ -19,7 +19,7 @@ jobs:
           git config --add remote.origin.fetch "+refs/pull/*/head:refs/remotes/origin/pr/*"
           git fetch
           git checkout "origin/pr/${{ github.event.client_payload.branch }}"
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
       - name: Install Python Packages
@@ -58,7 +58,7 @@ jobs:
           git push origin "HEAD:refs/pull/${{ github.event.client_payload.branch }}/head"
       - if: "steps.remote-update.outputs.has_update == 'true' && github.event.client_payload.branch == 'master'"
         name: Create Draft PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1  # v8.1.1
         with:
           token: ${{ github.token }}
           signoff: true

--- a/.github/workflows/github-actions-yaml-test.yml
+++ b/.github/workflows/github-actions-yaml-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 1
         sparse-checkout: |


### PR DESCRIPTION
Using commit sha helps prevent chain attacks that have become common.