### PR TITLE
flow: repair egregious fanout when writing 1_synth.odb

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -288,6 +288,7 @@ configuration file.
 | <a name="SKIP_PIN_SWAP"></a>SKIP_PIN_SWAP| Do not use pin swapping as a transform to fix timing violations (default: use pin swapping).| |
 | <a name="SKIP_REPAIR_TIE_FANOUT"></a>SKIP_REPAIR_TIE_FANOUT| Skip repair_tie_fanout at floorplan step.| 0|
 | <a name="SKIP_REPORT_METRICS"></a>SKIP_REPORT_METRICS| If set to 1, then metrics, report_metrics does nothing. Useful to speed up builds.| 0|
+| <a name="SKIP_SYNTH_REPAIR_DESIGN"></a>SKIP_SYNTH_REPAIR_DESIGN| Skip the DRC-only repair_design of egregious high-fanout nets when writing 1_synth.odb.| 0|
 | <a name="SKIP_VT_SWAP"></a>SKIP_VT_SWAP| Do not perform VT swap to improve QoR (default: do VT swap).| |
 | <a name="SLANG_PLUGIN_PATH"></a>SLANG_PLUGIN_PATH| Path to the slang plugin for Yosys. This can be a full path to a custom-built plugin (e.g. for Bazel builds) or just the plugin name.| slang|
 | <a name="SLEW_MARGIN"></a>SLEW_MARGIN| Specifies a slew margin when fixing max slew violations. This option allows you to overfix.| |
@@ -309,6 +310,7 @@ configuration file.
 | <a name="SYNTH_NETLIST_FILES"></a>SYNTH_NETLIST_FILES| Skips synthesis and uses the supplied netlist files. If the netlist files contains duplicate modules, which can happen when using hierarchical synthesis on indvidual netlist files and combining here, subsequent modules are silently ignored and only the first module is used.| |
 | <a name="SYNTH_OPERATIONS_ARGS"></a>SYNTH_OPERATIONS_ARGS| Extra arguments appended to the Yosys synth command operations list. When set, replaces the default Kogge-Stone adder extra-map.| |
 | <a name="SYNTH_OPT_HIER"></a>SYNTH_OPT_HIER| Optimize constants across hierarchical boundaries.| |
+| <a name="SYNTH_REPAIR_DESIGN_MAX_FANOUT"></a>SYNTH_REPAIR_DESIGN_MAX_FANOUT| Fanout above which a net is considered an egregious violation to be buffered by the synth stage repair_design.| 64|
 | <a name="SYNTH_REPEATABLE_BUILD"></a>SYNTH_REPEATABLE_BUILD| License to prune anything that makes builds less repeatable, typically used with Bazel to ensure that builds are bit-for-bit identical so that caching works optimally. Removes debug information that encodes paths, timestamps, etc.| 0|
 | <a name="SYNTH_RETIME_MODULES"></a>SYNTH_RETIME_MODULES| *This is an experimental option and may cause adverse effects.* *No effort has been made to check if the retimed RTL is logically equivalent to the non-retimed RTL.* List of modules to apply automatic retiming to. These modules must not get dissolved and as such they should either be the top module or be included in SYNTH_KEEP_MODULES. The main use case is to quickly identify if performance can be improved by manually retiming the input RTL. Retiming will treat module ports like register endpoints/startpoints. The objective function of retiming isn't informed by SDC, even the clock period is ignored. As such, retiming will optimize for best delay at potentially high register number cost. Automatic retiming can produce suboptimal results as its timing model is crude and it doesn't find the optimal distribution of registers on long pipelines. See OR discussion  # 8080.| |
 | <a name="SYNTH_SKIP_KEEP"></a>SYNTH_SKIP_KEEP| Only meaningful together with SYNTH_CHECKPOINT. When set, signals that the supplied checkpoint is still canonical RTLIL (coarse synth and `keep_hierarchy` have not been run yet), so synth.tcl runs the full coarse+fine synthesis flattened. When unset and SYNTH_CHECKPOINT is used, synth.tcl assumes the checkpoint already has coarse synth + `keep_hierarchy` done and resumes from `coarse:fine`.| 0|
@@ -353,6 +355,7 @@ configuration file.
 - [SDC_FILE](#SDC_FILE)
 - [SDC_GUT](#SDC_GUT)
 - [SKIP_REPORT_METRICS](#SKIP_REPORT_METRICS)
+- [SKIP_SYNTH_REPAIR_DESIGN](#SKIP_SYNTH_REPAIR_DESIGN)
 - [SLANG_PLUGIN_PATH](#SLANG_PLUGIN_PATH)
 - [SYNTH_ARGS](#SYNTH_ARGS)
 - [SYNTH_BLACKBOXES](#SYNTH_BLACKBOXES)
@@ -371,6 +374,7 @@ configuration file.
 - [SYNTH_NETLIST_FILES](#SYNTH_NETLIST_FILES)
 - [SYNTH_OPERATIONS_ARGS](#SYNTH_OPERATIONS_ARGS)
 - [SYNTH_OPT_HIER](#SYNTH_OPT_HIER)
+- [SYNTH_REPAIR_DESIGN_MAX_FANOUT](#SYNTH_REPAIR_DESIGN_MAX_FANOUT)
 - [SYNTH_REPEATABLE_BUILD](#SYNTH_REPEATABLE_BUILD)
 - [SYNTH_RETIME_MODULES](#SYNTH_RETIME_MODULES)
 - [SYNTH_SKIP_KEEP](#SYNTH_SKIP_KEEP)

--- a/flow/scripts/synth_odb.tcl
+++ b/flow/scripts/synth_odb.tcl
@@ -28,9 +28,35 @@ report_design_area
 report_design_area_metrics
 
 source_step_tcl POST SYNTH
-orfs_write_db $::env(RESULTS_DIR)/1_synth.odb
 # Canonicalize 1_synth.sdc. The original SDC_FILE provided by
 # the user could have dependencies, such as sourcing util.tcl,
 # which are read in here and a canonicalized version is written
 # out by OpenSTA that has no dependencies.
+#
+# Written before the fanout repair below so that its repair-scoping
+# set_max_fanout does not leak into the flow's SDC.
 orfs_write_sdc $::env(RESULTS_DIR)/1_synth.sdc
+
+# The synth stage owns the electrical sanity of its product. Raw yosys/ABC
+# output leaves egregious high-fanout nets unbuffered; STA on 1_synth.odb
+# then reports fanout artifacts instead of logic depth, which misleads
+# anyone using synth as a signal for RTL changes. synth_syn.tcl already
+# runs repair_design -pre_placement unconditionally before writing
+# 1_synth.odb; this is the yosys-path analog, but DRC-only and bounded:
+# -pre_placement is a whole-design gain round and conflicts with
+# -placement parasitics (EST-0104). set_max_fanout makes only the
+# egregious nets DRC violations; -max_wire_length large disables wire
+# splitting (unplaced cells have no meaningful wire length). Like
+# eliminate_dead_logic above, this is context-free (no die/bterm/layer
+# dependence) -- the floorplan.tcl conditioning block stays in floorplan
+# per PR #4187.
+if { !$::env(SKIP_SYNTH_REPAIR_DESIGN) } {
+  if { [env_var_exists_and_non_empty DONT_USE_CELLS] } {
+    set_dont_use $::env(DONT_USE_CELLS)
+  }
+  set_max_fanout $::env(SYNTH_REPAIR_DESIGN_MAX_FANOUT) [current_design]
+  log_cmd estimate_parasitics -placement
+  log_cmd repair_design -max_wire_length 1000000
+}
+
+orfs_write_db $::env(RESULTS_DIR)/1_synth.odb

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -1220,6 +1220,13 @@
       "final"
     ]
   },
+  "SKIP_SYNTH_REPAIR_DESIGN": {
+    "default": 0,
+    "description": "Skip the DRC-only repair_design of egregious high-fanout nets when writing 1_synth.odb.\n",
+    "stages": [
+      "synth"
+    ]
+  },
   "SKIP_VT_SWAP": {
     "description": "Do not perform VT swap to improve QoR (default: do VT swap).\n",
     "stages": [
@@ -1351,6 +1358,13 @@
   },
   "SYNTH_OPT_HIER": {
     "description": "Optimize constants across hierarchical boundaries.\n",
+    "stages": [
+      "synth"
+    ]
+  },
+  "SYNTH_REPAIR_DESIGN_MAX_FANOUT": {
+    "default": 64,
+    "description": "Fanout above which a net is considered an egregious violation to be buffered by the synth stage repair_design.\n",
     "stages": [
       "synth"
     ]

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -448,6 +448,20 @@ SWAP_ARITH_OPERATORS:
     Improve timing QoR by swapping ALU and MULT arithmetic operators.
   stages:
     - All stages
+SKIP_SYNTH_REPAIR_DESIGN:
+  description: >
+    Skip the DRC-only repair_design of egregious high-fanout nets when
+    writing 1_synth.odb.
+  stages:
+    - synth
+  default: 0
+SYNTH_REPAIR_DESIGN_MAX_FANOUT:
+  description: >
+    Fanout above which a net is considered an egregious violation to be
+    buffered by the synth stage repair_design.
+  stages:
+    - synth
+  default: 64
 FLOORPLAN_DEF:
   description: |
     Use the DEF file to initialize floorplan. Mutually exclusive with FOOTPRINT or DIE_AREA/CORE_AREA or CORE_UTILIZATION.


### PR DESCRIPTION
## Motivation / use-case

Synth is widely used as a fast signal for RTL changes: run `make synth`, look at the worst paths (`gui_synth`, STA on `1_synth.odb`), improve the RTL, repeat. Today that signal is misleading: raw yosys/ABC output leaves egregious high-fanout nets unbuffered, so synth-stage STA charges the full unbuffered fanout load as delay. The worst reported paths are then dominated by fanout artifacts the place-stage resizer later repairs for free — they carry no actionable information, and they hide the real, RTL-actionable logic-depth paths behind them.

## Lessons this encodes

Written down so others don't have to re-learn them:

- **Raw yosys/ABC output is electrically unrepaired.** ABC's own buffering is layout-blind and treated as throwaway by the flow; OpenROAD does all real buffering/sizing later. STA on the raw synth netlist is dominated by fanout artifacts, not logic depth.
- **The floorplan stage does not fix this.** Its repair sequence (`unbuffer,sizeup,swap,vt_swap`) upsizes drivers but deliberately never inserts buffers — buffer-tree construction is deferred to place, where real locations exist.
- **The first buffered netlist in the stock flow is therefore place**, which is too slow for RTL iteration.
- **A context-free, DRC-only repair at synth is the cheapest point to make the signal honest** — exactly where `synth_syn.tcl` already runs its `repair_design -pre_placement` unconditionally before writing `1_synth.odb`.

## What / how

After `eliminate_dead_logic`, before writing `1_synth.odb`:

- `set_max_fanout` (`SYNTH_REPAIR_DESIGN_MAX_FANOUT`, default 64) so only the truly egregious nets are DRC violations — the pass touches the artifacts, not the whole design;
- `estimate_parasitics -placement` (handles unplaced cells);
- `repair_design -max_wire_length 1000000` — wire splitting disabled, since unplaced cells have no meaningful wire length.

Deliberately **not** `repair_design -pre_placement`: that is a whole-design gain-based round (slow on large merged netlists) and conflicts with `-placement` parasitics (`EST-0104`). The recipe here is DRC-only and bounded.

Default **on**, because this is stage semantics rather than an optional extra: the synth stage owns the electrical sanity of its product, matching `synth_syn.tcl`. `SKIP_SYNTH_REPAIR_DESIGN=1` restores the previous behavior, following the `SKIP_REPAIR_TIE_FANOUT` convention.

The canonicalized `1_synth.sdc` is written before the repair block so the repair-scoping `set_max_fanout` does not leak into the flow's SDC (there is no `unset_max_fanout`).

## What this deliberately does not do

It does not touch the floorplan.tcl conditioning block (`repair_tie_fanout`, `replace_arith_modules`, `remove_buffers`/`repair_timing_helper`). Per PR #4187 those transforms depend on floorplan context (bterm placement from `initialize_floorplan`, layer stack from `set_routing_layers`) and regressed setup TNS 1.7–46x when moved to synth. This block is additive and context-free (no die/bterm/layer dependence), like `eliminate_dead_logic` before it.

## QoR hypothesis

Neutral-to-better downstream: floorplan's `repair_timing_helper` and the place-stage `repair_design` start from an electrically sane netlist instead of one with unbuffered fanout-100 nets. **This PR is a draft to let CI capture whether that holds across the design matrix.** If it does, the question for maintainers is whether this matches the intention of the rest of the flow; if it doesn't, the per-design results are the data to decide between raising the fanout bound, defaulting off, or dropping the idea.
