### PR TITLE
designs/sky130hd/microwatt/rules-base.json updates:

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1271,
+        "value": 1276,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -90,7 +90,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.73,
+        "value": -2.69,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
@@ -98,7 +98,7 @@
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.991,
+        "value": -0.989,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5575821,
+        "value": 5575637,
         "compare": "<="
     }
 }


### PR DESCRIPTION
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |       1271 |       1276 | Failing  |
| finish__timing__setup__ws                     |      -2.73 |      -2.69 | Tighten  |
| finish__timing__hold__ws                      |     -0.991 |     -0.989 | Tighten  |
| finish__design__instance__area                |    5575821 |    5575637 | Tighten  |