### PR TITLE
flows: platforms: ihp-sg13g2: Suppress DRT-0349

### DIFF
--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -31,6 +31,8 @@ export LIB_FILES ?= $(TYP_LIB_FILES)
 export GDS_FILES ?= $(PLATFORM_DIR)/gds/sg13g2_stdcell.gds \
                     $(ADDITIONAL_GDS)
 
+export PLATFORM_TCL ?= $(PLATFORM_DIR)/suppress_message.tcl
+
 # Dont use cells to ease congestion
 # Specify at least one filler cell if none
 

--- a/flow/platforms/ihp-sg13g2/suppress_message.tcl
+++ b/flow/platforms/ihp-sg13g2/suppress_message.tcl
@@ -1,0 +1,3 @@
+# Disable message
+#  LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer X
+suppress_message DRT 349


### PR DESCRIPTION
OpenROAD is printing some warnings about missing CUTCLASS with LEF58_ENCLOSURE. LEF58_ENCLOSURE is not defined in the IHP Open PDK nor is this feature required for 130nm.

Suppress this warning to remove them from the logs.

[WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer Cont [WARNING DRT-0349] LEF58_ENCLOSURE with no CUTCLASS is not supported. Skipping for layer Via1 ...