### PR TITLE
metric updates for est_fix_vias update

### DIFF
--- a/flow/designs/asap7/jpeg_lvt/rules-base.json
+++ b/flow/designs/asap7/jpeg_lvt/rules-base.json
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -120.0,
+        "value": -303.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/mock-alu/rules-base.json
+++ b/flow/designs/asap7/mock-alu/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -19300.0,
+        "value": -19400.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "52b64582f28d0ff10363e398dcb68a7ada693e7a",
+        "value": "855cc88198fc9faaf17317eaea4a3a07a4340d1d",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "79bb486be7570e7e421fd58aa35e4fd0cbbafb61",
+        "value": "6a79c1ff7404b566e96c52493d7eec2316d12f6a",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/nangate45/ariane133/rules-base.json
+++ b/flow/designs/nangate45/ariane133/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -572.0,
+        "value": -591.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -606.0,
+        "value": -616.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1416,
+        "value": 1439,
         "compare": "<="
     },
     "finish__timing__setup__ws": {


### PR DESCRIPTION
OpenROAD PR: https://github.com/The-OpenROAD-Project/OpenROAD/pull/10544

## Updated Rules
[WARNING] Multiple clocks not supported. Will use first clock: mrx_clk_pad_i: 300.0000.
[WARNING] Multiple clocks not supported. Will use first clock: mrx_clk_pad_i: 300.0000.
designs/asap7/jpeg_lvt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| finish__timing__setup__tns                    |     -120.0 |     -303.0 | Failing  |

designs/asap7/mock-alu/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |   -19300.0 |   -19400.0 | Failing  |

[WARNING] Multiple clocks not supported. Will use first clock: clk: 333.0000.
designs/asap7/riscv32i-mock-sram/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 52b64582f28d0ff10363e398dcb68a7ada693e7a | 855cc88198fc9faaf17317eaea4a3a07a4340d1d | Failing  |

designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 79bb486be7570e7e421fd58aa35e4fd0cbbafb61 | 6a79c1ff7404b566e96c52493d7eec2316d12f6a | Failing  |

designs/nangate45/ariane133/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -572.0 |     -591.0 | Failing  |
| finish__timing__setup__tns                    |     -606.0 |     -616.0 | Failing  |

[WARNING] Multiple clocks not supported. Will use first clock: clk_i: 3.0000.
[WARNING] Multiple clocks not supported. Will use first clock: ext_clk: 15.0000.
designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| detailedroute__antenna_diodes_count           |       1416 |       1439 | Failing  |


## Messages from CI
[INFO] asap7/minimal not included in CI.
[INFO] gf12 not included in the update.
[INFO] gf55 not included in the update.
[INFO] nangate45/bp_quad not included in CI.
