### PR TITLE
Write 3_place.sdc and 6_final.sdc from their stage scripts

### DIFF
--- a/flow/Makefile
+++ b/flow/Makefile
@@ -477,11 +477,13 @@ $(eval $(call do-step,3_5_place_dp,$(RESULTS_DIR)/3_4_place_resized.odb,detail_p
 
 $(eval $(call do-copy,3_place,3_5_place_dp.odb,))
 
-$(eval $(call do-copy,3_place,2_floorplan.sdc,,.sdc))
+# detail_place writes 3_place.sdc alongside 3_5_place_dp.odb (constraints
+# are unchanged during placement), mirroring how synth writes 1_synth.sdc.
+$(RESULTS_DIR)/3_place.sdc: $(RESULTS_DIR)/3_5_place_dp.odb
 
 .PHONY: do-place
 do-place:
-	$(UNSET_AND_MAKE) do-3_1_place_gp_skip_io do-3_2_place_iop do-3_3_place_gp do-3_4_place_resized do-3_5_place_dp do-3_place do-3_place.sdc
+	$(UNSET_AND_MAKE) do-3_1_place_gp_skip_io do-3_2_place_iop do-3_3_place_gp do-3_4_place_resized do-3_5_place_dp do-3_place
 
 # Clean Targets
 #-------------------------------------------------------------------------------
@@ -614,9 +616,11 @@ $(eval $(call do-step,6_1_fill,$(RESULTS_DIR)/5_route.odb $(RESULTS_DIR)/5_route
 
 $(eval $(call do-copy,6_1_fill,5_route.sdc,,.sdc))
 
-$(eval $(call do-copy,6_final,5_route.sdc,,.sdc))
-
 $(eval $(call do-step,6_report,$(RESULTS_DIR)/6_1_fill.odb $(RESULTS_DIR)/6_1_fill.sdc,final_report,.log,$(LOG_DIR)))
+
+# final_report writes 6_final.sdc alongside 6_final.odb (constraints are
+# unchanged during finishing), mirroring how synth writes 1_synth.sdc.
+$(RESULTS_DIR)/6_final.sdc: $(LOG_DIR)/6_report.log
 
 $(RESULTS_DIR)/6_final.def: $(LOG_DIR)/6_report.log
 
@@ -630,7 +634,7 @@ final: finish
 
 .PHONY: do-finish
 do-finish:
-	$(UNSET_AND_MAKE) do-6_1_fill do-6_1_fill.sdc do-6_final.sdc do-6_report elapsed
+	$(UNSET_AND_MAKE) do-6_1_fill do-6_1_fill.sdc do-6_report elapsed
 
 .PHONY: generate_abstract
 generate_abstract: $(RESULTS_DIR)/6_final.gds $(RESULTS_DIR)/6_final.def  $(RESULTS_DIR)/6_final.v $(RESULTS_DIR)/6_final.sdc

--- a/flow/scripts/detail_place.tcl
+++ b/flow/scripts/detail_place.tcl
@@ -44,3 +44,4 @@ report_metrics 3 "detailed place" true false
 source_step_tcl POST DETAIL_PLACE
 
 orfs_write_db $::env(RESULTS_DIR)/3_5_place_dp.odb
+orfs_write_sdc $::env(RESULTS_DIR)/3_place.sdc

--- a/flow/scripts/final_report.tcl
+++ b/flow/scripts/final_report.tcl
@@ -3,4 +3,5 @@
 # at the same point.
 source $::env(SCRIPTS_DIR)/final_connect.tcl
 orfs_write_db $::env(RESULTS_DIR)/6_final.odb
+orfs_write_sdc $::env(RESULTS_DIR)/6_final.sdc
 source $::env(SCRIPTS_DIR)/final_outputs.tcl

--- a/flow/scripts/flow.tcl
+++ b/flow/scripts/flow.tcl
@@ -94,7 +94,7 @@ flow_write_sdc 5_route.sdc
 flow_source density_fill.tcl
 flow_write_db 6_1_fill.odb
 flow_write_sdc 6_1_fill.sdc
-flow_write_sdc 6_final.sdc
 flow_source final_connect.tcl
 flow_write_db 6_final.odb
+flow_write_sdc 6_final.sdc
 flow_source final_outputs.tcl


### PR DESCRIPTION
## Summary

`place` and `final` were the only stages whose SDC was produced by a Makefile `do-copy` of a *prior* stage's file (`3_place.sdc ← 2_floorplan.sdc`, `6_final.sdc ← 5_route.sdc`) instead of being written by the stage script itself. Every other stage self-writes its SDC via `orfs_write_sdc` (synth, floorplan, cts, grt), and the single-process `flow.tcl` already wrote `3_place.sdc` / `6_final.sdc` directly.

This retires the copy-forward special case so SDC production is uniform and co-located with the `.odb` write — mirroring how synth writes `1_synth.sdc` alongside `1_synth.odb`.

## Changes

- `detail_place.tcl` writes `3_place.sdc` after `3_5_place_dp.odb`.
- `final_report.tcl` writes `6_final.sdc` after `6_final.odb` (after the `orfs_*` procs come into scope via `final_connect.tcl`).
- `Makefile`: drop the two `do-copy … .sdc` recipes; tie each aggregate `.sdc` to the step that now writes it with a recipe-less order rule (`3_place.sdc: 3_5_place_dp.odb`, `6_final.sdc: 6_report.log`) — the same shape as the existing `1_synth.sdc: 1_synth.odb` rule.
- `flow.tcl`: move the single-process `6_final.sdc` write to just after the `6_final.odb` write, so both flows write it from identical design state (preserving the final-stage byte-equivalence invariant documented in `designs/asap7/gcd/BUILD`).

## Rationale / no behavior change

Timing constraints don't change during placement or finishing, so the serialized SDC is unchanged. On `nangate45/gcd`, the new `3_place.sdc` and `6_final.sdc` are byte-identical (constraints) to the files the `do-copy` previously produced.

## Validation

- Per-stage flow on `nangate45/gcd`: `3_place.sdc` and `6_final.sdc` are produced by their stage scripts (exit 0), and downstream stages that consume them (cts reads `3_place.sdc`) succeed.
- Both new SDCs diff clean (constraints) against the prior copy sources.

Note: the `gcd_single_flow_{place,final}_test` byte-equivalence checks in `designs/asap7/gcd` are not expected to pass until the pending OpenROAD STA/DRT equivalence fixes land; they should not gate review of this change.