### PR TITLE
flow: remove unused MAX_REPAIR_TIMING_ITER variable

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -189,7 +189,6 @@ configuration file.
 | <a name="MAX_PLACE_STEP_COEF"></a>MAX_PLACE_STEP_COEF| Sets the maximum phi coefficient (pcof_max / µ_k Upper Bound) for global placement optimization. This parameter controls the step size upper bound in the RePlAce Nesterov optimization algorithm. Higher values allow more aggressive optimization but may risk divergence. Valid range: 1.00-1.20| 1.05|
 | <a name="MAX_REPAIR_ANTENNAS_ITER_DRT"></a>MAX_REPAIR_ANTENNAS_ITER_DRT| Defines the maximum number of iterations post-detailed routing repair antennas will run.| 5|
 | <a name="MAX_REPAIR_ANTENNAS_ITER_GRT"></a>MAX_REPAIR_ANTENNAS_ITER_GRT| Defines the maximum number of iterations post global routing repair antennas will run.| 5|
-| <a name="MAX_REPAIR_TIMING_ITER"></a>MAX_REPAIR_TIMING_ITER| Maximum number of iterations for repair setup and repair hold.| |
 | <a name="MAX_ROUTING_LAYER"></a>MAX_ROUTING_LAYER| The highest metal layer name to be used in routing.| |
 | <a name="MIN_BUF_CELL_AND_PORTS"></a>MIN_BUF_CELL_AND_PORTS| Used to insert a buffer cell to pass through wires. Used in synthesis.| |
 | <a name="MIN_CLK_ROUTING_LAYER"></a>MIN_CLK_ROUTING_LAYER| The lowest metal layer name to be used for clock-net routing in global routing. Used in flow/platforms/*/fastroute.tcl as the lower bound of `set_routing_layers -clock`. Typically higher than MIN_ROUTING_LAYER so clock nets prefer the upper, lower-RC layers. No `stages:` list because floorplan.tcl also `source`s the platform fastroute.tcl.| |
@@ -409,7 +408,6 @@ configuration file.
 - [MACRO_WRAPPERS](#MACRO_WRAPPERS)
 - [MAKE_TRACKS](#MAKE_TRACKS)
 - [MATCH_CELL_FOOTPRINT](#MATCH_CELL_FOOTPRINT)
-- [MAX_REPAIR_TIMING_ITER](#MAX_REPAIR_TIMING_ITER)
 - [MAX_ROUTING_LAYER](#MAX_ROUTING_LAYER)
 - [MIN_ROUTING_LAYER](#MIN_ROUTING_LAYER)
 - [PDN_TCL](#PDN_TCL)
@@ -481,7 +479,6 @@ configuration file.
 - [IO_PLACER_V](#IO_PLACER_V)
 - [MATCH_CELL_FOOTPRINT](#MATCH_CELL_FOOTPRINT)
 - [MAX_PLACE_STEP_COEF](#MAX_PLACE_STEP_COEF)
-- [MAX_REPAIR_TIMING_ITER](#MAX_REPAIR_TIMING_ITER)
 - [MAX_ROUTING_LAYER](#MAX_ROUTING_LAYER)
 - [MIN_PLACE_STEP_COEF](#MIN_PLACE_STEP_COEF)
 - [MIN_ROUTING_LAYER](#MIN_ROUTING_LAYER)
@@ -518,7 +515,6 @@ configuration file.
 - [LEC_AUX_VERILOG_FILES](#LEC_AUX_VERILOG_FILES)
 - [LEC_CHECK](#LEC_CHECK)
 - [MATCH_CELL_FOOTPRINT](#MATCH_CELL_FOOTPRINT)
-- [MAX_REPAIR_TIMING_ITER](#MAX_REPAIR_TIMING_ITER)
 - [POST_CTS_TCL](#POST_CTS_TCL)
 - [PRE_CTS_TCL](#PRE_CTS_TCL)
 - [REPORT_CLOCK_SKEW](#REPORT_CLOCK_SKEW)
@@ -543,7 +539,6 @@ configuration file.
 - [GLOBAL_ROUTE_USE_CUGR](#GLOBAL_ROUTE_USE_CUGR)
 - [HOLD_SLACK_MARGIN](#HOLD_SLACK_MARGIN)
 - [MAX_REPAIR_ANTENNAS_ITER_GRT](#MAX_REPAIR_ANTENNAS_ITER_GRT)
-- [MAX_REPAIR_TIMING_ITER](#MAX_REPAIR_TIMING_ITER)
 - [MAX_ROUTING_LAYER](#MAX_ROUTING_LAYER)
 - [MIN_ROUTING_LAYER](#MIN_ROUTING_LAYER)
 - [OPT_POST_GRT_WNS](#OPT_POST_GRT_WNS)

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -585,15 +585,6 @@
       "grt"
     ]
   },
-  "MAX_REPAIR_TIMING_ITER": {
-    "description": "Maximum number of iterations for repair setup and repair hold.\n",
-    "stages": [
-      "cts",
-      "floorplan",
-      "grt",
-      "place"
-    ]
-  },
   "MAX_ROUTING_LAYER": {
     "description": "The highest metal layer name to be used in routing.\n",
     "stages": [

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1549,14 +1549,6 @@ OPENROAD_HIERARCHICAL:
   default: 0
   stages:
     - All stages
-MAX_REPAIR_TIMING_ITER:
-  description: >
-    Maximum number of iterations for repair setup and repair hold.
-  stages:
-    - cts
-    - floorplan
-    - grt
-    - place
 NUM_CORES:
   description: >
     Passed to `openroad -threads $(NUM_CORES)`, defaults to numbers


### PR DESCRIPTION
`MAX_REPAIR_TIMING_ITER` is declared in `flow/scripts/variables.yaml` but read
by no flow script. `git grep` finds it only in `variables.yaml`, its generated
`variables.json` twin, and the generated `docs/user/FlowVariables.md`.

History: it was added in da116e8e1 and used on the `floorplan_to_place` target,
but that sole consumer was removed in 547e8c88b ("simplify
floorplan_to_place.tcl"), orphaning the declaration.

A hard `repair_timing` iteration cap is also the wrong lever going forward — the
adaptive plateau-stop / `-effort` direction (The-OpenROAD-Project/OpenROAD#10900)
supersedes it. So this removes the dead variable rather than leaving a knob that
does nothing.

`variables.json` and `FlowVariables.md` were regenerated with the checked-in
`flow/scripts/yaml_to_json.py` and `flow/scripts/generate-variables-docs.py`
(the yaml-test CI job's `git diff --exit-code` checks pass).