### PR TITLE
designs/sky130hd/microwatt/rules-base.json updates:

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1364,
+        "value": 1153,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -102,11 +102,11 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -9.71,
+        "value": -7.01,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5572106,
+        "value": 5571612,
         "compare": "<="
     }
 }


### PR DESCRIPTION
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |     -356.0 |     -359.0 | Failing  |
| globalroute__antenna_diodes_count             |       1364 |       1355 | Tighten  |
| globalroute__timing__setup__tns               |     -345.0 |     -365.0 | Failing  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1513 |       1406 | Tighten  |
| finish__timing__setup__tns                    |     -349.0 |     -364.0 | Failing  |
| finish__timing__hold__tns                     |      -9.71 |      -7.72 | Tighten  |