### PR TITLE
Make check-klayout an order-only prereq of merged GDS

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -673,7 +673,7 @@ $(WRAPPED_GDSOAS): $(OBJECTS_DIR)/klayout_wrap.lyt $(WRAPPED_LEFS)
 
 # Merge GDS using Klayout
 #-------------------------------------------------------------------------------
-$(GDS_MERGED_FILE): check-klayout $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klayout.lyt $(GDSOAS_FILES) $(WRAPPED_GDSOAS) $(SEAL_GDSOAS)
+$(GDS_MERGED_FILE): $(RESULTS_DIR)/6_final.def $(OBJECTS_DIR)/klayout.lyt $(GDSOAS_FILES) $(WRAPPED_GDSOAS) $(SEAL_GDSOAS) | check-klayout
 	$(UNSET_AND_MAKE) do-gds-merged
 
 .PHONY: do-gds-merged


### PR DESCRIPTION
## Problem

Running `make finish` (or `make metadata`, which depends on `finish`) repeatedly re-runs the KLayout `def2stream` GDS merge every single time, even when nothing upstream changed.

## Root cause

The phony `check-klayout` target was a **normal** prerequisite of `$(GDS_MERGED_FILE)`:

```makefile
$(GDS_MERGED_FILE): check-klayout $(RESULTS_DIR)/6_final.def ...
```

A phony prerequisite has no file on disk, so Make treats it as always newer than the target — forcing the merge recipe to run on every invocation regardless of timestamps. The re-merge then cascades into the `$(GDS_FINAL_FILE)` copy and downstream `finish`/`metadata` work.

## Fix

Move `check-klayout` behind `|` so it's an **order-only** prerequisite. The KLayout availability check still runs when the GDS actually needs building, but its phony status no longer marks the GDS perpetually out-of-date.

The `klayout_%` viewer shortcuts at the other `check-klayout` use-site are intentionally left unchanged — those targets are themselves `.PHONY` (interactive viewers meant to run on demand).

## Verification

`make finish -n` on an already-built `nangate45/gcd/base` no longer schedules `do-gds-merged`/`def2stream`, whereas before the fix it did on every run.