### PR TITLE
update metrics after back-to-back jumpers fix

### DIFF
--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 207,
+        "value": 209,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 846595,
+        "value": 846125,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,7 +90,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.282,
+        "value": -0.28,
         "compare": ">="
     },
     "finish__timing__setup__tns": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1271,
+        "value": 1276,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -86,11 +86,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1411,
+        "value": 1341,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.73,
+        "value": -2.69,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
@@ -98,7 +98,7 @@
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.991,
+        "value": -0.989,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5575821,
+        "value": 5575637,
         "compare": "<="
     }
 }


### PR DESCRIPTION
Just some diodes metrics failing after last updates

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |       1271 |       1276 | Failing  |
| detailedroute__antenna_diodes_count           |       1411 |       1341 | Tighten  |
| finish__timing__setup__ws                     |      -2.73 |      -2.69 | Tighten  |
| finish__timing__hold__ws                      |     -0.991 |     -0.989 | Tighten  |
| finish__design__instance__area                |    5575821 |    5575637 | Tighten  |

designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |        207 |        209 | Failing  |
| detailedroute__route__wirelength              |     846595 |     846125 | Tighten  |
| finish__timing__setup__ws                     |     -0.282 |      -0.28 | Tighten  |