### PR TITLE
Update misc metrics for small diffs

### DIFF
--- a/flow/designs/gf12/bp_dual/rules-base.json
+++ b/flow/designs/gf12/bp_dual/rules-base.json
@@ -1,4 +1,18 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "N/A",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "032eefdd8bbba36268d041958693a96a27ceca1c",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__design__instance__area__stdcell": {
+        "value": 282000.0,
+        "compare": "<="
+    },
     "constraints__clocks__count": {
         "value": 8,
         "compare": "=="
@@ -28,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1480000.0,
+        "value": -1500000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -80,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1180.0,
+        "value": -1170.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/bp_quad/rules-base.json
+++ b/flow/designs/gf12/bp_quad/rules-base.json
@@ -1,14 +1,28 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "N/A",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "711a9dffb814f041cb5e7523b9c962d40f2cb834",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__design__instance__area__stdcell": {
+        "value": 466000.0,
+        "compare": "<="
+    },
     "constraints__clocks__count": {
         "value": 8,
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1503890,
+        "value": 1497196,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 1472164,
+        "value": 1455380,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -16,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 128014,
+        "value": 126555,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 128014,
+        "value": 126555,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -375.0,
+        "value": -313.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -393000.0,
+        "value": -247000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -40,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1125,
+        "value": 1107,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -223.0,
+        "value": -133.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -4160.0,
+        "value": -702.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -64,7 +78,7 @@
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
-        "value": 0,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
@@ -72,15 +86,15 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1131,
+        "value": 1110,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -225.0,
+        "value": -219.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1730.0,
+        "value": -1620.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -92,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1534801,
+        "value": 1524210,
         "compare": "<="
     }
 }

--- a/flow/designs/gf12/bp_single/rules-base.json
+++ b/flow/designs/gf12/bp_single/rules-base.json
@@ -1,6 +1,16 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "3b0b948daad3e71a4671a8f99e3d4411a2791bdd",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "1d5d919af9c857fd363e3f4e55b112353dfd5cc9",
+        "compare": "==",
+        "level": "warning"
+    },
     "synth__design__instance__area__stdcell": {
-        "value": 1020000.0,
+        "value": 156000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -32,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -331000.0,
+        "value": -311000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -52,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -32700.0,
+        "value": -33700.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -84,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1600.0,
+        "value": -1590.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 207,
+        "value": 209,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 846595,
+        "value": 846125,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,7 +90,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.282,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__timing__setup__tns": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1276,
+        "value": 1271,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1341,
+        "value": 1411,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1271,
+        "value": 1276,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -86,11 +86,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1411,
+        "value": 1341,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.73,
+        "value": -2.69,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
@@ -98,7 +98,7 @@
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.991,
+        "value": -0.989,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5575821,
+        "value": 5575637,
         "compare": "<="
     }
 }


### PR DESCRIPTION
designs/gf12/bp_single/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |  1020000.0 |   156000.0 | Tighten  |
| cts__timing__setup__tns                       |  -331000.0 |  -311000.0 | Tighten  |
| globalroute__timing__setup__tns               |   -32700.0 |   -33700.0 | Failing  |
| finish__timing__setup__tns                    |    -1600.0 |    -1590.0 | Tighten  |

designs/gf12/bp_dual/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       | -1480000.0 | -1500000.0 | Failing  |
| finish__timing__setup__tns                    |    -1180.0 |    -1170.0 | Tighten  |

designs/gf12/bp_quad/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |    1503890 |    1497196 | Tighten  |
| placeopt__design__instance__count__stdcell    |    1472164 |    1455380 | Tighten  |
| cts__design__instance__count__setup_buffer    |     128014 |     126555 | Tighten  |
| cts__design__instance__count__hold_buffer     |     128014 |     126555 | Tighten  |
| cts__timing__setup__ws                        |     -375.0 |     -313.0 | Tighten  |
| cts__timing__setup__tns                       |  -393000.0 |  -247000.0 | Tighten  |
| globalroute__antenna_diodes_count             |       1125 |       1107 | Tighten  |
| globalroute__timing__setup__ws                |     -223.0 |     -133.0 | Tighten  |
| globalroute__timing__setup__tns               |    -4160.0 |     -702.0 | Tighten  |
| detailedroute__route__drc_errors              |          0 |          1 | Failing  |
| detailedroute__antenna_diodes_count           |       1131 |       1110 | Tighten  |
| finish__timing__setup__ws                     |     -225.0 |     -219.0 | Tighten  |
| finish__timing__setup__tns                    |    -1730.0 |    -1620.0 | Tighten  |
| finish__design__instance__area                |    1534801 |    1524210 | Tighten  |

designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |        207 |        209 | Failing  |
| detailedroute__route__wirelength              |     846595 |     846125 | Tighten  |
| finish__timing__setup__ws                     |     -0.282 |      -0.28 | Tighten  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |       1271 |       1276 | Failing  |
| detailedroute__antenna_diodes_count           |       1411 |       1341 | Tighten  |
| finish__timing__setup__ws                     |      -2.73 |      -2.69 | Tighten  |
| finish__timing__hold__ws                      |     -0.991 |     -0.989 | Tighten  |
| finish__design__instance__area                |    5575821 |    5575637 | Tighten  |