### PR TITLE
gf180: add metal density fill rules (fill.json)

### DIFF
--- a/flow/platforms/gf180/config.mk
+++ b/flow/platforms/gf180/config.mk
@@ -32,6 +32,10 @@ export FILL_CELLS                             ?= gf180mcu_fd_sc_mcu$(TRACK_OPTIO
                                                  gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__fill_2 \
                                                  gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__fill_1
 
+# Metal density fill rules (OpenROAD density_fill). Applied at chip level
+# only when USE_FILL=1; macro/block builds leave USE_FILL=0 (the default).
+export FILL_CONFIG                            ?= $(PLATFORM_DIR)/fill.json
+
 export TIE_CELL                               = gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__filltie
 export ENDCAP_CELL                            = gf180mcu_fd_sc_mcu$(TRACK_OPTION)$(POWER_OPTION)__endcap
 export RC_FILE                                = $(PLATFORM_DIR)/setRC.tcl

--- a/flow/platforms/gf180/fill.json
+++ b/flow/platforms/gf180/fill.json
@@ -1,0 +1,78 @@
+{
+    "layers" : {
+        "Metal1" : {
+            "layer":                   34,
+            "name":                    "Metal1",
+            "dir":                     "H",
+            "datatype":                 0,
+            "space_to_outline":         5,
+            "non-opc": {
+                "datatype":             4,
+                "width":                [12.00, 6.00, 3.00, 2.00],
+                "height":               [2.00, 2.00, 2.00, 2.00],
+                "space_to_fill":        1.0,
+                "space_to_non_fill":    2.0
+            }
+        },
+
+        "Metal2" : {
+            "layer":                   36,
+            "name":                    "Metal2",
+            "dir":                     "V",
+            "datatype":                 0,
+            "space_to_outline":         5,
+            "non-opc": {
+                "datatype":             4,
+                "width":                [2.00, 2.00, 2.00, 2.00],
+                "height":               [12.00, 6.00, 3.00, 2.00],
+                "space_to_fill":        1.0,
+                "space_to_non_fill":    2.0
+            }
+        },
+
+        "Metal3" : {
+            "layer":                   42,
+            "name":                    "Metal3",
+            "dir":                     "H",
+            "datatype":                 0,
+            "space_to_outline":         5,
+            "non-opc": {
+                "datatype":             4,
+                "width":                [12.00, 6.00, 3.00, 2.00],
+                "height":               [2.00, 2.00, 2.00, 2.00],
+                "space_to_fill":        1.0,
+                "space_to_non_fill":    2.0
+            }
+        },
+
+        "Metal4" : {
+            "layer":                   46,
+            "name":                    "Metal4",
+            "dir":                     "V",
+            "datatype":                 0,
+            "space_to_outline":         5,
+            "non-opc": {
+                "datatype":             4,
+                "width":                [2.00, 2.00, 2.00, 2.00],
+                "height":               [12.00, 6.00, 3.00, 2.00],
+                "space_to_fill":        1.0,
+                "space_to_non_fill":    2.0
+            }
+        },
+
+        "Metal5" : {
+            "layer":                   81,
+            "name":                    "Metal5",
+            "dir":                     "H",
+            "datatype":                 0,
+            "space_to_outline":         5,
+            "non-opc": {
+                "datatype":             4,
+                "width":                [12.00, 6.00, 3.00, 2.00],
+                "height":               [2.00, 2.00, 2.00, 2.00],
+                "space_to_fill":        1.0,
+                "space_to_non_fill":    2.0
+            }
+        }
+    }
+}

--- a/flow/platforms/gf180/gds/7t/gf180mcu_5LM_1TM_9K_7t_edi2gds.layermap
+++ b/flow/platforms/gf180/gds/7t/gf180mcu_5LM_1TM_9K_7t_edi2gds.layermap
@@ -6,8 +6,8 @@ Metal1		NET		34		0
 Metal1		SPNET		34		0
 Metal1		PIN		34		0
 Metal1		LEFPIN		34		0
-Metal1		FILL		34		0
-Metal1		FILLOPC		34		0
+Metal1		FILL		34		4
+Metal1		FILLOPC		34		4
 Metal1		VIA		34		0
 Metal1		VIAFILL		34		0
 Metal1		VIAFILLOPC	34		0
@@ -31,8 +31,8 @@ Metal2		NET		36		0
 Metal2		SPNET		36		0
 Metal2		PIN		36		0
 Metal2		LEFPIN		36		0
-Metal2		FILL		36		0
-Metal2		FILLOPC		36		0
+Metal2		FILL		36		4
+Metal2		FILLOPC		36		4
 Metal2		VIA		36		0
 Metal2		VIAFILL		36		0
 Metal2		VIAFILLOPC	36		0
@@ -56,8 +56,8 @@ Metal3		NET		42		0
 Metal3		SPNET		42		0
 Metal3		PIN		42		0
 Metal3		LEFPIN		42		0
-Metal3		FILL		42		0
-Metal3		FILLOPC		42		0
+Metal3		FILL		42		4
+Metal3		FILLOPC		42		4
 Metal3		VIA		42		0
 Metal3		VIAFILL		42		0
 Metal3		VIAFILLOPC	42		0
@@ -81,8 +81,8 @@ Metal4		NET		46		0
 Metal4		SPNET		46		0
 Metal4		PIN		46		0
 Metal4		LEFPIN		46		0
-Metal4		FILL		46		0
-Metal4		FILLOPC		46		0
+Metal4		FILL		46		4
+Metal4		FILLOPC		46		4
 Metal4		VIA		46		0
 Metal4		VIAFILL		46		0
 Metal4		VIAFILLOPC	46		0
@@ -106,8 +106,8 @@ Metal5		NET		81		0
 Metal5		SPNET		81		0
 Metal5		PIN		81		0
 Metal5		LEFPIN		81		0
-Metal5		FILL		81		0
-Metal5		FILLOPC		81		0
+Metal5		FILL		81		4
+Metal5		FILLOPC		81		4
 Metal5		VIA		81		0
 Metal5		VIAFILL		81		0
 Metal5		VIAFILLOPC	81		0

--- a/flow/platforms/gf180/gds/7t/gf180mcu_6LM_1TM_9K_7t_edi2gds.layermap
+++ b/flow/platforms/gf180/gds/7t/gf180mcu_6LM_1TM_9K_7t_edi2gds.layermap
@@ -6,8 +6,8 @@ Metal1		NET		34		0
 Metal1		SPNET		34		0
 Metal1		PIN		34		0
 Metal1		LEFPIN		34		0
-Metal1		FILL		34		0
-Metal1		FILLOPC		34		0
+Metal1		FILL		34		4
+Metal1		FILLOPC		34		4
 Metal1		VIA		34		0
 Metal1		VIAFILL		34		0
 Metal1		VIAFILLOPC	34		0
@@ -31,8 +31,8 @@ Metal2		NET		36		0
 Metal2		SPNET		36		0
 Metal2		PIN		36		0
 Metal2		LEFPIN		36		0
-Metal2		FILL		36		0
-Metal2		FILLOPC		36		0
+Metal2		FILL		36		4
+Metal2		FILLOPC		36		4
 Metal2		VIA		36		0
 Metal2		VIAFILL		36		0
 Metal2		VIAFILLOPC	36		0
@@ -56,8 +56,8 @@ Metal3		NET		42		0
 Metal3		SPNET		42		0
 Metal3		PIN		42		0
 Metal3		LEFPIN		42		0
-Metal3		FILL		42		0
-Metal3		FILLOPC		42		0
+Metal3		FILL		42		4
+Metal3		FILLOPC		42		4
 Metal3		VIA		42		0
 Metal3		VIAFILL		42		0
 Metal3		VIAFILLOPC	42		0
@@ -81,8 +81,8 @@ Metal4		NET		46		0
 Metal4		SPNET		46		0
 Metal4		PIN		46		0
 Metal4		LEFPIN		46		0
-Metal4		FILL		46		0
-Metal4		FILLOPC		46		0
+Metal4		FILL		46		4
+Metal4		FILLOPC		46		4
 Metal4		VIA		46		0
 Metal4		VIAFILL		46		0
 Metal4		VIAFILLOPC	46		0
@@ -106,8 +106,8 @@ Metal5		NET		81		0
 Metal5		SPNET		81		0
 Metal5		PIN		81		0
 Metal5		LEFPIN		81		0
-Metal5		FILL		81		0
-Metal5		FILLOPC		81		0
+Metal5		FILL		81		4
+Metal5		FILLOPC		81		4
 Metal5		VIA		81		0
 Metal5		VIAFILL		81		0
 Metal5		VIAFILLOPC	81		0

--- a/flow/platforms/gf180/gds/9t/gf180mcu_5LM_1TM_9K_9t_edi2gds.layermap
+++ b/flow/platforms/gf180/gds/9t/gf180mcu_5LM_1TM_9K_9t_edi2gds.layermap
@@ -6,8 +6,8 @@ Metal1		NET		34		0
 Metal1		SPNET		34		0
 Metal1		PIN		34		0
 Metal1		LEFPIN		34		0
-Metal1		FILL		34		0
-Metal1		FILLOPC		34		0
+Metal1		FILL		34		4
+Metal1		FILLOPC		34		4
 Metal1		VIA		34		0
 Metal1		VIAFILL		34		0
 Metal1		VIAFILLOPC	34		0
@@ -31,8 +31,8 @@ Metal2		NET		36		0
 Metal2		SPNET		36		0
 Metal2		PIN		36		0
 Metal2		LEFPIN		36		0
-Metal2		FILL		36		0
-Metal2		FILLOPC		36		0
+Metal2		FILL		36		4
+Metal2		FILLOPC		36		4
 Metal2		VIA		36		0
 Metal2		VIAFILL		36		0
 Metal2		VIAFILLOPC	36		0
@@ -56,8 +56,8 @@ Metal3		NET		42		0
 Metal3		SPNET		42		0
 Metal3		PIN		42		0
 Metal3		LEFPIN		42		0
-Metal3		FILL		42		0
-Metal3		FILLOPC		42		0
+Metal3		FILL		42		4
+Metal3		FILLOPC		42		4
 Metal3		VIA		42		0
 Metal3		VIAFILL		42		0
 Metal3		VIAFILLOPC	42		0
@@ -81,8 +81,8 @@ Metal4		NET		46		0
 Metal4		SPNET		46		0
 Metal4		PIN		46		0
 Metal4		LEFPIN		46		0
-Metal4		FILL		46		0
-Metal4		FILLOPC		46		0
+Metal4		FILL		46		4
+Metal4		FILLOPC		46		4
 Metal4		VIA		46		0
 Metal4		VIAFILL		46		0
 Metal4		VIAFILLOPC	46		0
@@ -106,8 +106,8 @@ Metal5		NET		81		0
 Metal5		SPNET		81		0
 Metal5		PIN		81		0
 Metal5		LEFPIN		81		0
-Metal5		FILL		81		0
-Metal5		FILLOPC		81		0
+Metal5		FILL		81		4
+Metal5		FILLOPC		81		4
 Metal5		VIA		81		0
 Metal5		VIAFILL		81		0
 Metal5		VIAFILLOPC	81		0

--- a/flow/platforms/gf180/gds/9t/gf180mcu_6LM_1TM_9K_9t_edi2gds.layermap
+++ b/flow/platforms/gf180/gds/9t/gf180mcu_6LM_1TM_9K_9t_edi2gds.layermap
@@ -6,8 +6,8 @@ Metal1		NET		34		0
 Metal1		SPNET		34		0
 Metal1		PIN		34		0
 Metal1		LEFPIN		34		0
-Metal1		FILL		34		0
-Metal1		FILLOPC		34		0
+Metal1		FILL		34		4
+Metal1		FILLOPC		34		4
 Metal1		VIA		34		0
 Metal1		VIAFILL		34		0
 Metal1		VIAFILLOPC	34		0
@@ -31,8 +31,8 @@ Metal2		NET		36		0
 Metal2		SPNET		36		0
 Metal2		PIN		36		0
 Metal2		LEFPIN		36		0
-Metal2		FILL		36		0
-Metal2		FILLOPC		36		0
+Metal2		FILL		36		4
+Metal2		FILLOPC		36		4
 Metal2		VIA		36		0
 Metal2		VIAFILL		36		0
 Metal2		VIAFILLOPC	36		0
@@ -56,8 +56,8 @@ Metal3		NET		42		0
 Metal3		SPNET		42		0
 Metal3		PIN		42		0
 Metal3		LEFPIN		42		0
-Metal3		FILL		42		0
-Metal3		FILLOPC		42		0
+Metal3		FILL		42		4
+Metal3		FILLOPC		42		4
 Metal3		VIA		42		0
 Metal3		VIAFILL		42		0
 Metal3		VIAFILLOPC	42		0
@@ -81,8 +81,8 @@ Metal4		NET		46		0
 Metal4		SPNET		46		0
 Metal4		PIN		46		0
 Metal4		LEFPIN		46		0
-Metal4		FILL		46		0
-Metal4		FILLOPC		46		0
+Metal4		FILL		46		4
+Metal4		FILLOPC		46		4
 Metal4		VIA		46		0
 Metal4		VIAFILL		46		0
 Metal4		VIAFILLOPC	46		0
@@ -106,8 +106,8 @@ Metal5		NET		81		0
 Metal5		SPNET		81		0
 Metal5		PIN		81		0
 Metal5		LEFPIN		81		0
-Metal5		FILL		81		0
-Metal5		FILLOPC		81		0
+Metal5		FILL		81		4
+Metal5		FILLOPC		81		4
 Metal5		VIA		81		0
 Metal5		VIAFILL		81		0
 Metal5		VIAFILLOPC	81		0


### PR DESCRIPTION
## Summary

The `gf180` platform shipped `FILL_CELLS` (std-cell filler) but **no metal density fill**: there was no `FILL_CONFIG`, so the `density_fill` step (`6_1_fill`) inserted nothing. gf180mcu's density rules require **>30% metal coverage per layer, die-wide** (`M2.4` / `M3.4` / `M5.4` / `MT.3`), which sparse designs cannot meet without fill.

This adds `flow/platforms/gf180/fill.json` (Metal1–Metal5), points `FILL_CONFIG` at it, and routes the fill to the foundry dummy-metal datatype.

## Details

**Stripe geometry (per DRM §13.3 dummy rules).** Fill is emitted as rectangular **stripes** — 2.0 µm in the constrained axis, extended along each layer's routing channel (H: Metal1/3/5, V: Metal2/4) — rather than squares. Square 2.0 µm tiles waste a gap on all four sides and top out ~18% coverage (Metal5 below the 30% floor); stripes only pay the gap at channel ends and reach ~30–60%. Spacing follows DM.1 (min dimension 2.0 µm), DM.2 (fill-to-fill 1.0 µm, ≥0.98), DM.3 (fill-to-circuit-metal 2.0 µm). In the default `5LM_1TM` stack Metal5 is the thick top metal (`MT.4` min area 0.5625 µm²); the 2.0 µm stripes give ≥4 µm².

**Dummy datatype (LVS).** Density fill is spaced 2.0 µm from real metal, so each shape is an electrically floating island. The `edi2gds` layermaps mapped `Metal1..Metal5` `FILL`/`FILLOPC` to datatype 0, which merges fill with drawn circuit metal — LVS extraction would then see metal on no net. This routes `FILL`/`FILLOPC` to **datatype 4** (the `Metal*_Dummy` layers) so fill is distinguishable and LVS-clean.

## Opt-in / no behavior change

`USE_FILL` still defaults to `0`, so `density_fill` stays a no-op and **no existing design's results change**. A chip/top-level design opts in with `USE_FILL=1`. Metal fill is intentionally a chip-level (die-wide) step — block / hard-macro builds keep `USE_FILL=0` so fill is inserted once at the top, not per block.

## Verification

Ran OpenROAD `density_fill -rules flow/platforms/gf180/fill.json` on a routed gf180mcu design: rules parse and stripe fill inserts on Metal1–Metal5 with no errors. Per-layer fill-only coverage was 24–29% (Metal2 26.0 / Metal3 27.1 / Metal4 23.7 / Metal5 28.6%); adding drawn routing clears the 30% floor on all checked layers.