### PR TITLE
designs/sky130hd/microwatt/rules-base.json updates:

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -356.0,
+        "value": -359.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1153,
+        "value": 1355,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -345.0,
+        "value": -365.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1513,
+        "value": 1406,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -349.0,
+        "value": -364.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |     -356.0 |     -359.0 | Failing  |
| globalroute__antenna_diodes_count             |       1153 |       1355 | Failing  |
| globalroute__timing__setup__tns               |     -345.0 |     -365.0 | Failing  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1513 |       1406 | Tighten  |
| finish__timing__setup__tns                    |     -349.0 |     -364.0 | Failing  |