### PR TITLE
Update metrics for 10642

### DIFF
--- a/flow/designs/asap7/aes-mbff/rules-base.json
+++ b/flow/designs/asap7/aes-mbff/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1897,
+        "value": 1877,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 18134,
+        "value": 17932,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1577,
+        "value": 1559,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1577,
+        "value": 1559,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 69120,
+        "value": 68143,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -20.8,
+        "value": -47.7,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -77.8,
+        "value": -329.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1942,
+        "value": 1911,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/ethmac/rules-base.json
+++ b/flow/designs/asap7/ethmac/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1270.0,
+        "value": -1480.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1790.0,
+        "value": -1870.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1400.0,
+        "value": -1500.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/ethmac_lvt/rules-base.json
+++ b/flow/designs/asap7/ethmac_lvt/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -231.0,
+        "value": -308.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/asap7/mock-alu/rules-base.json
+++ b/flow/designs/asap7/mock-alu/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -17900.0,
+        "value": -18100.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -20200.0,
+        "value": -19700.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "787d6a4946b12ba374364f9b9de6770296d04729",
+        "value": "fb786d77e841d2488f5a6b7db514abf2010cf808",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 2296,
+        "value": 2291,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 11715,
+        "value": 11655,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1019,
+        "value": 1014,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1019,
+        "value": 1014,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -58,7 +58,7 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -52.8,
+        "value": -52.1,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 64638,
+        "value": 61587,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -6380.0,
+        "value": -21300.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 2373,
+        "value": 2367,
         "compare": "<="
     }
 }

--- a/flow/designs/gf12/swerv_wrapper/rules-base.json
+++ b/flow/designs/gf12/swerv_wrapper/rules-base.json
@@ -1,6 +1,16 @@
 {
+    "synth__canonical_netlist__hash": {
+        "value": "3a6b36cb373f44ed20a03f155fabfa9462db6385",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "e26a9a3ae1ffa1e8e44de7f44e29cb6479199257",
+        "compare": "==",
+        "level": "warning"
+    },
     "synth__design__instance__area__stdcell": {
-        "value": 156883.93,
+        "value": 38200.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -8,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 172761,
+        "value": 172730,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -24,7 +34,7 @@
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 11303,
+        "value": 11294,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -36,7 +46,7 @@
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -104.0,
+        "value": -236.0,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
@@ -64,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 2307185,
+        "value": 2275794,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -96,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 177526,
+        "value": 177466,
         "compare": "<="
     }
 }

--- a/flow/designs/gf180/aes/rules-base.json
+++ b/flow/designs/gf180/aes/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -83.0,
+        "value": -87.3,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -101.0,
+        "value": -100.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -96.3,
+        "value": -97.6,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 810940,
+        "value": 804777,
         "compare": "<="
     }
 }

--- a/flow/designs/ihp-sg13g2/jpeg/rules-base.json
+++ b/flow/designs/ihp-sg13g2/jpeg/rules-base.json
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 3457035,
+        "value": 3409783,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 116,
+        "value": 176,
         "compare": "<="
     },
     "finish__timing__setup__ws": {

--- a/flow/designs/nangate45/ariane133/rules-base.json
+++ b/flow/designs/nangate45/ariane133/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "608c7e7060b1b403c0e893101b0bd83a23b7f306",
+        "value": "7af2e5d516717525c8e4b86fbe5c8c0fc7e3e6b0",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "624023bd257848127135daf0c0d20528d8fb9315",
+        "value": "0925e491023b71ddf98d5a9d92664c9607d38b85",
         "compare": "==",
         "level": "warning"
     },
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -674.0,
+        "value": -929.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.569,
+        "value": -0.557,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -664.0,
+        "value": -755.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 8478680,
+        "value": 8397160,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.595,
+        "value": -0.589,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -702.0,
+        "value": -801.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/ariane136/rules-base.json
+++ b/flow/designs/nangate45/ariane136/rules-base.json
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.318,
+        "value": -0.3,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1.36,
+        "value": -1.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/mempool_group/rules-base.json
+++ b/flow/designs/nangate45/mempool_group/rules-base.json
@@ -10,7 +10,7 @@
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 424000.0,
+        "value": 304000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 188318,
+        "value": 188286,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -12200.0,
+        "value": -12400.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -12100.0,
+        "value": -14800.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -102,11 +102,11 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -1.35,
+        "value": -1.02,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 453719,
+        "value": 453697,
         "compare": "<="
     }
 }

--- a/flow/designs/nangate45/swerv/rules-base.json
+++ b/flow/designs/nangate45/swerv/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -358.0,
+        "value": -319.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.719,
+        "value": -0.699,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -562.0,
+        "value": -299.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.677,
+        "value": -0.672,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -473.0,
+        "value": -359.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.344,
+        "value": -0.335,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -223.0,
+        "value": -237.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.357,
+        "value": -0.337,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -266.0,
+        "value": -230.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 4192077,
+        "value": 4160494,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.35,
+        "value": -0.315,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -247.0,
+        "value": -211.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 59473,
+        "value": 59466,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5172,
+        "value": 5171,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5172,
+        "value": 5171,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.321,
+        "value": -0.301,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -5.4,
+        "value": -4.9,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 209,
+        "value": 231,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.356,
+        "value": -0.318,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -6.6,
+        "value": -5.15,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 846125,
+        "value": 845205,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.28,
+        "value": -0.247,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -2.59,
+        "value": -1.93,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -18,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 4695,
+        "value": 4681,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -60.3,
+        "value": -58.6,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -67.2,
+        "value": -67.4,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -61.2,
+        "value": -62.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.71,
+        "value": -2.66,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -355.0,
+        "value": -337.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1276,
+        "value": 1909,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -2.8,
+        "value": -2.49,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -373.0,
+        "value": -295.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -86,19 +86,19 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1411,
+        "value": 1267,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.69,
+        "value": -2.42,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -333.0,
+        "value": -258.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.989,
+        "value": -0.954,
         "compare": ">="
     },
     "finish__timing__hold__tns": {


### PR DESCRIPTION
designs/asap7/aes-mbff/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |       1897 |       1877 | Tighten  |
| placeopt__design__instance__count__stdcell    |      18134 |      17932 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1577 |       1559 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1577 |       1559 | Tighten  |
| detailedroute__route__wirelength              |      69120 |      68143 | Tighten  |
| finish__timing__setup__ws                     |      -20.8 |      -47.7 | Failing  |
| finish__timing__setup__tns                    |      -77.8 |     -329.0 | Failing  |
| finish__design__instance__area                |       1942 |       1911 | Tighten  |

designs/asap7/ethmac/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |    -1270.0 |    -1480.0 | Failing  |
| globalroute__timing__setup__tns               |    -1790.0 |    -1870.0 | Failing  |
| finish__timing__setup__tns                    |    -1400.0 |    -1500.0 | Failing  |

designs/asap7/ethmac_lvt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -231.0 |     -308.0 | Failing  |

designs/asap7/mock-alu/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |   -17900.0 |   -18100.0 | Failing  |
| finish__timing__setup__tns                    |   -20200.0 |   -19700.0 | Tighten  |

designs/asap7/riscv32i-mock-sram/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 787d6a4946b12ba374364f9b9de6770296d04729 | fb786d77e841d2488f5a6b7db514abf2010cf808 | Failing  |
| placeopt__design__instance__area              |       2296 |       2291 | Tighten  |
| placeopt__design__instance__count__stdcell    |      11715 |      11655 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1019 |       1014 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1019 |       1014 | Tighten  |
| globalroute__timing__setup__ws                |      -52.8 |      -52.1 | Tighten  |
| detailedroute__route__wirelength              |      64638 |      61587 | Tighten  |
| finish__timing__setup__tns                    |    -6380.0 |   -21300.0 | Failing  |
| finish__design__instance__area                |       2373 |       2367 | Tighten  |

designs/gf12/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |  156883.93 |    38200.0 | Tighten  |
| placeopt__design__instance__area              |     172761 |     172730 | Tighten  |
| cts__design__instance__count__hold_buffer     |      11303 |      11294 | Tighten  |
| cts__timing__hold__ws                         |     -104.0 |     -236.0 | Failing  |
| detailedroute__route__wirelength              |    2307185 |    2275794 | Tighten  |
| finish__design__instance__area                |     177526 |     177466 | Tighten  |

designs/gf180/aes/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |      -83.0 |      -87.3 | Failing  |
| globalroute__timing__setup__tns               |     -101.0 |     -100.0 | Tighten  |
| finish__timing__setup__tns                    |      -96.3 |      -97.6 | Failing  |
| finish__design__instance__area                |     810940 |     804777 | Tighten  |

designs/ihp-sg13g2/jpeg/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| detailedroute__route__wirelength              |    3457035 |    3409783 | Tighten  |
| detailedroute__antenna_diodes_count           |        116 |        176 | Failing  |

designs/nangate45/ariane136/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| finish__timing__setup__ws                     |     -0.318 |       -0.3 | Tighten  |
| finish__timing__setup__tns                    |      -1.36 |       -1.2 | Tighten  |

designs/nangate45/mempool_group/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |   424000.0 |   304000.0 | Tighten  |
| placeopt__design__instance__count__stdcell    |     188318 |     188286 | Tighten  |
| cts__timing__setup__tns                       |   -12200.0 |   -12400.0 | Failing  |
| globalroute__timing__setup__tns               |   -12100.0 |   -14800.0 | Failing  |
| finish__timing__hold__tns                     |      -1.35 |      -1.02 | Tighten  |
| finish__design__instance__area                |     453719 |     453697 | Tighten  |

designs/nangate45/swerv/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |     -358.0 |     -319.0 | Tighten  |
| globalroute__timing__setup__ws                |     -0.719 |     -0.699 | Tighten  |
| globalroute__timing__setup__tns               |     -562.0 |     -299.0 | Tighten  |
| finish__timing__setup__ws                     |     -0.677 |     -0.672 | Tighten  |
| finish__timing__setup__tns                    |     -473.0 |     -359.0 | Tighten  |

designs/nangate45/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -0.344 |     -0.335 | Tighten  |
| cts__timing__setup__tns                       |     -223.0 |     -237.0 | Failing  |
| globalroute__timing__setup__ws                |     -0.357 |     -0.337 | Tighten  |
| globalroute__timing__setup__tns               |     -266.0 |     -230.0 | Tighten  |
| detailedroute__route__wirelength              |    4192077 |    4160494 | Tighten  |
| finish__timing__setup__ws                     |      -0.35 |     -0.315 | Tighten  |
| finish__timing__setup__tns                    |     -247.0 |     -211.0 | Tighten  |

designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__count__stdcell    |      59473 |      59466 | Tighten  |
| cts__design__instance__count__setup_buffer    |       5172 |       5171 | Tighten  |
| cts__design__instance__count__hold_buffer     |       5172 |       5171 | Tighten  |
| cts__timing__setup__ws                        |     -0.321 |     -0.301 | Tighten  |
| cts__timing__setup__tns                       |       -5.4 |       -4.9 | Tighten  |
| globalroute__antenna_diodes_count             |        209 |        231 | Failing  |
| globalroute__timing__setup__ws                |     -0.356 |     -0.318 | Tighten  |
| globalroute__timing__setup__tns               |       -6.6 |      -5.15 | Tighten  |
| detailedroute__route__wirelength              |     846125 |     845205 | Tighten  |
| finish__timing__setup__ws                     |      -0.28 |     -0.247 | Tighten  |
| finish__timing__setup__tns                    |      -2.59 |      -1.93 | Tighten  |

designs/sky130hd/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |       4695 |       4681 | Tighten  |
| cts__timing__setup__tns                       |      -60.3 |      -58.6 | Tighten  |
| globalroute__timing__setup__tns               |      -67.2 |      -67.4 | Failing  |
| finish__timing__setup__tns                    |      -61.2 |      -62.0 | Failing  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -2.71 |      -2.66 | Tighten  |
| cts__timing__setup__tns                       |     -355.0 |     -337.0 | Tighten  |
| globalroute__antenna_diodes_count             |       1276 |       1909 | Failing  |
| globalroute__timing__setup__ws                |       -2.8 |      -2.49 | Tighten  |
| globalroute__timing__setup__tns               |     -373.0 |     -295.0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1411 |       1267 | Tighten  |
| finish__timing__setup__ws                     |      -2.69 |      -2.42 | Tighten  |
| finish__timing__setup__tns                    |     -333.0 |     -258.0 | Tighten  |
| finish__timing__hold__ws                      |     -0.989 |     -0.954 | Tighten  |

designs/nangate45/ariane133/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 608c7e7060b1b403c0e893101b0bd83a23b7f306 | 7af2e5d516717525c8e4b86fbe5c8c0fc7e3e6b0 | Failing  |
| synth__netlist__hash                          | 624023bd257848127135daf0c0d20528d8fb9315 | 0925e491023b71ddf98d5a9d92664c9607d38b85 | Failing  |
| cts__timing__setup__tns                       |     -674.0 |     -929.0 | Failing  |
| globalroute__timing__setup__ws                |     -0.569 |     -0.557 | Tighten  |
| globalroute__timing__setup__tns               |     -664.0 |     -755.0 | Failing  |
| detailedroute__route__wirelength              |    8478680 |    8397160 | Tighten  |
| finish__timing__setup__ws                     |     -0.595 |     -0.589 | Tighten  |
| finish__timing__setup__tns                    |     -702.0 |     -801.0 | Failing  |