### PR TITLE
docs: add sphinx-llm to generate llms.txt and llms-full.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.10"
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     "sphinx_copybutton",
     "myst_parser",
     "sphinxcontrib.mermaid",
+    "sphinx_llm.txt",
 ]
 
 myst_enable_extensions = [

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -5,3 +5,4 @@ myst-parser
 sphinx-book-theme
 sphinx-copybutton
 sphinxcontrib-mermaid
+sphinx-llm

--- a/docs/requirements_lock.txt
+++ b/docs/requirements_lock.txt
@@ -180,6 +180,7 @@ docutils==0.19 \
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
 exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
@@ -432,6 +433,8 @@ sphinx==5.3.0 \
     #   sphinx-book-theme
     #   sphinx-copybutton
     #   sphinx-external-toc
+    #   sphinx-llm
+    #   sphinx-markdown-builder
     #   sphinxcontrib-mermaid
 sphinx-autobuild==2024.10.3 \
     --hash=sha256:158e16c36f9d633e613c9aaf81c19b0fc458ca78b112533b20dafcda430d60fa \
@@ -449,6 +452,14 @@ sphinx-external-toc==0.3.1 \
     --hash=sha256:9c8ea9980ea0e57bf3ce98f6a400f9b69eb1df808f7dd796c9c8cc1873d8b355 \
     --hash=sha256:cd93c1e7599327b2a728db12d9819068ce719c4b037ffc62e47f20ffb6310fb3
     # via -r docs/requirements.in
+sphinx-llm==0.4.1 \
+    --hash=sha256:0789185dcbbecc00b5e25aa3db6342b98dad6a9def96088a9e50fa0203fda090 \
+    --hash=sha256:d7c8ee2a6335636b628ea2b26cd1e1dee1f0cf9c40fe51b20f201af1c05b95f5
+    # via -r docs/requirements.in
+sphinx-markdown-builder==0.6.10 \
+    --hash=sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e \
+    --hash=sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86
+    # via sphinx-llm
 sphinxcontrib-applehelp==2.0.0 \
     --hash=sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1 \
     --hash=sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5
@@ -481,6 +492,10 @@ starlette==1.2.0 \
     --hash=sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7 \
     --hash=sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553
     # via sphinx-autobuild
+tabulate==0.10.0 \
+    --hash=sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d \
+    --hash=sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3
+    # via sphinx-markdown-builder
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548


### PR DESCRIPTION
## Summary

Add support for `llms.txt` and `llms-full.txt` to the ReadTheDocs documentation site using the [`sphinx-llm`](https://pypi.org/project/sphinx-llm/) extension. These files follow the [llmstxt.org](https://llmstxt.org/) standard and make OpenROAD-flow-scripts documentation directly consumable by LLMs without HTML scraping.

Mirrors [The-OpenROAD-Project/OpenROAD#10598](https://github.com/The-OpenROAD-Project/OpenROAD/pull/10598).

### Changes

- `docs/conf.py`: add `sphinx_llm.txt` to the Sphinx extensions list — the extension generates both files as a native build step, writing directly into the HTML output
- `docs/requirements.txt`: add `sphinx-llm`

Once merged and built, files will be served at:
- `https://openroad-flow-scripts.readthedocs.io/llms.txt`
- `https://openroad-flow-scripts.readthedocs.io/llms-full.txt`

## Test plan

- [x] ReadTheDocs build succeeds with `sphinx-llm` installed on Python 3.11
- [x] `llms.txt` is accessible at the root of the ReadTheDocs site after build