### PR TITLE
RFC: install bazel-packaged yosys instead of compiling from scratch

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,23 @@
+load("@bazel-orfs//:yosys_pkg.bzl", "yosys_prefix_tar")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 sh_binary(
     name = "install_for_bazel",
-    srcs = ["bazel/install.sh"],
+    # bazel/ is its own package (bazel/BUILD), so a cross-package label
+    # is required here; bazel/install.sh silently broke every root-package
+    # target once bazel/BUILD appeared.
+    srcs = ["//bazel:install.sh"],
+)
+
+# Relocatable PREFIX tarball of the hermetic bazel-built yosys
+# (bin/yosys, bin/yosys-abc, share/yosys/..., share/yosys/plugins/slang.so).
+# This is the single source of truth for the yosys that
+# etc/DependencyInstaller.sh and bazel/install.sh install; the version is
+# the @yosys pin in bazel-orfs MODULE.bazel (bump via
+# `bazelisk run @bazel-orfs//:bump`).
+yosys_prefix_tar(
+    name = "yosys_tar",
+    # Same label as orfs.default(yosys_plugins = ...) in MODULE.bazel, so
+    # SYNTH_HDL_FRONTEND=slang works identically in the classic flow.
+    plugins = ["@yosys-slang//src/yosys_plugin:slang.so"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ bazel_dep(name = "rules_shell", version = "0.6.1")
 # our MODULE.bazel doesn't need to be patched at non-root consumption
 # time.
 
+bazel_dep(name = "rules_pycross", version = "0.8.1", dev_dependency = True)
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 bazel_dep(name = "openroad", dev_dependency = True)
 local_path_override(
@@ -41,9 +42,18 @@ BAZEL_ORFS_COMMIT = "6ebadeb4be5c9ada103081c9a5e668c014126616"
 BAZEL_ORFS_REMOTE = "https://github.com/The-OpenROAD-Project/bazel-orfs.git"
 
 # To bump version, run: bazelisk run @bazel-orfs//:bump
+#
+# `patches =` keeps small bazel-orfs changes vendored in this repo while
+# they make their way upstream, instead of round-tripping every change
+# through a bazel-orfs PR + pin bump.  When a patch lands upstream, drop
+# the entry here and bump BAZEL_ORFS_COMMIT.
 git_override(
     module_name = "bazel-orfs",
     commit = BAZEL_ORFS_COMMIT,
+    patch_strip = 1,
+    patches = [
+        "//patches/bazel-orfs:0001-add-yosys-prefix-tar-packaging.patch",
+    ],
     remote = BAZEL_ORFS_REMOTE,
 )
 
@@ -64,6 +74,17 @@ git_override(
     commit = "7753ea70431d85929292b90c33b32f6dbdb3b048",
     init_submodules = True,
     remote = "https://github.com/povik/yosys-slang.git",
+)
+
+# The sed resolved via @yosys -> abc -> readline -> ncurses ships a
+# gnulib whose memchr replacement does not compile against glibc 2.43
+# (its function-like memchr macro mangles the definition). Pin the
+# newest sed and carry small gnulib fixes until they land upstream.
+single_version_override(
+    module_name = "sed",
+    patch_strip = 1,
+    patches = ["//patches/bcr:sed-4.10-glibc-2.43.patch"],
+    version = "4.10",
 )
 
 # --- Extensions ---
@@ -88,6 +109,20 @@ python.toolchain(
     ignore_root_user_error = True,
     python_version = "3.13",
 )
+
+# sv-lang (via @openroad) pulls in rules_pycross, whose toolchain
+# computation fails on Python 3.8 (registered transitively via
+# or-tools -> pybind11_abseil, dropped from rules_python 2.0.0's
+# MINOR_MAPPING). pycross.configure_* tags are root-honored only, so the
+# workaround from tools/OpenROAD/MODULE.bazel must be repeated here.
+# Without it any target that needs python toolchain resolution from this
+# root (e.g. rules_pkg's pkg_tar) fails.
+pycross = use_extension(
+    "@rules_pycross//pycross/extensions:pycross.bzl",
+    "pycross",
+    dev_dependency = True,
+)
+pycross.configure_environments(python_versions = ["3.13"])
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,1 +1,1 @@
-exports_files(glob(["*.patch"]))
+exports_files(glob(["*.patch"]) + ["install.sh"])

--- a/bazel/install.sh
+++ b/bazel/install.sh
@@ -2,48 +2,15 @@
 set -e
 
 # ORFS developer install script
-# Builds and installs OpenROAD, Yosys, and yosys-slang to tools/install/
-# where flow/Makefile expects them.
+# Builds and installs OpenROAD, Yosys (with the yosys-slang plugin) to
+# tools/install/ where flow/Makefile expects them.
 #
-# Uses stamp files for fast no-op re-runs (seconds when nothing changed).
+# Yosys comes from the bazel-built //:yosys_tar tarball (hermetic, cached
+# by bazel), so re-runs are fast and no host toolchain beyond bazelisk is
+# needed.
 
 WORKSPACE="${BUILD_WORKSPACE_DIRECTORY:-.}"
 INSTALL_DIR="${WORKSPACE}/tools/install"
-NUM_THREADS=$(nproc)
-
-# --- Check system dependencies for yosys/slang builds ---
-check_deps() {
-    local missing_cmds=()
-
-    for cmd in bison flex gawk g++ pkg-config tclsh git cmake; do
-        if ! command -v "$cmd" &>/dev/null; then
-            missing_cmds+=("$cmd")
-        fi
-    done
-
-    if [[ ${#missing_cmds[@]} -eq 0 ]]; then
-        return
-    fi
-
-    echo "ERROR: Missing commands: ${missing_cmds[*]}"
-    echo ""
-
-    # Platform-specific install hint
-    if [[ "$(uname -s)" == "Darwin" ]]; then
-        echo "  brew install bison flex gawk cmake pkg-config tcl-tk"
-    elif command -v apt-get &>/dev/null; then
-        echo "  sudo apt-get install bison flex gawk g++ pkg-config tcl cmake git"
-    elif command -v dnf &>/dev/null; then
-        echo "  sudo dnf install bison flex gawk gcc-c++ pkgconf tcl cmake git"
-    elif command -v yum &>/dev/null; then
-        echo "  sudo yum install bison flex gawk gcc-c++ pkgconf tcl cmake git"
-    elif command -v zypper &>/dev/null; then
-        echo "  sudo zypper install bison flex gawk gcc-c++ pkg-config tcl cmake git"
-    fi
-    exit 1
-}
-
-check_deps
 
 BUILD_OPENROAD=1
 
@@ -54,7 +21,6 @@ Usage: bazelisk run //:install_for_bazel [-- OPTIONS]
 Options:
   --help, -h        Show this help
   --skip-openroad   Skip OpenROAD build
-  --threads N       Compilation threads (default: nproc)
 EOF
     exit 0
 }
@@ -67,10 +33,6 @@ while [[ $# -gt 0 ]]; do
         --skip-openroad)
             BUILD_OPENROAD=0
             ;;
-        --threads)
-            NUM_THREADS="$2"
-            shift
-            ;;
         *)
             echo "Unknown option: $1"
             usage
@@ -80,7 +42,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # --- Check submodules are initialized ---
-for sub in tools/OpenROAD tools/yosys tools/yosys-slang; do
+for sub in tools/OpenROAD; do
     if [[ ! -d "${WORKSPACE}/${sub}" ]] || [[ -z "$(ls -A "${WORKSPACE}/${sub}" 2>/dev/null)" ]]; then
         echo "ERROR: ${sub} not initialized."
         echo "Run: git submodule update --init --recursive"
@@ -94,47 +56,21 @@ if [[ $BUILD_OPENROAD -eq 1 ]]; then
     (cd "${WORKSPACE}/tools/OpenROAD" && bazelisk run --//:platform=gui //packaging:install)
 fi
 
-# --- Yosys ---
-# Uses stamp file for fast no-op: if the yosys submodule commit hasn't
-# changed, skip the build entirely.
+# --- Yosys (bazel-packaged tarball, includes yosys-abc and slang.so) ---
+# //:yosys_tar is the bazel-built relocatable PREFIX tarball; bazel
+# caches the build so re-runs are fast no-ops.
 YOSYS_INSTALL="${INSTALL_DIR}/yosys"
-YOSYS_STAMP="${YOSYS_INSTALL}/.yosys_commit"
-YOSYS_COMMIT="$(git -C "${WORKSPACE}/tools/yosys" rev-parse HEAD)"
 
-if [[ -f "${YOSYS_STAMP}" ]] && [[ "$(cat "${YOSYS_STAMP}")" == "${YOSYS_COMMIT}" ]]; then
-    echo "=== Yosys already up to date (${YOSYS_COMMIT:0:12}) ==="
-else
-    echo "=== Building Yosys ==="
-    (
-        cd "${WORKSPACE}/tools/yosys"
-        make -j "${NUM_THREADS}" PREFIX="${YOSYS_INSTALL}" ABC_ARCHFLAGS=-Wno-register
-        make install PREFIX="${YOSYS_INSTALL}"
-    )
-    echo "${YOSYS_COMMIT}" > "${YOSYS_STAMP}"
-    echo "Yosys installed to ${YOSYS_INSTALL}/bin/yosys"
-fi
-
-# --- yosys-slang ---
-SLANG_STAMP="${YOSYS_INSTALL}/.slang_commit"
-SLANG_COMMIT="$(git -C "${WORKSPACE}/tools/yosys-slang" rev-parse HEAD)"
-
-if [[ -f "${SLANG_STAMP}" ]] && [[ "$(cat "${SLANG_STAMP}")" == "${SLANG_COMMIT}" ]]; then
-    echo "=== yosys-slang already up to date (${SLANG_COMMIT:0:12}) ==="
-else
-    echo "=== Building yosys-slang ==="
-    (
-        cd "${WORKSPACE}/tools/yosys-slang"
-        cmake -S . -B build \
-            -DYOSYS_CONFIG="${YOSYS_INSTALL}/bin/yosys-config" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DYOSYS_SLANG_REVISION=unknown \
-            -DSLANG_REVISION=unknown
-        cmake --build build -j "${NUM_THREADS}"
-        cmake --install build --prefix "${YOSYS_INSTALL}"
-    )
-    echo "${SLANG_COMMIT}" > "${SLANG_STAMP}"
-    echo "yosys-slang installed to ${YOSYS_INSTALL}/share/yosys/plugins/"
-fi
+echo "=== Installing Yosys (bazel //:yosys_tar) ==="
+(
+    cd "${WORKSPACE}"
+    bazelisk build //:yosys_tar
+    TARBALL="$(bazelisk info execution_root)/$(bazelisk cquery --output=files //:yosys_tar 2>/dev/null)"
+    rm -rf "${YOSYS_INSTALL}"
+    mkdir -p "${YOSYS_INSTALL}"
+    tar -xzf "${TARBALL}" -C "${YOSYS_INSTALL}"
+)
+echo "Yosys installed to ${YOSYS_INSTALL}/bin/yosys"
 
 echo ""
 echo "=== Done ==="

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -27,10 +27,40 @@ _versionCompare() {
 }
 
 _installORDependencies() {
-    if [[ ${YOSYS_VER} == "" ]]; then
-        YOSYS_VER=v$(grep 'yosys_ver =' tools/yosys/docs/source/conf.py | awk -F'"' '{print $2}')
+    # Bootstrap bazelisk; the bazel-packaged yosys below needs it and it
+    # is idempotent (-bazel alone is a valid OpenROAD installer call).
+    ./tools/OpenROAD/etc/DependencyInstaller.sh -bazel ${PREFIX:+-prefix=${PREFIX}}
+
+    # Install the bazel-packaged yosys.  Single source of truth: the
+    # @yosys pin in bazel-orfs MODULE.bazel (bump via
+    # `bazelisk run @bazel-orfs//:bump`).  Bazel caches the build, so
+    # re-runs are fast: no git clone, no make, and the same hermetic
+    # yosys on every OS.
+    _installYosysBazel
+
+    # Delegate the rest.  Pass the version of the yosys installed above
+    # so the OpenROAD installer's _install_yosys version check succeeds
+    # and its git-clone-and-make build is a no-op; -eqy still installs
+    # eqy/sby against the bazel-built yosys.
+    local yosys_version
+    yosys_version=$("${PREFIX:-/usr/local}/bin/yosys" --version | awk '{print $2}')
+    ./tools/OpenROAD/etc/DependencyInstaller.sh ${OR_INSTALLER_ARGS} -yosys-ver="v${yosys_version}"
+}
+
+_installYosysBazel() {
+    local yosys_prefix=${PREFIX:-"/usr/local"}
+    local bazelisk="bazelisk"
+    if ! command -v bazelisk &> /dev/null; then
+        bazelisk="${yosys_prefix}/bin/bazelisk"
     fi
-    ./tools/OpenROAD/etc/DependencyInstaller.sh ${OR_INSTALLER_ARGS} -yosys-ver="${YOSYS_VER}"
+    # --symlink_prefix=/ avoids dropping bazel-* convenience symlinks
+    # (root-owned when run under sudo) in the source tree; resolve the
+    # tarball via the execution root instead of the symlinks.
+    "${bazelisk}" build --symlink_prefix=/ //:yosys_tar
+    local tarball
+    tarball="$("${bazelisk}" info execution_root)/$("${bazelisk}" cquery --symlink_prefix=/ --output=files //:yosys_tar 2> /dev/null)"
+    mkdir -p "${yosys_prefix}"
+    tar -xzf "${tarball}" -C "${yosys_prefix}"
 }
 
 _installPipCommon() {
@@ -350,10 +380,6 @@ Usage: $0 [-all|-base|-common] [-<ARGS>]
                                 #    sudo or with root access.
        $0 -ci
                                 # Installs CI tools
-       $0 -yosys-ver=VERSION
-                                # Installs specified version of Yosys.
-                                #    By default, the Yosys version is
-                                #    obtained from tools/yosys/docs/source/conf.py
        $0 -constant-build-dir
                                 #  Use constant build directory, instead of
                                 #    random one.
@@ -363,7 +389,6 @@ EOF
 
 # default args
 OR_INSTALLER_ARGS="-eqy"
-YOSYS_VER=""
 # default prefix
 PREFIX=""
 # default option
@@ -406,9 +431,6 @@ while [ "$#" -gt 0 ]; do
             ;;
         -save-deps-prefixes=*)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"
-            ;;
-        -yosys-ver=*)
-            YOSYS_VER=${1#*=}
             ;;
         -prefix=*)
             OR_INSTALLER_ARGS="${OR_INSTALLER_ARGS} $1"

--- a/patches/bazel-orfs/0001-add-yosys-prefix-tar-packaging.patch
+++ b/patches/bazel-orfs/0001-add-yosys-prefix-tar-packaging.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Thu, 2 Jul 2026 16:29:00 +0200
+Subject: [PATCH] Add yosys_prefix_tar packaging macro and :yosys_tar target
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Package the hermetic @yosys BCR build (yosys binary, yosys-abc, share
+tree, optional plugins) as a relocatable PREFIX tarball via rules_pkg.
+Extract into any prefix; yosys finds share/ and abc relative to its
+binary, so no path patching is needed.
+
+This gives installers (e.g. ORFS DependencyInstaller.sh) a single
+source of truth for yosys instead of ad-hoc git-clone-and-make builds.
+
+Signed-off-by: Øyvind Harboe <oyvind.harboe@zylin.com>
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+---
+ BUILD         |  9 +++++++
+ yosys_pkg.bzl | 73 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 82 insertions(+)
+ create mode 100644 yosys_pkg.bzl
+
+diff --git a/BUILD b/BUILD
+index f995236..390aeff 100644
+--- a/BUILD
++++ b/BUILD
+@@ -4,6 +4,7 @@
+ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+ load("@rules_python//python:pip.bzl", "compile_pip_requirements")
+ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
++load(":yosys_pkg.bzl", "yosys_prefix_tar")
+ 
+ exports_files([
+     "bump.py",
+@@ -31,6 +32,14 @@ exports_files([
+     "synth_partition.sh",
+ ])
+ 
++# Relocatable PREFIX tarball of the hermetic yosys build (bin/yosys,
++# bin/yosys-abc, share/yosys/...). Consumers that want plugins bundled
++# (e.g. yosys-slang) instantiate yosys_prefix_tar() themselves.
++yosys_prefix_tar(
++    name = "yosys_tar",
++    visibility = ["//visibility:public"],
++)
++
+ sh_binary(
+     name = "klayout",
+     srcs = ["klayout.sh"],
+diff --git a/yosys_pkg.bzl b/yosys_pkg.bzl
+new file mode 100644
+index 0000000..6751195
+--- /dev/null
++++ b/yosys_pkg.bzl
+@@ -0,0 +1,73 @@
++"""Package the hermetic @yosys build as a relocatable PREFIX tarball.
++
++The tarball follows the standard `make install` PREFIX layout:
++
++  bin/yosys
++  bin/yosys-abc
++  share/yosys/...
++  share/yosys/plugins/*.so   (optional, via the plugins attribute)
++
++Yosys resolves its data directory as <bindir>/../share/yosys/ and abc as
++<bindir>/yosys-abc (proc_self_dirname()), so the tarball can be extracted
++into any prefix (e.g. /usr/local or a user directory) without patching.
++"""
++
++load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
++load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
++
++# Label() resolves in bazel-orfs's repo mapping, so consumers of the
++# macro don't need their own @yosys/@abc bazel_dep.
++_YOSYS = Label("@yosys//:yosys")
++_YOSYS_SHARE = Label("@yosys//:yosys_share")
++_ABC = Label("@abc//:abc_bin")
++
++def yosys_prefix_tar(name, plugins = [], visibility = None):
++    """Create <name>.tar.gz with a relocatable PREFIX install of yosys.
++
++    Args:
++      name: name of the resulting pkg_tar target.
++      plugins: optional list of yosys plugin shared-object labels
++        (e.g. @yosys-slang//src/yosys_plugin:slang.so) placed in
++        share/yosys/plugins/ where `plugin -i <name>` finds them.
++      visibility: standard visibility.
++    """
++    pkg_files(
++        name = name + "_bin",
++        srcs = [
++            _YOSYS,
++            _ABC,
++        ],
++        attributes = pkg_attributes(mode = "0755"),
++        prefix = "bin",
++        renames = {
++            # proc_self_dirname() + "yosys-abc" is how yosys finds abc.
++            _ABC: "yosys-abc",
++        },
++    )
++    pkg_files(
++        name = name + "_share",
++        # The share tree is declared as share/<dst> in @yosys's root
++        # package; remap to the installed share/yosys/<dst> layout.
++        srcs = [_YOSYS_SHARE],
++        prefix = "share/yosys",
++        strip_prefix = strip_prefix.from_pkg("share"),
++    )
++    srcs = [
++        name + "_bin",
++        name + "_share",
++    ]
++    if plugins:
++        pkg_files(
++            name = name + "_plugins",
++            srcs = plugins,
++            attributes = pkg_attributes(mode = "0755"),
++            prefix = "share/yosys/plugins",
++        )
++        srcs.append(name + "_plugins")
++    pkg_tar(
++        name = name,
++        srcs = srcs,
++        extension = "tar.gz",
++        tags = ["manual"],
++        visibility = visibility,
++    )

--- a/patches/bazel-orfs/BUILD.bazel
+++ b/patches/bazel-orfs/BUILD.bazel
@@ -1,0 +1,8 @@
+"""Vendored patches applied on top of the bazel-orfs git_override pin.
+
+These are small fixes we keep here to reduce churn while iterating;
+when they land upstream, drop the entry from MODULE.bazel and bump
+BAZEL_ORFS_COMMIT instead.
+"""
+
+exports_files(glob(["*.patch"]))

--- a/patches/bcr/BUILD.bazel
+++ b/patches/bcr/BUILD.bazel
@@ -1,0 +1,8 @@
+"""Vendored patches applied on top of BCR module pins.
+
+Same idea as patches/bazel-orfs: keep small fixes here while they make
+their way upstream (gnulib / the BCR module), drop them once an
+upstream release carries the fix.
+"""
+
+exports_files(glob(["*.patch"]))

--- a/patches/bcr/sed-4.10-glibc-2.43.patch
+++ b/patches/bcr/sed-4.10-glibc-2.43.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=C3=98yvind=20Harboe?= <oyvind.harboe@zylin.com>
+Date: Thu, 2 Jul 2026 17:05:27 +0200
+Subject: [PATCH] Fix gnulib vs glibc 2.43 and enable strnul
+
+gnulib's memchr replacement predates glibc 2.43, whose <string.h>
+defines memchr as a function-like macro (__glibc_const_generic); always
+undefine it before defining the replacement.  gnulib's error.c uses
+getprogname(), which glibc only declares under __USE_MISC and only
+since 2.38, and the pregenerated Bazel config does not provide gnulib's
+<stdlib.h> override; declare it directly.  file-has-acl.c uses strnul()
+unconditionally, but the generated string.h had GNULIB_STRNUL=0; flip
+it to 1 (lib/strnul.c is already compiled).
+---
+ BUILD.bazel  | 2 +-
+ lib/error.c  | 6 ++++++
+ lib/memchr.c | 4 +---
+ 3 files changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 0d52d41..2f23fd8 100755
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -505,7 +505,7 @@ autoconf(
+         checks.AC_SUBST("GNULIB_STRNCPY", 0),
+         checks.AC_SUBST("GNULIB_STRNDUP", 0),
+         checks.AC_SUBST("GNULIB_STRNLEN", 0),
+-        checks.AC_SUBST("GNULIB_STRNUL", 0),
++        checks.AC_SUBST("GNULIB_STRNUL", 1),
+         checks.AC_SUBST("GNULIB_STRPBRK", 0),
+         checks.AC_SUBST("GNULIB_STRPTIME", 0),
+         checks.AC_SUBST("GNULIB_STRSEP", 0),
+diff --git a/lib/error.c b/lib/error.c
+index e066241..14bb98d 100644
+--- a/lib/error.c
++++ b/lib/error.c
+@@ -31,6 +31,12 @@
+ 
+ #include <error.h>
+ 
++/* glibc declares getprogname in <stdlib.h> only under __USE_MISC and
++   only since 2.38; the pregenerated Bazel config does not provide
++   gnulib's <stdlib.h> override, so declare it directly (matches both
++   glibc's and gnulib's definition).  */
++const char *getprogname (void);
++
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+diff --git a/lib/memchr.c b/lib/memchr.c
+index 6adac7e..e4dc51b 100644
+--- a/lib/memchr.c
++++ b/lib/memchr.c
+@@ -46,9 +46,7 @@
+ #endif
+ 
+ #undef __memchr
+-#ifdef _LIBC
+-# undef memchr
+-#endif
++#undef memchr
+ 
+ #ifndef weak_alias
+ # define __memchr memchr


### PR DESCRIPTION
**Concept PR for comments — not intended to merge as-is.**

## What

Stop compiling yosys from scratch with ad-hoc git-clone-and-make code in
`DependencyInstaller.sh` and `bazel/install.sh`. Instead, package the
hermetic bazel-built yosys (binary + `yosys-abc` + share tree +
`slang.so` plugin) as a relocatable PREFIX tarball, `//:yosys_tar`, and
have the installers build and extract that.

- `patches/bazel-orfs/0001-add-yosys-prefix-tar-packaging.patch` — adds a
  `yosys_prefix_tar()` macro (rules_pkg `pkg_tar`) to bazel-orfs, vendored
  as a `git_override` patch. Offered upstream as
  The-OpenROAD-Project/bazel-orfs#752; this PR works
  identically whether that lands, stalls, or is closed — when it lands we
  drop the patch and bump `BAZEL_ORFS_COMMIT`.
- `BUILD.bazel` — instantiates `//:yosys_tar` with the yosys-slang plugin
  (same label as `orfs.default(yosys_plugins = ...)`), so
  `SYNTH_HDL_FRONTEND=slang` keeps working.
- `etc/DependencyInstaller.sh` — `_installORDependencies` now bootstraps
  bazelisk (which it installed anyway), builds + extracts `//:yosys_tar`
  into the prefix, and passes the installed version to the OpenROAD
  installer so its `_install_yosys` source build becomes a verified
  no-op. The `-yosys-ver` flag and the `tools/yosys/docs/source/conf.py`
  version scraping are gone.
- `bazel/install.sh` — the hand-rolled yosys `make` and yosys-slang
  `cmake` builds are replaced by the same tarball; the
  bison/flex/gawk/cmake host-dependency checks disappear with them.
- `patches/bcr/sed-4.10-glibc-2.43.patch` — the BCR `sed` module (via
  `@yosys → abc → readline → ncurses`) ships a gnulib that does not
  compile against glibc 2.43; `single_version_override` pins sed 4.10
  with two small gnulib fixes. The same patching zen, one level deeper:
  works today, dropped when gnulib/BCR catch up.

## Why

- **Single source of truth.** The yosys version is the `@yosys` pin in
  bazel-orfs `MODULE.bazel` (bumped via `bazelisk run @bazel-orfs//:bump`),
  identical for the bazel flow and the classic make flow. No more
  version scraping, no more OS-specific compile paths in
  `DependencyInstaller.sh` — the same hermetic binary on every OS,
  including macOS.
- **Faster installs.** Bazel caches the yosys build; re-running the
  installer is a cache hit instead of a re-clone and full rebuild.
- **Gradual, additive migration.** This simplifies maintainers' lives
  *before* the switch to bazel is complete: the old bash scripts shrink
  instead of growing, and each piece is testable in isolation —
  `bazelisk build //:yosys_tar` is a lot easier to exercise than a code
  path buried inside `DependencyInstaller.sh`.
- **A sane patching story.** With yosys consumed as a bazel module we
  can carry patches for yosys (or any other tool) while waiting for
  upstream fixes to land — backports from the next release, macOS
  fixes, etc. — with Claude handling the mechanical patch maintenance.
  The zen of it: every patch is offered upstream as a GitHub PR, and
  the vendored copy keeps working regardless of the upstream PR's fate.
  The amount of patching stays roughly constant over time and will
  never be zero — ORFS/OpenROAD's bleeding edge will always be on the
  bleeding edge. (The `.bazelrc` fallback registry for yosys 0.64,
  pending bazelbuild/bazel-central-registry#8862, is this same pattern
  already in action.)
- **Toward dropping the yosys submodules.** `tools/yosys` and
  `tools/yosys-slang` are no longer needed by these paths; removing
  them is deliberately left for a follow-up.

## Tarball layout

```
bin/yosys
bin/yosys-abc
share/yosys/...
share/yosys/plugins/slang.so
```

Yosys resolves share as `<bindir>/../share/yosys/` and abc as
`<bindir>/yosys-abc`, and the bazel build links readline/tcl/zlib/ffi/abc
statically — the tarball extracts into any prefix unmodified.

## Latent master issues this surfaced (fixed here)

Nothing built root-package or pkg_tar targets from the ORFS root before,
so two pre-existing breakages were invisible:

- `//:install_for_bazel`'s `srcs = ["bazel/install.sh"]` label is invalid
  — `bazel/BUILD` makes `bazel/` its own package, which silently broke
  every root-package target. Fixed with a cross-package label +
  `exports_files`.
- rules_pycross's toolchain computation fails on Python 3.8 (registered
  transitively via or-tools → pybind11_abseil, dropped from
  rules_python 2.0.0's `MINOR_MAPPING`). The workaround already in
  `tools/OpenROAD/MODULE.bazel` is root-honored only, so it is repeated
  in the ORFS `MODULE.bazel`.

## Known gaps / discussion points

- The tarball does not ship the `make install` extras `yosys-config`,
  `yosys-smtbmc`, `yosys-witness`, `yosys-filterlib`. sby's smtbmc
  engines and out-of-tree plugin builds against the installed yosys
  would need them; extending the macro is a follow-up if required.
- eqy/sby keep their existing source builds (pure-Python YosysHQ tools,
  no bazel modules yet); they build against the bazel-installed yosys.
- The bazel path needs network access to BCR/registries; there is no
  `-nocert` equivalent plumbed through yet.
- Deleting `_install_yosys` from the OpenROAD installer is a separate
  OpenROAD PR once nothing exercises it.
