### PR TITLE
(DO NOT MERGE) ORFS QoR check for latch D-input path optimization

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "3fc8a6d24fdb16116484d2eed15ff2dbe4531126",
+        "value": "19acb7d687b178ee91ab01ad07af25e3abedb535",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "fb786d77e841d2488f5a6b7db514abf2010cf808",
+        "value": "9f7d39ee0f440924eabd30155a544d8efcc50841",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/gf180/uart-blocks/rules-base.json
+++ b/flow/designs/gf180/uart-blocks/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "6539c6f38d2e14aa6b73a233552bb9e77150c29e",
+        "value": "e210b6053e7d9b8ec2bee901b225bfcccb372a8e",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/gt2n/aes/rules-base.json
+++ b/flow/designs/gt2n/aes/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "e9426c391e35d86c9f9023e814fd4826714b89b5",
+        "value": "b5cb62181bb94986892fda8e1365619061e48646",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "93f9e9316090c4b4b44bf35599036a9c5cdfe109",
+        "value": "ea6d1e1b8dfb6a178bcd19185426c4d458de61db",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/gt2n/gcd/rules-base.json
+++ b/flow/designs/gt2n/gcd/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "94435b2c79066c9133b4aed43b6f5abf1ec21003",
+        "value": "108e2de983c01ded46ab267946b5516413d044ad",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "102bf37d6da7bc1aa234e916ebbf91984197836d",
+        "value": "b93b42902bb727f11898a7e24cd3ba60e4d9d132",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/gt2n/jpeg/rules-base.json
+++ b/flow/designs/gt2n/jpeg/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "39cc69c759997747b607f7a6d205bc6b27432dce",
+        "value": "51457652a38612abc81c6f24d04adbd8156dac64",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "eda4f7adafcd818f9ad0d4da7c8f3dd4089ea87b",
+        "value": "366edccbe4bd276e7aec2ed99938c43c1276ca73",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
+++ b/flow/designs/ihp-sg13g2/i2c-gpio-expander/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "2145f9fd37063135e1bf5bef2eb081c962b4c279",
+        "value": "809b3e13fb7db39aac4af944ae07eb3e07e9c905",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/nangate45/mempool_group/rules-base.json
+++ b/flow/designs/nangate45/mempool_group/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -12400.0,
+        "value": -12425.7,
         "compare": ">="
     },
     "cts__timing__hold__ws": {

--- a/flow/designs/nangate45/tinyRocket/rules-base.json
+++ b/flow/designs/nangate45/tinyRocket/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -32.4,
+        "value": -37.3637,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -53.9,
+        "value": -56.3263,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -46.6,
+        "value": -47.9277,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -295.0,
+        "value": -312.055,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1274,
+        "value": 1296,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -258.0,
+        "value": -309.073,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
## Summary
- Bump the OpenROAD submodule to the latest `secure-rsz-time-borrow-opt` commit.
- Enable ORFS CI coverage for the RSZ latch time-borrow repair updates and empty violator debug-log cleanup.

## Problem
- ORFS is still pinned to an older OpenROAD commit and does not exercise the latest RSZ changes in flow-level CI.
- The OpenROAD PR needs corresponding ORFS secure and public CI coverage to check QoR and metric impact.

## Solution
- Update `tools/OpenROAD` from `8eade99b1` to `9896dd27ff`.
- Include the current OpenROAD RSZ time-borrow repair commits and the `RSZ-0008` logging cleanup.

## Impact
- No ORFS script or design configuration changes.
- Flow impact is limited to the OpenROAD engine submodule update.
- CI should report whether the RSZ changes introduce QoR, metric, or regression changes.

## Testing
- OpenROAD local RSZ regression passed: `bazelisk test //src/rsz/test:all --cache_test_results=no --test_output=errors`.
- ORFS CI is expected to run from this PR.

## Reviewer Notes
- Review the CI metric and QoR deltas for RSZ timing repair behavior.

## Related
- Related OpenROAD private PR: https://github.com/The-OpenROAD-Project-private/OpenROAD/pull/3575
- Related OpenROAD public PR: https://github.com/The-OpenROAD-Project/OpenROAD/pull/10825
