### PR TITLE
updates for EST fixes

### DIFF
--- a/flow/designs/asap7/gcd-ccs/config.mk
+++ b/flow/designs/asap7/gcd-ccs/config.mk
@@ -1,3 +1,8 @@
 export DESIGN_NICKNAME = gcd-ccs
 export LIB_MODEL = CCS
 include designs/asap7/gcd/config.mk
+
+# Lower the core utilization from 65 (base asap7/gcd) to 60
+# due to a DPL failure at the global route stage due to extra
+# buffers inserted by repair_timing
+export CORE_UTILIZATION = 60

--- a/flow/designs/asap7/gcd-ccs/rules-base.json
+++ b/flow/designs/asap7/gcd-ccs/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "9b1daddbf16520e983085be7f06a02bc2fc2e27a",
+        "value": "7250dc152c2381ac020b86c78a5191b1c336244b",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "2d3fbf9f1b7357c0cadb1e193d984ae458d68fa8",
+        "value": "a954b979a1a0eff89ed870fa50d202847b6807bf",
         "compare": "==",
         "level": "warning"
     },
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -63.5,
+        "value": -79.2,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -773.0,
+        "value": -1260.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -63.5,
+        "value": -93.7,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -771.0,
+        "value": -1530.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -84.2,
+        "value": -78.5,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1200.0,
+        "value": -1190.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
designs/asap7/gcd-ccs/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -63.5 |      -79.2 | Failing  |
| cts__timing__setup__tns                       |     -773.0 |    -1260.0 | Failing  |
| globalroute__timing__setup__ws                |      -63.5 |      -93.7 | Failing  |
| globalroute__timing__setup__tns               |     -771.0 |    -1530.0 | Failing  |
| finish__timing__setup__ws                     |      -84.2 |      -78.5 | Tighten  |
| finish__timing__setup__tns                    |    -1200.0 |    -1190.0 | Tighten  |