### PR TITLE
Fix uW, ca53, bp_single and bp_dual metric failures

### DIFF
--- a/flow/designs/gf12/bp_dual/rules-base.json
+++ b/flow/designs/gf12/bp_dual/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -614.0,
+        "value": -750.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1500000.0,
+        "value": -1670000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -201.0,
+        "value": -117.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -6470.0,
+        "value": -541.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1160.0,
+        "value": -989.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/bp_single/rules-base.json
+++ b/flow/designs/gf12/bp_single/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -474000.0,
+        "value": -389000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -50,7 +50,7 @@
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -4700.0,
+        "value": -763.0,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -62,11 +62,11 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -79400.0,
+        "value": -48500.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -275.0,
+        "value": -375.0,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1430.0,
+        "value": -1850.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/ca53/rules-base.json
+++ b/flow/designs/gf12/ca53/rules-base.json
@@ -9,6 +9,10 @@
         "compare": "==",
         "level": "warning"
     },
+    "synth__design__instance__area__stdcell": {
+        "value": 174000.0,
+        "compare": "<="
+    },
     "constraints__clocks__count": {
         "value": 1,
         "compare": "=="
@@ -98,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -4350.0,
+        "value": -5290.0,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
Fix metric failuers after PR https://github.com/The-OpenROAD-Project-private/OpenROAD/pull/3573.
Bump Or version for master failure.


designs/gf12/bp_single/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |  -474000.0 |  -389000.0 | Tighten  |
| cts__timing__hold__tns                        |    -4700.0 |     -763.0 | Tighten  |
| globalroute__timing__setup__tns               |   -79400.0 |   -48500.0 | Tighten  |
| globalroute__timing__hold__ws                 |     -275.0 |     -375.0 | Failing  |
| finish__timing__setup__tns                    |    -1430.0 |    -1850.0 | Failing  |

designs/gf12/ca53/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| finish__timing__hold__tns                     |    -4350.0 |    -5290.0 | Failing  |

designs/gf12/bp_dual/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -614.0 |     -750.0 | Failing  |
| cts__timing__setup__tns                       | -1500000.0 | -1670000.0 | Failing  |
| globalroute__timing__setup__ws                |     -201.0 |     -117.0 | Tighten  |
| globalroute__timing__setup__tns               |    -6470.0 |     -541.0 | Tighten  |
| finish__timing__setup__tns                    |    -1160.0 |     -989.0 | Tighten  |