### PR TITLE
update metrics for bp_single and bp_quad

### DIFF
--- a/flow/designs/gf12/bp_quad/rules-base.json
+++ b/flow/designs/gf12/bp_quad/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -247000.0,
+        "value": -638000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -702.0,
+        "value": -8020.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -78,7 +78,7 @@
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -219.0,
+        "value": -208.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1620.0,
+        "value": -1420.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/bp_single/rules-base.json
+++ b/flow/designs/gf12/bp_single/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -517000.0,
+        "value": -474000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -50,7 +50,7 @@
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -4250.0,
+        "value": -4700.0,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -615.0,
+        "value": -556.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -106000.0,
+        "value": -79400.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {


### PR DESCRIPTION
designs/gf12/bp_quad/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |  -247000.0 |  -638000.0 | Failing  |
| globalroute__timing__setup__tns               |     -702.0 |    -8020.0 | Failing  |
| detailedroute__route__drc_errors              |          1 |          0 | Tighten  |
| finish__timing__setup__ws                     |     -219.0 |     -208.0 | Tighten  |
| finish__timing__setup__tns                    |    -1620.0 |    -1420.0 | Tighten  |

designs/gf12/bp_single/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |  -517000.0 |  -474000.0 | Tighten  |
| cts__timing__hold__tns                        |    -4250.0 |    -4700.0 | Failing  |
| globalroute__timing__setup__ws                |     -615.0 |     -556.0 | Tighten  |
| globalroute__timing__setup__tns               |  -106000.0 |   -79400.0 | Tighten  |