### PR TITLE
Continue using cmake for now

### DIFF
--- a/build_openroad.sh
+++ b/build_openroad.sh
@@ -340,6 +340,7 @@ __local_build()
                         DEPS_PREFIX_ARG="-deps-prefixes-file=${DEPS_PREFIX_ARG}"
                 fi
                 eval ${NICE} ./tools/OpenROAD/etc/Build.sh \
+                        -cmake-build \
                         -dir="$DIR/tools/OpenROAD/build" \
                         -threads=${PROC} \
                         -cmake=\'${OPENROAD_APP_ARGS}\' \


### PR DESCRIPTION
OR's Build.sh uses bazel by default now.