### PR TITLE
bazel: keep bazel_dep(bazel-orfs) non-dev for load() visibility

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ git_override(
 # root-only) is dev-conditional — at non-root the consumer's own bazel-orfs
 # satisfies this dep. When @orfs is root, dev deps are honoured anyway, so
 # the resolved module graph is unchanged.
-bazel_dep(name = "bazel-orfs")
+bazel_dep(name = "bazel-orfs", version = "0.0.1")
 
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -33,7 +33,15 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
-bazel_dep(name = "bazel-orfs", dev_dependency = True)
+# Exception to the dev-only rule above: flow/BUILD has
+# load("@bazel-orfs//:openroad.bzl", "orfs_pdk"), so @bazel-orfs must stay
+# visible from @orfs even at non-root consumption; a dev-only bazel_dep
+# suppresses that visibility. Only the git_override below (implicitly
+# root-only) is dev-conditional — at non-root the consumer's own bazel-orfs
+# satisfies this dep. When @orfs is root, dev deps are honoured anyway, so
+# the resolved module graph is unchanged.
+bazel_dep(name = "bazel-orfs")
+
 bazel_dep(name = "bazel-orfs-verilog", dev_dependency = True)
 
 BAZEL_ORFS_COMMIT = "6ebadeb4be5c9ada103081c9a5e668c014126616"


### PR DESCRIPTION
flow/BUILD has load("@bazel-orfs//:openroad.bzl", "orfs_pdk"), which needs @bazel-orfs visible from @orfs even when ORFS is consumed as a non-root module. Marking the bazel_dep dev-only suppresses that visibility, and every non-root consumer (bazel-orfs itself, its gallery and downstream-test workspaces) has to patch it back in at consumption time (bazel-orfs patches/0036).

Only the git_override needs to be dev-conditional, and it already is: overrides are implicitly root-only. At non-root the consumer's own bazel-orfs module satisfies the dep; when @orfs is the root module, dev deps are honoured anyway, so 'bazel mod graph' output is byte-identical before and after this change.