### PR TITLE
Fix metrics

### DIFF
--- a/flow/designs/nangate45/mempool_group/rules-base.json
+++ b/flow/designs/nangate45/mempool_group/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -12400.0,
+        "value": -14900.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -14800.0,
+        "value": -12400.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/nangate45/tinyRocket/rules-base.json
+++ b/flow/designs/nangate45/tinyRocket/rules-base.json
@@ -10,7 +10,7 @@
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 59681.09,
+        "value": 58300.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -32.4,
+        "value": -37.6,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -53.9,
+        "value": -56.6,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -46.6,
+        "value": -48.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.66,
+        "value": -2.6,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -337.0,
+        "value": -331.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1931,
+        "value": 1747,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -295.0,
+        "value": -315.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1274,
+        "value": 1297,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -258.0,
+        "value": -312.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -102,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -5.76,
+        "value": -5.02,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
The PR https://github.com/The-OpenROAD-Project/OpenROAD/pull/10793 had some mismatch with the OR submodule and metrics seemed passing.

## make update_ok for microwatt (sky130hd)...
designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -2.66 |       -2.6 | Tighten  |
| cts__timing__setup__tns                       |     -337.0 |     -331.0 | Tighten  |
| globalroute__antenna_diodes_count             |       1931 |       1747 | Tighten  |
| globalroute__timing__setup__tns               |     -295.0 |     -315.0 | Failing  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1274 |       1297 | Failing  |
| finish__timing__setup__tns                    |     -258.0 |     -312.0 | Failing  |
| finish__timing__hold__tns                     |      -5.76 |      -5.02 | Tighten  |

## make update_ok for tinyRocket (nangate45)...
designs/nangate45/tinyRocket/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |   59681.09 |    58300.0 | Tighten  |
| cts__timing__setup__tns                       |      -32.4 |      -37.6 | Failing  |
| globalroute__timing__setup__tns               |      -53.9 |      -56.6 | Failing  |
| finish__timing__setup__tns                    |      -46.6 |      -48.2 | Failing  |

## make update_ok for mempool_group (nangate45)... designs/nangate45/mempool_group/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |   -12400.0 |   -14900.0 | Failing  |
| globalroute__timing__setup__tns               |   -14800.0 |   -12400.0 | Tighten  |

Large percentage improvements in tighten metrics (>50%):
 - microwatt (sky130hd)  detailedroute__antenna__violating__nets  -100.00%  (1 → 0)