### PR TITLE
designs/gf12/bp_single/rules-base.json updates:

### DIFF
--- a/flow/designs/gf12/bp_dual/rules-base.json
+++ b/flow/designs/gf12/bp_dual/rules-base.json
@@ -38,7 +38,7 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -758.0,
+        "value": -614.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -100.0,
+        "value": -201.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -400.0,
+        "value": -6470.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1170.0,
+        "value": -1160.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/bp_single/rules-base.json
+++ b/flow/designs/gf12/bp_single/rules-base.json
@@ -38,19 +38,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -632.0,
+        "value": -835.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -311000.0,
+        "value": -517000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -305.0,
+        "value": -299.0,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -784.0,
+        "value": -4250.0,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -470.0,
+        "value": -615.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -33700.0,
+        "value": -106000.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -227.0,
+        "value": -207.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1590.0,
+        "value": -1430.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -632.0 |     -835.0 | Failing  |
| cts__timing__setup__tns                       |  -311000.0 |  -517000.0 | Failing  |
| cts__timing__hold__ws                         |     -305.0 |     -299.0 | Tighten  |
| cts__timing__hold__tns                        |     -784.0 |    -4250.0 | Failing  |
| globalroute__timing__setup__ws                |     -470.0 |     -615.0 | Failing  |
| globalroute__timing__setup__tns               |   -33700.0 |  -106000.0 | Failing  |
| finish__timing__setup__ws                     |     -227.0 |     -207.0 | Tighten  |
| finish__timing__setup__tns                    |    -1590.0 |    -1430.0 | Tighten  |

designs/gf12/bp_dual/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -758.0 |     -614.0 | Tighten  |
| globalroute__timing__setup__ws                |     -100.0 |     -201.0 | Failing  |
| globalroute__timing__setup__tns               |     -400.0 |    -6470.0 | Failing  |
| finish__timing__setup__tns                    |    -1170.0 |    -1160.0 | Tighten  |