### PR TITLE
open: skip CRPR pre-CTS to avoid OOM on high-reconvergence clocks

### DIFF
--- a/flow/scripts/open.tcl
+++ b/flow/scripts/open.tcl
@@ -53,6 +53,12 @@ proc read_timing { input_file } {
   if { $design_stage >= 4 } {
     # CTS has run, so propagate clocks
     set_propagated_clock [all_clocks]
+  } else {
+    # Pre-CTS there is no clock tree, so CRPR has no real launch/capture
+    # common-path delay to remove and its correction is ~0. On designs with
+    # high clock reconvergence the CRPR tag set can still grow to tens of GB
+    # and OOM the process. Skip it pre-CTS.
+    sta::set_crpr_enabled 0
   }
 
   if { $design_stage >= 6 && [file exist $::env(RESULTS_DIR)/6_final.spef] } {


### PR DESCRIPTION
## Problem

The `open.tcl` timing setup runs CRPR (clock reconvergence pessimism removal) at every stage, including pre-CTS (floorplan/place). Pre-CTS there is no clock tree, so the launch/capture common clock path has ~0 delay and CRPR's correction is ~0 — it contributes nothing to the reported slacks.

On designs with **high clock reconvergence**, however, the CRPR tag set can grow to **tens of GB** during `find_timing` and OOM-kill the process at the placement-stage timing/power report — even though a *larger*, less-reconvergent configuration of the same design reports fine. The memory is spent producing a zero correction.

This is particularly painful for **design-space exploration**: DSE runs STA at placement to score and prune candidate configurations cheaply, *before* paying for CTS and routing. The pathological, highly-reconvergent configurations are exactly the ones we want to reject at place — but instead of being scored and pruned, they OOM-kill the process and derail the sweep. These candidates are pruned at placement and never need to run through CTS at all.

## Fix

Disable CRPR for `design_stage < 4`, mirroring the existing `set_propagated_clock [all_clocks]` gate right above it. At `design_stage >= 4` (CTS onward, where a real clock tree exists) CRPR is unchanged, so routed/sign-off timing is unaffected.

```tcl
  if { $design_stage >= 4 } {
    # CTS has run, so propagate clocks
    set_propagated_clock [all_clocks]
  } else {
    # Pre-CTS there is no clock tree, so CRPR has no real launch/capture
    # common-path delay to remove and its correction is ~0. ... Skip it pre-CTS.
    sta::set_crpr_enabled 0
  }
```

Equivalent to the `set_crpr_enabled 0` workaround, scoped to exactly the stages where CRPR is inert. In my testing this takes the pre-CTS report from an OOM (tens of GB) down to single-digit GB with the reported slacks unchanged.

## Note on the OpenSTA side

I also proposed an OpenSTA change to skip the inert CRPR machinery automatically when no clock is propagated: parallaxsw/OpenSTA#445. That does **not** fix this case — the pre-CTS report runs with the clock already propagated (the load path propagates it before `find_timing`), so the OpenSTA guard there is bypassed and CRPR still runs. This ORFS-side gate is the reliable fix for pre-CTS reports. The underlying CRPR tag-set memory scaling on high-reconvergence clocks remains a separate upstream issue.
