### PR TITLE
designs/sky130hd/microwatt/rules-base.json updates:

### DIFF
--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.6,
+        "value": -2.47,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -331.0,
+        "value": -299.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1692,
+        "value": 1497,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -2.49,
+        "value": -2.43,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -315.0,
+        "value": -277.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1295,
+        "value": 1425,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -307.0,
+        "value": -326.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -102,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -4.65,
+        "value": -9.05,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
Metrics update needed for https://github.com/The-OpenROAD-Project/OpenROAD/pull/10842


| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |       -2.6 |      -2.47 | Tighten  |
| cts__timing__setup__tns                       |     -331.0 |     -299.0 | Tighten  |
| globalroute__antenna_diodes_count             |       1692 |       1497 | Tighten  |
| globalroute__timing__setup__ws                |      -2.49 |      -2.43 | Tighten  |
| globalroute__timing__setup__tns               |     -315.0 |     -277.0 | Tighten  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1295 |       1425 | Failing  |
| finish__timing__setup__tns                    |     -307.0 |     -326.0 | Failing  |
| finish__timing__hold__tns                     |      -4.65 |      -9.05 | Failing  |