### PR TITLE
bazel-orfs: bump to 553c1c3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,7 +36,7 @@ git_override(
 bazel_dep(name = "bazel-orfs", dev_dependency = True)
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
 
-BAZEL_ORFS_COMMIT = "6ebadeb4be5c9ada103081c9a5e668c014126616"
+BAZEL_ORFS_COMMIT = "553c1c3a44f0e0e857b1abb0b1b8035a77076456"
 
 BAZEL_ORFS_REMOTE = "https://github.com/The-OpenROAD-Project/bazel-orfs.git"
 


### PR DESCRIPTION
Bumps the `bazel-orfs` rules pin (`BAZEL_ORFS_COMMIT`, shared by the
`bazel-orfs` and `bazel-orfs-verilog` git_overrides) from `6ebadeb` to
[`553c1c3a44f0`](https://github.com/The-OpenROAD-Project/bazel-orfs/commit/553c1c3a44f0e0e857b1abb0b1b8035a77076456)
(current bazel-orfs `main`).

- **openroad** unchanged — tracked via `local_path_override` to
  `tools/OpenROAD` (master pins `4c26918f`, which requires
  `sv-lang@10.0.1-20260316-f04e8156`, published on BCR).
- **yosys 0.64 / yosys-slang / qt-bazel** already current at this
  bazel-orfs commit — no change.
- No `orfs-patches/` needed (openroad is local, not archive-pinned).

A companion bazel-orfs PR (The-OpenROAD-Project/bazel-orfs#750) advances
bazel-orfs's own ORFS/OpenROAD pins; once it merges, a follow-up
`@bazel-orfs//:bump` will move this pin forward again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)