### PR TITLE
fix: make issue tarballs self-contained when WORK_HOME differs

### DIFF
--- a/flow/test/test_make_issue.sh
+++ b/flow/test/test_make_issue.sh
@@ -15,13 +15,12 @@ make ISSUE_TAG=tag DESIGN_CONFIG=designs/asap7/gcd/config.mk ${ISSUE_TARGET}_iss
 test_archive=${ISSUE_TARGET}_tag.tar.gz
 ls -l $test_archive
 echo "Testing $test_archive"
-runme=$(realpath run-me-gcd-asap7-base.sh)
 . ../env.sh
 rm -rf results/make-issue/
 mkdir -p results/make-issue/
 cd results/make-issue/
 tar --strip-components=1 -xzf ../../$test_archive
-sed -i 's/openroad -no_init/openroad -exit -no_init/g' $runme
-$runme
+sed -i 's/openroad -no_init/openroad -exit -no_init/g' run-me-gcd-asap7-base.sh
+./run-me-gcd-asap7-base.sh
 # check for basic syntax errors
 openroad -exit -no_init vars-gcd-asap7-base.tcl

--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 FLOW_ROOT=$(realpath "${FLOW_HOME}")
 ORFS_ROOT=$(realpath "${FLOW_HOME}/../")
+WORK_ROOT=$(realpath "${WORK_HOME:-.}")
 
 # exclude system and CI variables
 EXCLUDED_VARS='MAKE|MAKEFLAGS|PERL5LIB|QT_QPA_PLATFORM'
@@ -54,6 +55,15 @@ while read -r VAR; do
 
     # PII members use PRESERVE_PATHS=1 make issue ...
     if [[ ! -v PRESERVE_PATHS ]]; then
+        # Relativize paths under WORK_HOME (e.g. a CI workspace); makeIssue.sh
+        # stores those files at the tarball root. Both the literal and the
+        # symlink-resolved form may appear in values. Skip when WORK_HOME is
+        # FLOW_HOME, which is handled via ${FLOW_HOME} below.
+        for work_path in "${WORK_HOME:-.}" "${WORK_ROOT}"; do
+            if [[ "${work_path}" == /* && "${work_path}" != "${FLOW_ROOT}" ]]; then
+                value=$(sed -e "s,\(^\|[: \"']\)${work_path},\1.,g" <<< "${value}")
+            fi
+        done
         for path in workspace platforms; do
             value=$(sed -e "s,\(^\|[: \"']\)/${path},\1./${path},g" <<< "${value}")
         done

--- a/flow/util/generate-vars.sh
+++ b/flow/util/generate-vars.sh
@@ -60,8 +60,11 @@ while read -r VAR; do
         # symlink-resolved form may appear in values. Skip when WORK_HOME is
         # FLOW_HOME, which is handled via ${FLOW_HOME} below.
         for work_path in "${WORK_HOME:-.}" "${WORK_ROOT}"; do
+            work_path="${work_path%/}"
             if [[ "${work_path}" == /* && "${work_path}" != "${FLOW_ROOT}" ]]; then
-                value=$(sed -e "s,\(^\|[: \"']\)${work_path},\1.,g" <<< "${value}")
+                # require a path boundary after the match so e.g. /tmp/work
+                # does not corrupt /tmp/work_other
+                value=$(sed -e "s,\(^\|[: \"']\)${work_path}\(/\|[: \"']\|$\),\1.\2,g" <<< "${value}")
             fi
         done
         for path in workspace platforms; do

--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -132,9 +132,9 @@ fi
 # the tarball root instead of recreating the absolute path (e.g. tmp/...).
 # Both the literal and the symlink-resolved form may appear in member names.
 WORK_ROOT=$(realpath "${WORK_HOME:-.}")
-WORK_HOME_TRANSFORMS=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_ROOT}/|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
-if [[ "${WORK_HOME:-.}" == /* && "${WORK_HOME:-.}" != "${WORK_ROOT}" ]]; then
-    WORK_HOME_TRANSFORMS+=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_HOME}/|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
+WORK_HOME_TRANSFORMS=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_ROOT}//*|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
+if [[ "${WORK_HOME:-.}" == /* && "${WORK_HOME%/}" != "${WORK_ROOT}" ]]; then
+    WORK_HOME_TRANSFORMS+=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_HOME%/}//*|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
 fi
 tar --use-compress-program=${COMPRESS} \
     --ignore-failed-read -chf ${TAR_NAME} \

--- a/flow/util/makeIssue.sh
+++ b/flow/util/makeIssue.sh
@@ -80,17 +80,22 @@ else
     IS_YOSYS=0
 fi
 
+# Source the vars file relative to the run-me script itself, so the
+# reproducible works out of the box wherever the tarball is extracted
+# (WORK_HOME is an absolute CI path that does not exist elsewhere).
 if [ "$IS_YOSYS" -eq 1 ]; then
 cat > ${RUN_ME_SCRIPT} <<EOF
 #!/usr/bin/env bash
-source ${VARS_BASENAME}.sh
+cd "\$(dirname "\$0")"
+source ./$(basename ${VARS_BASENAME}).sh
 export PYTHON_EXE=\${PYTHON_EXE:-\$(command -v python3)}
 yosys ${YOSYS_FLAGS:-} -c \${SCRIPTS_DIR}/${ISSUE_TARGET}.tcl
 EOF
 else
 cat > ${RUN_ME_SCRIPT} <<EOF
 #!/usr/bin/env bash
-source ${VARS_BASENAME}.sh
+cd "\$(dirname "\$0")"
+source ./$(basename ${VARS_BASENAME}).sh
 if [[ ! -z \${GDB+x} ]]; then
     gdb --args openroad -no_init -threads ${NUM_CORES:-1} \${SCRIPTS_DIR}/${ISSUE_TARGET}.tcl
 else
@@ -122,10 +127,20 @@ else
     DESIGN_PLATFORM_FILES="$DESIGN_CONFIG $PLATFORM_DIR/config*.mk"
 fi
 
+# Strip the WORK_HOME prefix as well, so files generated outside FLOW_HOME
+# (vars, run-me, logs, ... when WORK_HOME points at a CI workspace) land at
+# the tarball root instead of recreating the absolute path (e.g. tmp/...).
+# Both the literal and the symlink-resolved form may appear in member names.
+WORK_ROOT=$(realpath "${WORK_HOME:-.}")
+WORK_HOME_TRANSFORMS=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_ROOT}/|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
+if [[ "${WORK_HOME:-.}" == /* && "${WORK_HOME:-.}" != "${WORK_ROOT}" ]]; then
+    WORK_HOME_TRANSFORMS+=(--transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${WORK_HOME}/|${ISSUE_TARGET}_${ISSUE_TAG}/|S")
+fi
 tar --use-compress-program=${COMPRESS} \
     --ignore-failed-read -chf ${TAR_NAME} \
     --transform="s|^|${ISSUE_TARGET}_${ISSUE_TAG}/|S" \
     --transform="s|^${ISSUE_TARGET}_${ISSUE_TAG}${FLOW_HOME}/|${ISSUE_TARGET}_${ISSUE_TAG}/|S" \
+    "${WORK_HOME_TRANSFORMS[@]}" \
     $DESIGN_PLATFORM_FILES \
     $LOG_DIR \
     $OBJECTS_DIR \


### PR DESCRIPTION
CI runs ORFS from a docker image (/OpenROAD-flow-scripts) with WORK_HOME set to the Jenkins workspace (/tmp/workspace/...). The issue tarballs then recreated the absolute workspace path (tmp/ folder) and run-me sourced the vars file via a hardcoded CI path, so extracted reproducibles failed out of the box:

```
run-me-*.sh: line 2: /tmp/workspace/.../vars-*.sh: No such file
[ERROR STA-0340] cannot open '/final_report.tcl'.
```

- makeIssue.sh: source vars relative to run-me location; strip WORK_HOME prefix (literal and symlink-resolved) from tar members
- generate-vars.sh: relativize paths under WORK_HOME instead of only the hardcoded /workspace prefix
- test_make_issue.sh: run the extracted run-me script instead of the WORK_HOME copy via absolute path