### PR TITLE
Update metrics grt incremental fix

### DIFF
--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "855cc88198fc9faaf17317eaea4a3a07a4340d1d",
+        "value": "8b6a7c8c51339babf0f00aeb44dd4b65ab30b183",
         "compare": "==",
         "level": "warning"
     },
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 64313,
+        "value": 63228,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -230.0,
+        "value": -1720.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "8b6a7c8c51339babf0f00aeb44dd4b65ab30b183",
+        "value": "58bf274dad2592154068ebaf8f3893ccf8b388fa",
         "compare": "==",
         "level": "warning"
     },
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1720.0,
+        "value": -2770.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/gcd/rules-base.json
+++ b/flow/designs/gf12/gcd/rules-base.json
@@ -1,4 +1,14 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "a5874bf0d7a4676c0e25a99a5c7f6fcc237ed682",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "4289d9760a66cd6331d0d0a75d97005969ecace5",
+        "compare": "==",
+        "level": "warning"
+    },
     "synth__design__instance__area__stdcell": {
         "value": 107.0,
         "compare": "<="
@@ -52,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -133.0,
+        "value": -210.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/ihp-sg13g2/jpeg/rules-base.json
+++ b/flow/designs/ihp-sg13g2/jpeg/rules-base.json
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 120,
+        "value": 121,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/ihp-sg13g2/jpeg/rules-base.json
+++ b/flow/designs/ihp-sg13g2/jpeg/rules-base.json
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 109,
+        "value": 120,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/nangate45/aes/rules-base.json
+++ b/flow/designs/nangate45/aes/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.673,
+        "value": -0.671,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -70,7 +70,7 @@
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -0.726,
+        "value": -0.624,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -0.167,
+        "value": -0.339,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/ariane133/rules-base.json
+++ b/flow/designs/nangate45/ariane133/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -577.0,
+        "value": -576.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -576.0,
+        "value": -585.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/bp_be_top/rules-base.json
+++ b/flow/designs/nangate45/bp_be_top/rules-base.json
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -19.1,
+        "value": -20.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/bp_fe_top/rules-base.json
+++ b/flow/designs/nangate45/bp_fe_top/rules-base.json
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1.23,
+        "value": -1.8,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/swerv/rules-base.json
+++ b/flow/designs/nangate45/swerv/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -485.0,
+        "value": -502.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 2366013,
+        "value": 2365053,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -479.0,
+        "value": -609.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 183688,
+        "value": 183574,
         "compare": "<="
     }
 }

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.345,
+        "value": -0.34,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -146.0,
+        "value": -157.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -126.0,
+        "value": -142.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -142.0,
+        "value": -143.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/aes/fastroute.tcl
+++ b/flow/designs/sky130hd/aes/fastroute.tcl
@@ -1,4 +1,4 @@
-set_global_routing_layer_adjustment $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) 0.4
+set_global_routing_layer_adjustment $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER) 0.3
 
 set_routing_layers -clock $::env(MIN_CLK_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)
 set_routing_layers -signal $::env(MIN_ROUTING_LAYER)-$::env(MAX_ROUTING_LAYER)

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -54,11 +54,11 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 196,
+        "value": 200,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.944,
+        "value": -0.943,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -88.8,
+        "value": -89.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.85,
+        "value": -1.82,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -87.6,
+        "value": -85.7,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/jpeg/rules-base.json
+++ b/flow/designs/sky130hd/jpeg/rules-base.json
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 100,
+        "value": 102,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.764,
+        "value": -0.754,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -111.0,
+        "value": -113.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -42.9,
+        "value": -42.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1333,
+        "value": 1364,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -345.0,
+        "value": -306.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -86,23 +86,23 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1434,
+        "value": 1281,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.7,
+        "value": -2.65,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -360.0,
+        "value": -306.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -1.0,
+        "value": -0.964,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -6.71,
+        "value": -6.38,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 0,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1281,
+        "value": 1352,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,15 +94,15 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -306.0,
+        "value": -305.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.964,
+        "value": -0.959,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -6.38,
+        "value": -5.94,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/sky130hd/riscv32i/rules-base.json
+++ b/flow/designs/sky130hd/riscv32i/rules-base.json
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -167.0,
+        "value": -169.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/riscv32i/rules-base.json
+++ b/flow/designs/sky130hd/riscv32i/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -300.0,
+        "value": -304.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/sky130hs/ibex/rules-base.json
+++ b/flow/designs/sky130hs/ibex/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -23.4,
+        "value": -43.4,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/sky130hs/riscv32i/rules-base.json
+++ b/flow/designs/sky130hs/riscv32i/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -134.0,
+        "value": -142.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 346876,
+        "value": 346646,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -20.9,
+        "value": -29.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
GRT results are fine. Some designs had a degradation in post-DRT stage (e.g., asap7 riscv32i-mock-sram).
Related to this [PR](https://github.com/The-OpenROAD-Project/OpenROAD/pull/10455)

designs/nangate45/aes/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -0.673 |     -0.671 | Tighten  |
| globalroute__timing__hold__tns                |     -0.726 |     -0.624 | Tighten  |
| finish__timing__setup__tns                    |     -0.167 |     -0.339 | Failing  |

designs/nangate45/ariane133/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -577.0 |     -576.0 | Tighten  |
| finish__timing__setup__tns                    |     -576.0 |     -585.0 | Failing  |

designs/nangate45/bp_be_top/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| finish__timing__setup__tns                    |      -19.1 |      -20.0 | Failing  |

designs/nangate45/bp_fe_top/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| finish__timing__setup__tns                    |      -1.23 |       -1.8 | Failing  |

designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |        196 |        200 | Failing  |
| globalroute__timing__setup__ws                |     -0.944 |     -0.943 | Tighten  |

designs/sky130hd/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |      -88.8 |      -89.0 | Failing  |
| finish__timing__setup__ws                     |      -1.85 |      -1.82 | Tighten  |
| finish__timing__setup__tns                    |      -87.6 |      -85.7 | Tighten  |

designs/sky130hs/ibex/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |      -23.4 |      -43.4 | Failing  |

designs/sky130hd/jpeg/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |        100 |        102 | Failing  |
| globalroute__timing__setup__ws                |     -0.764 |     -0.754 | Tighten  |
| globalroute__timing__setup__tns               |     -111.0 |     -113.0 | Failing  |
| finish__timing__setup__tns                    |      -42.9 |      -42.2 | Tighten  |

designs/ihp-sg13g2/jpeg/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| detailedroute__antenna_diodes_count           |        109 |        120 | Failing  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |       1333 |       1364 | Failing  |
| globalroute__timing__setup__tns               |     -345.0 |     -306.0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1434 |       1281 | Tighten  |
| finish__timing__setup__ws                     |       -2.7 |      -2.65 | Tighten  |
| finish__timing__setup__tns                    |     -360.0 |     -306.0 | Tighten  |
| finish__timing__hold__ws                      |       -1.0 |     -0.964 | Tighten  |
| finish__timing__hold__tns                     |      -6.71 |      -6.38 | Tighten  |

designs/sky130hd/riscv32i/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -300.0 |     -304.0 | Failing  |

designs/sky130hs/riscv32i/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -134.0 |     -142.0 | Failing  |
| detailedroute__route__wirelength              |     346876 |     346646 | Tighten  |
| finish__timing__setup__tns                    |      -20.9 |      -29.2 | Failing  |

designs/asap7/riscv32i-mock-sram/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 855cc88198fc9faaf17317eaea4a3a07a4340d1d | 8b6a7c8c51339babf0f00aeb44dd4b65ab30b183 | Failing  |
| detailedroute__route__wirelength              |      64313 |      63228 | Tighten  |
| finish__timing__setup__tns                    |     -230.0 |    -1720.0 | Failing  |

designs/nangate45/swerv/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -485.0 |     -502.0 | Failing  |
| detailedroute__route__wirelength              |    2366013 |    2365053 | Tighten  |
| finish__timing__setup__tns                    |     -479.0 |     -609.0 | Failing  |
| finish__design__instance__area                |     183688 |     183574 | Tighten  |

designs/nangate45/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__ws                |     -0.345 |      -0.34 | Tighten  |
| globalroute__timing__setup__tns               |     -146.0 |     -157.0 | Failing  |
| finish__timing__setup__tns                    |     -126.0 |     -142.0 | Failing  |

designs/gf12/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -133.0 |     -210.0 | Failing  |

