### PR TITLE
Fix OPT_POST_GRT_WNS and disable for some PDKs

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1747,
+        "value": 1692,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 0,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1297,
+        "value": 1295,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -312.0,
+        "value": -307.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -102,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -5.02,
+        "value": -4.65,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/platforms/gf180/config.mk
+++ b/flow/platforms/gf180/config.mk
@@ -97,7 +97,7 @@ export MIN_ROUTING_LAYER                     ?= Metal2
 export MAX_ROUTING_LAYER                     ?= Metal5
 export DISABLE_VIA_GEN                       ?= 1
 
-export OPT_POST_GRT_WNS                      = 0
+export OPT_POST_GRT_WNS                      ?= 0
 
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/gf180/config.mk
+++ b/flow/platforms/gf180/config.mk
@@ -97,6 +97,8 @@ export MIN_ROUTING_LAYER                     ?= Metal2
 export MAX_ROUTING_LAYER                     ?= Metal5
 export DISABLE_VIA_GEN                       ?= 1
 
+export OPT_POST_GRT_WNS                      = 0
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -140,7 +140,7 @@ export MAX_ROUTING_LAYER    ?= Metal5
 #export VIA_IN_PIN_MAX_LAYER ?= Metal1
 #export DISABLE_VIA_GEN      ?= 1
 
-export OPT_POST_GRT_WNS     = 0
+export OPT_POST_GRT_WNS     ?= 0
 
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/ihp-sg13g2/config.mk
+++ b/flow/platforms/ihp-sg13g2/config.mk
@@ -140,6 +140,8 @@ export MAX_ROUTING_LAYER    ?= Metal5
 #export VIA_IN_PIN_MAX_LAYER ?= Metal1
 #export DISABLE_VIA_GEN      ?= 1
 
+export OPT_POST_GRT_WNS     = 0
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -75,6 +75,8 @@ export MIN_ROUTING_LAYER = metal2
 export MIN_CLK_ROUTING_LAYER = metal4
 export MAX_ROUTING_LAYER = metal10
 
+export OPT_POST_GRT_WNS = 0
+
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl
 

--- a/flow/platforms/nangate45/config.mk
+++ b/flow/platforms/nangate45/config.mk
@@ -75,7 +75,7 @@ export MIN_ROUTING_LAYER = metal2
 export MIN_CLK_ROUTING_LAYER = metal4
 export MAX_ROUTING_LAYER = metal10
 
-export OPT_POST_GRT_WNS = 0
+export OPT_POST_GRT_WNS ?= 0
 
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -118,7 +118,7 @@ export MIN_ROUTING_LAYER ?= met1
 export MIN_CLK_ROUTING_LAYER ?= met3
 export MAX_ROUTING_LAYER ?= met5
 
-export OPT_POST_GRT_WNS = 0
+export OPT_POST_GRT_WNS ?= 0
 
 #
 # Define fastRoute tcl

--- a/flow/platforms/sky130hd/config.mk
+++ b/flow/platforms/sky130hd/config.mk
@@ -118,6 +118,8 @@ export MIN_ROUTING_LAYER ?= met1
 export MIN_CLK_ROUTING_LAYER ?= met3
 export MAX_ROUTING_LAYER ?= met5
 
+export OPT_POST_GRT_WNS = 0
+
 #
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -80,6 +80,8 @@ export MIN_ROUTING_LAYER = met1
 export MIN_CLK_ROUTING_LAYER = met3
 export MAX_ROUTING_LAYER = met5
 
+export OPT_POST_GRT_WNS = 0
+
 #
 # Define fastRoute tcl
 export FASTROUTE_TCL ?= $(PLATFORM_DIR)/fastroute.tcl

--- a/flow/platforms/sky130hs/config.mk
+++ b/flow/platforms/sky130hs/config.mk
@@ -80,7 +80,7 @@ export MIN_ROUTING_LAYER = met1
 export MIN_CLK_ROUTING_LAYER = met3
 export MAX_ROUTING_LAYER = met5
 
-export OPT_POST_GRT_WNS = 0
+export OPT_POST_GRT_WNS ?= 0
 
 #
 # Define fastRoute tcl

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -87,14 +87,16 @@ proc global_route_helper { } {
       report_metrics 5 "global route post repair timing"
     }
 
-    if { $::env(OPT_POST_GRT_WNS) } {
-      log_cmd global_route -start_incremental
-      log_cmd detailed_placement {*}$dpl_args
-      log_cmd check_placement -verbose
-      # Route only the modified net by DPL
-      log_cmd global_route -end_incremental {*}$res_aware \
-        -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing_opt_wns.rpt
+    log_cmd global_route -start_incremental
+    log_cmd detailed_placement {*}$dpl_args
+    log_cmd check_placement -verbose
+    # Route only the modified net by DPL
+    log_cmd global_route -end_incremental {*}$res_aware \
+      -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
 
+    log_cmd estimate_parasitics -global_routing
+    
+    if { $::env(OPT_POST_GRT_WNS) } {
       set repair_timing_args \
         [list -setup -sequence "vt_swap reroute" -skip_last_gasp -repair_tns 0 -verbose]
       if { [env_var_exists_and_non_empty MATCH_CELL_FOOTPRINT] } {
@@ -109,15 +111,6 @@ proc global_route_helper { } {
         report_metrics 5 "global route post repair timing_opt_wns"
       }
     }
-
-    # Running DPL to fix overlapped instances
-    # Run to get modified net by DPL
-    log_cmd global_route -start_incremental
-    log_cmd detailed_placement {*}$dpl_args
-    log_cmd check_placement -verbose
-    # Route only the modified net by DPL
-    log_cmd global_route -end_incremental {*}$res_aware \
-      -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
   }
 
   if { !$::env(OPT_POST_GRT_WNS) } {

--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -95,7 +95,7 @@ proc global_route_helper { } {
       -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
 
     log_cmd estimate_parasitics -global_routing
-    
+
     if { $::env(OPT_POST_GRT_WNS) } {
       set repair_timing_args \
         [list -setup -sequence "vt_swap reroute" -skip_last_gasp -repair_tns 0 -verbose]


### PR DESCRIPTION
There is no need to run vt_swap and reroute for PDKs that don't benefit from it.
In this PR I disabled this optimization for Sky130HD/HS, GF180, Nangate45, IHP-SG13G2.

The reroute move does not account for capacitance, which is more relevant to timing closure on these PDKs.
It is possible to reroute a net to a lower-resistance path, but at significantly higher capacitance, which degrades timing.

Currently, we are missing an estimate_parasitics call before running the additional optimizations.
And as we are not changing placement with Reroute and VtSwap, there is no need for a legalization + incremental GRT post-repair_setup.

This prevents issues with another PR with Reroute move enhancements

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__antenna_diodes_count             |       1747 |       1692 | Tighten  |
| detailedroute__antenna__violating__nets       |          0 |          1 | Failing  |
| detailedroute__antenna_diodes_count           |       1297 |       1295 | Tighten  |
| finish__timing__setup__tns                    |     -312.0 |     -307.0 | Tighten  |
| finish__timing__hold__tns                     |      -5.02 |      -4.65 | Tighten  |