### PR TITLE
flow: log_cmd the unlogged synth and load steps for timing

### DIFF
--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -16,11 +16,11 @@ proc load_design { design_file sdc_file } {
   # Read design files
   set ext [file extension $design_file]
   if { $ext == ".v" } {
-    read_lef $::env(TECH_LEF)
-    read_lef $::env(SC_LEF)
+    log_cmd read_lef $::env(TECH_LEF)
+    log_cmd read_lef $::env(SC_LEF)
     if { [env_var_exists_and_non_empty ADDITIONAL_LEFS] } {
       foreach lef $::env(ADDITIONAL_LEFS) {
-        read_lef $lef
+        log_cmd read_lef $lef
       }
     }
     log_cmd read_verilog $::env(RESULTS_DIR)/$design_file

--- a/flow/scripts/load.tcl
+++ b/flow/scripts/load.tcl
@@ -23,7 +23,7 @@ proc load_design { design_file sdc_file } {
         read_lef $lef
       }
     }
-    read_verilog $::env(RESULTS_DIR)/$design_file
+    log_cmd read_verilog $::env(RESULTS_DIR)/$design_file
     log_cmd link_design {*}[hier_options] $::env(DESIGN_NAME)
   } elseif { $ext == ".odb" } {
     log_cmd read_db {*}[hier_options] $::env(RESULTS_DIR)/$design_file

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -1,8 +1,8 @@
 utl::set_metrics_stage "synth__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables synth
-load_design 1_2_yosys.v 1_2_yosys.sdc
-source_step_tcl PRE SYNTH
+log_cmd load_design 1_2_yosys.v 1_2_yosys.sdc
+log_cmd source_step_tcl PRE SYNTH
 
 # Eliminate dead logic before writing the synthesis odb so that
 # 1_synth.odb already reflects the live design.
@@ -27,7 +27,7 @@ log_cmd eliminate_dead_logic
 report_design_area
 report_design_area_metrics
 
-source_step_tcl POST SYNTH
+log_cmd source_step_tcl POST SYNTH
 orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
 # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
 # the user could have dependencies, such as sourcing util.tcl,

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -1,8 +1,8 @@
 utl::set_metrics_stage "synth__{}"
 source $::env(SCRIPTS_DIR)/load.tcl
 erase_non_stage_variables synth
-log_cmd load_design 1_2_yosys.v 1_2_yosys.sdc
-log_cmd source_step_tcl PRE SYNTH
+load_design 1_2_yosys.v 1_2_yosys.sdc
+source_step_tcl PRE SYNTH
 
 # Eliminate dead logic before writing the synthesis odb so that
 # 1_synth.odb already reflects the live design.
@@ -27,7 +27,7 @@ log_cmd eliminate_dead_logic
 report_design_area
 report_design_area_metrics
 
-log_cmd source_step_tcl POST SYNTH
+source_step_tcl POST SYNTH
 orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
 # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
 # the user could have dependencies, such as sourcing util.tcl,


### PR DESCRIPTION
The `synth_odb` step runs `load_design` and the `PRE`/`POST SYNTH` step-tcl hooks, and `load.tcl` runs `read_verilog`, without wrapping them in `log_cmd`. Their wall time is therefore not attributed in the per-command timing log, leaving a gap when accounting for where the synth step spends its time.

`link_design`, `read_sdc`, `eliminate_dead_logic`, `write_db` and `write_sdc` already log themselves; this wraps the remaining ops to match. No behavior change.