### PR TITLE
flow: route 'run' target through run_command.py for consistent logging

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -839,7 +839,7 @@ klayout:
 .phony: run
 run:
 	@mkdir -p $(RESULTS_DIR) $(LOG_DIR) $(REPORTS_DIR) $(OBJECTS_DIR)
-	($(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT) 2>&1 | tee $(abspath $(LOG_DIR)/$(RUN_LOG_NAME_STEM).log))
+	$(RUN_CMD) --log $(abspath $(LOG_DIR)/$(RUN_LOG_NAME_STEM).log) --tee -- $(OPENROAD_CMD) -no_splash $(if $(filter %.py,$(RUN_SCRIPT)),-python) $(RUN_SCRIPT)
 
 export RUN_YOSYS_ARGS ?= -c $(SCRIPTS_DIR)/yosys_keep.tcl
 .phony: run-yosys


### PR DESCRIPTION
Every flow stage logs through `$(RUN_CMD) --log ... --tee -- ...` (scripts/run_command.py) except the generic `run` target, which was the lone holdout still shelling out to `2>&1 | tee`. Route it through run_command.py like the rest.

This is a consistency cleanup, not a bugfix: .SHELLFLAGS already sets `-o pipefail`, so the old pipeline propagated OpenROAD's exit status correctly, and run_command.py returns the child's returncode, so exit behavior is unchanged. One logging mechanism instead of two reduces cognitive load and removes a copy-and-paste divergence.

As a side effect, the `run` target now gains the per-step timing and peak-memory line run_command.py emits for every other stage, and the RUNFILES_* scrubbing that keeps a parent Bazel invocation's runfiles environment from leaking into the OpenROAD subprocess.