### PR TITLE
[DO NOT MERGE] Coarse/fine setup-repair phases — CI QoR evaluation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = ../../The-OpenROAD-Project/yosys.git
 [submodule "tools/OpenROAD"]
 	path = tools/OpenROAD
-	url = ../OpenROAD.git
+	url = https://github.com/VLSIDA/OpenROAD.git
+	branch = coarse-fine
 [submodule "tools/yosys-slang"]
 	path = tools/yosys-slang
 	url = https://github.com/povik/yosys-slang.git

--- a/flow/Makefile
+++ b/flow/Makefile
@@ -475,13 +475,17 @@ clean_resize:
 #-------------------------------------------------------------------------------
 $(eval $(call do-step,3_5_place_dp,$(RESULTS_DIR)/3_4_place_resized.odb,detail_place))
 
-$(eval $(call do-copy,3_place,3_5_place_dp.odb,))
+# STEP 6: Post-detailed-placement timing repair (coarse and fine moves)
+#-------------------------------------------------------------------------------
+$(eval $(call do-step,3_6_place_repair_timing,$(RESULTS_DIR)/3_5_place_dp.odb $(RESULTS_DIR)/2_floorplan.sdc,repair_timing_post_place))
+
+$(eval $(call do-copy,3_place,3_6_place_repair_timing.odb,))
 
 $(eval $(call do-copy,3_place,2_floorplan.sdc,,.sdc))
 
 .PHONY: do-place
 do-place:
-	$(UNSET_AND_MAKE) do-3_1_place_gp_skip_io do-3_2_place_iop do-3_3_place_gp do-3_4_place_resized do-3_5_place_dp do-3_place do-3_place.sdc
+	$(UNSET_AND_MAKE) do-3_1_place_gp_skip_io do-3_2_place_iop do-3_3_place_gp do-3_4_place_resized do-3_5_place_dp do-3_6_place_repair_timing do-3_place do-3_place.sdc
 
 # Clean Targets
 #-------------------------------------------------------------------------------

--- a/flow/scripts/cts.tcl
+++ b/flow/scripts/cts.tcl
@@ -66,7 +66,7 @@ if { !$::env(SKIP_CTS_REPAIR_TIMING) } {
     write_lec_verilog 4_before_rsz_lec.v
   }
 
-  repair_timing_helper
+  repair_timing_helper -phases "COARSE FINE"
 
   if { $lec_enabled } {
     write_lec_verilog 4_after_rsz_lec.v

--- a/flow/scripts/floorplan.tcl
+++ b/flow/scripts/floorplan.tcl
@@ -157,8 +157,8 @@ if { $::env(REMOVE_ABC_BUFFERS) } {
   # remove buffers inserted by yosys/abc
   remove_buffers
 } else {
-  # Skip clone & split
-  repair_timing_helper -setup -skip_last_gasp -sequence "unbuffer,sizeup,swap,vt_swap"
+  # Coarse optimization only (netlist-changing moves), skip last gasp.
+  repair_timing_helper -setup -skip_last_gasp -phases "COARSE"
 }
 
 puts "Default units for flow"

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -73,7 +73,7 @@ proc global_route_helper { } {
     puts "Repair setup and hold violations..."
     log_cmd estimate_parasitics -global_routing
 
-    repair_timing_helper
+    repair_timing_helper -phases "COARSE FINE"
 
     if { $::env(DETAILED_METRICS) } {
       report_metrics 5 "global route post repair timing"

--- a/flow/scripts/repair_timing_post_place.tcl
+++ b/flow/scripts/repair_timing_post_place.tcl
@@ -1,0 +1,28 @@
+# Post-detailed-placement timing repair: coarse + fine.
+# Runs after detailed placement (3_5_place_dp) and before CTS, on placement
+# parasitics; we re-legalize afterward.
+#
+# Note: "reroute" (part of FINE) is a no-op here -- it needs global routes
+# (stage 5), which don't exist yet at post-placement.
+utl::set_metrics_stage "place_repair_timing__{}"
+source $::env(SCRIPTS_DIR)/load.tcl
+erase_non_stage_variables place
+load_design 3_5_place_dp.odb 2_floorplan.sdc
+
+set_placement_padding -global \
+  -left $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT) \
+  -right $::env(CELL_PAD_IN_SITES_DETAIL_PLACEMENT)
+
+puts "Repair setup violations after detailed placement (coarse + fine)..."
+log_cmd estimate_parasitics -placement
+repair_timing_helper -setup -phases "COARSE FINE"
+
+# Re-legalize after timing repair.
+set dpl_args {}
+append_env_var dpl_args USE_NEGOTIATION -use_negotiation 0
+log_cmd detailed_placement {*}$dpl_args
+
+log_cmd estimate_parasitics -placement
+report_metrics 3 "place repair timing" true false
+
+orfs_write_db $::env(RESULTS_DIR)/3_6_place_repair_timing.odb

--- a/flow/scripts/resize.tcl
+++ b/flow/scripts/resize.tcl
@@ -29,7 +29,7 @@ if { $::env(ENABLE_PLACE_REPAIR_TIMING) } {
   puts "Repair setup and hold violations..."
   log_cmd estimate_parasitics -placement
 
-  repair_timing_helper
+  repair_timing_helper -phases "COARSE FINE"
 }
 
 # post report

--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -40,6 +40,7 @@ proc repair_timing_helper { args } {
   append_env_var additional_args SKIP_VT_SWAP -skip_vt_swap 0
   append_env_var additional_args SKIP_CRIT_VT_SWAP -skip_crit_vt_swap 0
   append_env_var additional_args MATCH_CELL_FOOTPRINT -match_cell_footprint 0
+  append_env_var additional_args REPAIR_TIMING_PHASES -phases 1
   lappend additional_args {*}$args -verbose
 
   log_cmd repair_timing {*}$additional_args


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — evaluation-only PR for an experimental coarse→fine `repair_timing` setup-repair flow. It depends on an out-of-tree OpenROAD branch, so it is not mergeable.

**Flow change:** sequences setup repair coarse→fine via new `COARSE`/`FINE` `repair_timing -phases` tokens:
- floorplan: `COARSE` (+ skip last gasp)
- resize (3_4): `COARSE FINE` (opt-in via `ENABLE_PLACE_REPAIR_TIMING`)
- post-dpl (new 3_6 target): `COARSE FINE`
- CTS / global route: `COARSE FINE`

`COARSE` = sizeup/clone/buffer/split; `FINE` = vt_swap/pin-swap/size_down/unbuffer/reroute.

**OpenROAD dependency:** submodule bumped to `VLSIDA/OpenROAD@coarse-fine` (`9ddd6967fe`) — https://github.com/VLSIDA/OpenROAD/tree/coarse-fine — which adds the `COARSE`/`FINE` phase tokens and two move-generator crash fixes (RerouteGenerator hierarchical-net; SizeDownFanoutGenerator dangling-path).

**Verified locally:** gcd/aes/ibex on nangate45 + asap7 complete (rc=0, no crashes).