### PR TITLE
Added res/cap for M8/M9 in asap7

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "e845e75a0a2ebf22edd0b35335fffe85bf118732",
+        "value": "e170ce0bd7cfcf444de582d0b162d04257919dfe",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "a1413c77490f5f69d469c02fd395b9047501eb60",
+        "value": "ac67d5d781a1a44363fff6984484822975d46415",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 6705,
+        "value": 6704,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 10214,
+        "value": 10164,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 888,
+        "value": 884,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 888,
+        "value": 884,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -126.0,
+        "value": -83.2,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -5500.0,
+        "value": -2760.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 48942,
+        "value": 48476,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -55.6,
+        "value": -54.3,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -511.0,
+        "value": -305.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 6750,
+        "value": 6746,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/aes-mbff/rules-base.json
+++ b/flow/designs/asap7/aes-mbff/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "f657f68d8fc6a5a1050e3594864d42efefcbc3ad",
+        "value": "d010fc1da6f5d55e7a77ac315d50bb117b578623",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "a04d44da52dba7d4a701d80927ba32d1d89ef9a1",
+        "value": "ca0ecfa89d2c94d786878954d07aa05862851850",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1877,
+        "value": 1861,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 17932,
+        "value": 17759,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1559,
+        "value": 1544,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1559,
+        "value": 1544,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -20.8,
+        "value": -19.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -77.8,
+        "value": -76.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -47.7,
+        "value": -26.7,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -329.0,
+        "value": -130.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1911,
+        "value": 1897,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/aes/rules-base.json
+++ b/flow/designs/asap7/aes/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1614,
+        "value": 1597,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 14476,
+        "value": 14321,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1259,
+        "value": 1245,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1259,
+        "value": 1245,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -27.5,
+        "value": -20.8,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -119.0,
+        "value": -79.3,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 57961,
+        "value": 57763,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1664,
+        "value": 1663,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/aes_lvt/rules-base.json
+++ b/flow/designs/asap7/aes_lvt/rules-base.json
@@ -10,7 +10,7 @@
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 1780.0,
+        "value": 1610.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1818,
+        "value": 1478,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 17450,
+        "value": 13303,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1517,
+        "value": 1157,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1517,
+        "value": 1157,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 65052,
+        "value": 60074,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -26.1,
+        "value": -18.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -92.8,
+        "value": -72.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 1846,
+        "value": 1499,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,16 +1,16 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "b2dd6370ed8478581c9a1ee9550b27cfeec93f86",
+        "value": "9748abf15742455460b79d224448b6283beb4d85",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "bc34db09fd40dc22fbdf270e8983632fcfad1e91",
+        "value": "304b3a6dac47ed0454dff6246bbc522d55a3e26c",
         "compare": "==",
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 18700.0,
+        "value": 14100.0,
         "compare": "<="
     },
     "constraints__clocks__count": {

--- a/flow/designs/asap7/ethmac/rules-base.json
+++ b/flow/designs/asap7/ethmac/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "7acd8f58cb4522b4111742580e4e5e656473ba7d",
+        "value": "26a20acf67a20b5e4fd650c49dac7cc8094ced0d",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "cb3ea9e02e4231a1646261bbc4f6cba6dd58b568",
+        "value": "8813866d712239fbd4a4942c19dbcfa49854b3d0",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 8704,
+        "value": 8699,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 68710,
+        "value": 68653,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5975,
+        "value": 5970,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5975,
+        "value": 5970,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -105.0,
+        "value": -94.1,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1480.0,
+        "value": -1410.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -2020.0,
+        "value": -1950.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 240797,
+        "value": 240731,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 9362,
+        "value": 9358,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/ethmac_lvt/rules-base.json
+++ b/flow/designs/asap7/ethmac_lvt/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "33992b5da1dc882c4608f47bc0409c878a97d6c8",
+        "value": "714e1088a38a48cd8fae0f8ce71d1d9c19a8ecfa",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "0b1dcc331782e587fe4b21d90bfc8961d47c4a16",
+        "value": "0165b4af6b6271c9157dc0254f301d222f4b74ec",
         "compare": "==",
         "level": "warning"
     },
@@ -18,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 8327,
+        "value": 8324,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -19.0,
+        "value": -16.7,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -86.3,
+        "value": -74.7,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -29.5,
+        "value": -26.5,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -303.0,
+        "value": -230.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 264399,
+        "value": 252888,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -121.0,
+        "value": -80.4,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/gcd-ccs/rules-base.json
+++ b/flow/designs/asap7/gcd-ccs/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 61,
+        "value": 51,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 606,
+        "value": 481,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -101.0,
+        "value": -62.8,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1260.0,
+        "value": -194.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -93.7,
+        "value": -70.5,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1530.0,
+        "value": -253.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1159,
+        "value": 920,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -96.4,
+        "value": -59.6,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1190.0,
+        "value": -186.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 63,
+        "value": 52,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/gcd/rules-base.json
+++ b/flow/designs/asap7/gcd/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 61,
+        "value": 51,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 611,
+        "value": 476,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -85.9,
+        "value": -58.6,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1290.0,
+        "value": -173.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -110.0,
+        "value": -62.8,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1770.0,
+        "value": -206.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1302,
+        "value": 919,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -96.7,
+        "value": -54.4,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1460.0,
+        "value": -157.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 66,
+        "value": 53,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/ibex/rules-base.json
+++ b/flow/designs/asap7/ibex/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "c71c7862fff7c81741b828a339928acda020c3b5",
+        "value": "357cb5b412d09a37d5c2271f6fec78404cd500c6",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "9c66bcd0e25e2d13f6ede8450ee0fede3085d513",
+        "value": "f75159d6cb90606b1edcfebc8685cfc195eb3d5b",
         "compare": "==",
         "level": "warning"
     },
@@ -18,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 2680,
+        "value": 2673,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -79.4,
+        "value": -50.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -11000.0,
+        "value": -200.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -74.3,
+        "value": -51.2,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -432.0,
+        "value": -209.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -52.5,
+        "value": -50.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -205.0,
+        "value": -200.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 2804,
+        "value": 2761,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/jpeg/rules-base.json
+++ b/flow/designs/asap7/jpeg/rules-base.json
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 63593,
+        "value": 59181,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5530,
+        "value": 5146,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5530,
+        "value": 5146,
         "compare": "<="
     },
     "cts__timing__setup__ws": {

--- a/flow/designs/asap7/jpeg_lvt/rules-base.json
+++ b/flow/designs/asap7/jpeg_lvt/rules-base.json
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 64302,
+        "value": 56601,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 5592,
+        "value": 4922,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 5592,
+        "value": 4922,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -63.9,
+        "value": -58.5,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -514.0,
+        "value": -219.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/mock-alu/rules-base.json
+++ b/flow/designs/asap7/mock-alu/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "d0a6833a306cda71e37ecddd17bb91eea73ac61d",
+        "value": "ddc1aafae1b9232cd6bd6e02e4bd330c2936321e",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "40ca8160347fae3c64f7382fb857373eae66ec98",
+        "value": "f1075b2f768453717c3476487a23723e2c1d1f75",
         "compare": "==",
         "level": "warning"
     },
@@ -18,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1790,
+        "value": 1789,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -18500.0,
+        "value": -18100.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -19900.0,
+        "value": -18500.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/mock-cpu/rules-base.json
+++ b/flow/designs/asap7/mock-cpu/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "771a9d0326dc83e6280f73ddf3224fc1ea11b6d2",
+        "value": "9b4a0ea984b4c979a35d65385194a31f2946b076",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "2f58a268bf553a76653f0379ec897523fbe0e817",
+        "value": "5f6596f67351c53dbaeb2691ee247853e87978d1",
         "compare": "==",
         "level": "warning"
     },

--- a/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
+++ b/flow/designs/asap7/riscv32i-mock-sram/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "fb786d77e841d2488f5a6b7db514abf2010cf808",
+        "value": "fe4d66129bb218a22c28c4ac4c43f410e514e0f1",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "dcacb109edc520790edef0e3dafa7f41c263bb4f",
+        "value": "54039137968361c46540ba4a487c9228f6d6cb7a",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 2291,
+        "value": 2284,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 11655,
+        "value": 11589,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1014,
+        "value": 1008,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1014,
+        "value": 1008,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -58,7 +58,7 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -52.1,
+        "value": -51.4,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -21300.0,
+        "value": -13300.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 2367,
+        "value": 2358,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/riscv32i/rules-base.json
+++ b/flow/designs/asap7/riscv32i/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "24d1128afe4c92ecfe91e78f05b71e9f23fe18a0",
+        "value": "425a17aec581e5e916644caa21f7a1b762772786",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "35c991086e2870003e3a2bd8f0b533614ab30c5a",
+        "value": "a9c4be932722e12a7d42150def0da7ad8bf918b3",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 2985,
+        "value": 2972,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 11797,
+        "value": 11671,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 1026,
+        "value": 1015,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 1026,
+        "value": 1015,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -17000.0,
+        "value": -31800.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 3061,
+        "value": 3050,
         "compare": "<="
     }
 }

--- a/flow/designs/asap7/swerv_wrapper/rules-base.json
+++ b/flow/designs/asap7/swerv_wrapper/rules-base.json
@@ -1,16 +1,16 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "68ba4d0498b5f5509620f1587c58f834db0e2ba5",
+        "value": "N/A",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "1dad51c25993385e0c22055e59b392b87bf78f13",
+        "value": "N/A",
         "compare": "==",
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 52700.0,
+        "value": 16800.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 155203,
+        "value": 141318,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 13496,
+        "value": 12288,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 13496,
+        "value": 12288,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 116,
+        "value": 101,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -86,23 +86,23 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 116,
+        "value": 101,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -318.0,
+        "value": -80.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -46800.0,
+        "value": -320.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -88.9,
+        "value": -80.0,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -338.0,
+        "value": -320.0,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/asap7/uart/rules-base.json
+++ b/flow/designs/asap7/uart/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "9d22ef80013103403a033908fb53508a1d450230",
+        "value": "e8af99db1e484c32592029f80854985e4d1f8ac8",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "ce0d25d00d85be55467e23ccf3d02f7dbb38fd93",
+        "value": "d0d9a53a383c1cb753436991b6f1c4f072ec8c6b",
         "compare": "==",
         "level": "warning"
     },
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 997,
+        "value": 987,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 87,
+        "value": 86,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 87,
+        "value": 86,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -47.6,
+        "value": -41.4,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1450.0,
+        "value": -813.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -58.7,
+        "value": -48.4,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -2090.0,
+        "value": -1510.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -49.1,
+        "value": -40.7,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1450.0,
+        "value": -889.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/platforms/asap7/setRC.tcl
+++ b/flow/platforms/asap7/setRC.tcl
@@ -1,13 +1,15 @@
 set_layer_rc -layer M1 -resistance 7.04175E-02 -capacitance 1e-10
-set_layer_rc -layer M2 -resistance 2.97126E-02 -capacitance 1.84542E-01
-set_layer_rc -layer M3 -resistance 3.12872E-02 -capacitance 1.53955E-01
-set_layer_rc -layer M4 -resistance 1.80365E-02 -capacitance 1.89434E-01
-set_layer_rc -layer M5 -resistance 1.89936E-02 -capacitance 1.71593E-01
-set_layer_rc -layer M6 -resistance 1.18797E-02 -capacitance 1.76146E-01
-set_layer_rc -layer M7 -resistance 1.25097E-02 -capacitance 1.47030E-01
+set_layer_rc -layer M2 -resistance 2.97127E-02 -capacitance 1.74942E-01
+set_layer_rc -layer M3 -resistance 3.12870E-02 -capacitance 1.55554E-01
+set_layer_rc -layer M4 -resistance 1.80365E-02 -capacitance 1.78475E-01
+set_layer_rc -layer M5 -resistance 1.89935E-02 -capacitance 1.64264E-01
+set_layer_rc -layer M6 -resistance 1.18796E-02 -capacitance 1.87426E-01
+set_layer_rc -layer M7 -resistance 1.25096E-02 -capacitance 1.62979E-01
+set_layer_rc -layer M8 -resistance 8.44765E-03 -capacitance 1.03962E-01
+set_layer_rc -layer M9 -resistance 8.89556E-03 -capacitance 9.28446E-02
 
-set_wire_rc -signal -resistance 3.23151E-02 -capacitance 1.73323E-01
-set_wire_rc -clock -resistance 5.13971E-02 -capacitance 1.44549E-01
+set_wire_rc -signal -resistance 2.65684E-02 -capacitance 1.65790E-01
+set_wire_rc -clock -resistance 2.14161E-02 -capacitance 1.45426E-01
 
 set_layer_rc -via V1 -resistance 1.72E-02
 set_layer_rc -via V2 -resistance 1.72E-02
@@ -17,3 +19,4 @@ set_layer_rc -via V5 -resistance 1.18E-02
 set_layer_rc -via V6 -resistance 8.20E-03
 set_layer_rc -via V7 -resistance 8.20E-03
 set_layer_rc -via V8 -resistance 6.30E-03
+set_layer_rc -via V9 -resistance 6.30E-03


### PR DESCRIPTION
Added res/cap for M8/M9 in asap7 setRC.tcl

Updated metrics

### aes-block base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | e845e75a0a2ebf22edd0b35335fffe85bf118732 | e170ce0bd7cfcf444de582d0b162d04257919dfe | Failing  |
| synth__netlist__hash                          | a1413c77490f5f69d469c02fd395b9047501eb60 | ac67d5d781a1a44363fff6984484822975d46415 | Failing  |
| placeopt__design__instance__area              |       6705 |       6704 | Tighten  |
| placeopt__design__instance__count__stdcell    |      10214 |      10164 | Tighten  |
| cts__design__instance__count__setup_buffer    |        888 |        884 | Tighten  |
| cts__design__instance__count__hold_buffer     |        888 |        884 | Tighten  |
| cts__timing__setup__ws                        |     -126.0 |      -83.2 | Tighten  |
| cts__timing__setup__tns                       |    -5500.0 |    -2760.0 | Tighten  |
| detailedroute__route__wirelength              |      48942 |      48476 | Tighten  |
| finish__timing__setup__ws                     |      -55.6 |      -54.3 | Tighten  |
| finish__timing__setup__tns                    |     -511.0 |     -305.0 | Tighten  |
| finish__design__instance__area                |       6750 |       6746 | Tighten  |


### aes-mbff base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | f657f68d8fc6a5a1050e3594864d42efefcbc3ad | d010fc1da6f5d55e7a77ac315d50bb117b578623 | Failing  |
| synth__netlist__hash                          | a04d44da52dba7d4a701d80927ba32d1d89ef9a1 | ca0ecfa89d2c94d786878954d07aa05862851850 | Failing  |
| placeopt__design__instance__area              |       1877 |       1861 | Tighten  |
| placeopt__design__instance__count__stdcell    |      17932 |      17759 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1559 |       1544 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1559 |       1544 | Tighten  |
| cts__timing__setup__ws                        |      -20.8 |      -19.0 | Tighten  |
| cts__timing__setup__tns                       |      -77.8 |      -76.0 | Tighten  |
| finish__timing__setup__ws                     |      -47.7 |      -26.7 | Tighten  |
| finish__timing__setup__tns                    |     -329.0 |     -130.0 | Tighten  |
| finish__design__instance__area                |       1911 |       1897 | Tighten  |


### aes base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |       1614 |       1597 | Tighten  |
| placeopt__design__instance__count__stdcell    |      14476 |      14321 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1259 |       1245 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1259 |       1245 | Tighten  |
| cts__timing__setup__ws                        |      -27.5 |      -20.8 | Tighten  |
| cts__timing__setup__tns                       |     -119.0 |      -79.3 | Tighten  |
| detailedroute__route__wirelength              |      57961 |      57763 | Tighten  |
| finish__design__instance__area                |       1664 |       1663 | Tighten  |


### aes_lvt base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |     1780.0 |     1610.0 | Tighten  |
| placeopt__design__instance__area              |       1818 |       1478 | Tighten  |
| placeopt__design__instance__count__stdcell    |      17450 |      13303 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1517 |       1157 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1517 |       1157 | Tighten  |
| detailedroute__route__wirelength              |      65052 |      60074 | Tighten  |
| finish__timing__setup__ws                     |      -26.1 |      -18.0 | Tighten  |
| finish__timing__setup__tns                    |      -92.8 |      -72.0 | Tighten  |
| finish__design__instance__area                |       1846 |       1499 | Tighten  |


### cva6 base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | b2dd6370ed8478581c9a1ee9550b27cfeec93f86 | 9748abf15742455460b79d224448b6283beb4d85 | Failing  |
| synth__netlist__hash                          | bc34db09fd40dc22fbdf270e8983632fcfad1e91 | 304b3a6dac47ed0454dff6246bbc522d55a3e26c | Failing  |
| synth__design__instance__area__stdcell        |    18700.0 |    14100.0 | Tighten  |


### ethmac base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 7acd8f58cb4522b4111742580e4e5e656473ba7d | 26a20acf67a20b5e4fd650c49dac7cc8094ced0d | Failing  |
| synth__netlist__hash                          | cb3ea9e02e4231a1646261bbc4f6cba6dd58b568 | 8813866d712239fbd4a4942c19dbcfa49854b3d0 | Failing  |
| placeopt__design__instance__area              |       8704 |       8699 | Tighten  |
| placeopt__design__instance__count__stdcell    |      68710 |      68653 | Tighten  |
| cts__design__instance__count__setup_buffer    |       5975 |       5970 | Tighten  |
| cts__design__instance__count__hold_buffer     |       5975 |       5970 | Tighten  |
| cts__timing__setup__ws                        |     -105.0 |      -94.1 | Tighten  |
| cts__timing__setup__tns                       |    -1480.0 |    -1410.0 | Tighten  |
| globalroute__timing__setup__tns               |    -2020.0 |    -1950.0 | Tighten  |
| detailedroute__route__wirelength              |     240797 |     240731 | Tighten  |
| finish__design__instance__area                |       9362 |       9358 | Tighten  |


### ethmac_lvt base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 33992b5da1dc882c4608f47bc0409c878a97d6c8 | 714e1088a38a48cd8fae0f8ce71d1d9c19a8ecfa | Failing  |
| synth__netlist__hash                          | 0b1dcc331782e587fe4b21d90bfc8961d47c4a16 | 0165b4af6b6271c9157dc0254f301d222f4b74ec | Failing  |
| placeopt__design__instance__area              |       8327 |       8324 | Tighten  |
| cts__timing__setup__ws                        |      -19.0 |      -16.7 | Tighten  |
| cts__timing__setup__tns                       |      -86.3 |      -74.7 | Tighten  |
| globalroute__timing__setup__ws                |      -29.5 |      -26.5 | Tighten  |
| globalroute__timing__setup__tns               |     -303.0 |     -230.0 | Tighten  |
| detailedroute__route__wirelength              |     264399 |     252888 | Tighten  |
| finish__timing__setup__tns                    |     -121.0 |      -80.4 | Tighten  |


### gcd-ccs base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |         61 |         51 | Tighten  |
| placeopt__design__instance__count__stdcell    |        606 |        481 | Tighten  |
| cts__timing__setup__ws                        |     -101.0 |      -62.8 | Tighten  |
| cts__timing__setup__tns                       |    -1260.0 |     -194.0 | Tighten  |
| globalroute__timing__setup__ws                |      -93.7 |      -70.5 | Tighten  |
| globalroute__timing__setup__tns               |    -1530.0 |     -253.0 | Tighten  |
| detailedroute__route__wirelength              |       1159 |        920 | Tighten  |
| finish__timing__setup__ws                     |      -96.4 |      -59.6 | Tighten  |
| finish__timing__setup__tns                    |    -1190.0 |     -186.0 | Tighten  |
| finish__design__instance__area                |         63 |         52 | Tighten  |


### gcd base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |         61 |         51 | Tighten  |
| placeopt__design__instance__count__stdcell    |        611 |        476 | Tighten  |
| cts__timing__setup__ws                        |      -85.9 |      -58.6 | Tighten  |
| cts__timing__setup__tns                       |    -1290.0 |     -173.0 | Tighten  |
| globalroute__timing__setup__ws                |     -110.0 |      -62.8 | Tighten  |
| globalroute__timing__setup__tns               |    -1770.0 |     -206.0 | Tighten  |
| detailedroute__route__wirelength              |       1302 |        919 | Tighten  |
| finish__timing__setup__ws                     |      -96.7 |      -54.4 | Tighten  |
| finish__timing__setup__tns                    |    -1460.0 |     -157.0 | Tighten  |
| finish__design__instance__area                |         66 |         53 | Tighten  |


### ibex base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | c71c7862fff7c81741b828a339928acda020c3b5 | 357cb5b412d09a37d5c2271f6fec78404cd500c6 | Failing  |
| synth__netlist__hash                          | 9c66bcd0e25e2d13f6ede8450ee0fede3085d513 | f75159d6cb90606b1edcfebc8685cfc195eb3d5b | Failing  |
| placeopt__design__instance__area              |       2680 |       2673 | Tighten  |
| cts__timing__setup__ws                        |      -79.4 |      -50.0 | Tighten  |
| cts__timing__setup__tns                       |   -11000.0 |     -200.0 | Tighten  |
| globalroute__timing__setup__ws                |      -74.3 |      -51.2 | Tighten  |
| globalroute__timing__setup__tns               |     -432.0 |     -209.0 | Tighten  |
| finish__timing__setup__ws                     |      -52.5 |      -50.0 | Tighten  |
| finish__timing__setup__tns                    |     -205.0 |     -200.0 | Tighten  |
| finish__design__instance__area                |       2804 |       2761 | Tighten  |


### jpeg base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__count__stdcell    |      63593 |      59181 | Tighten  |
| cts__design__instance__count__setup_buffer    |       5530 |       5146 | Tighten  |
| cts__design__instance__count__hold_buffer     |       5530 |       5146 | Tighten  |


### jpeg_lvt base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__count__stdcell    |      64302 |      56601 | Tighten  |
| cts__design__instance__count__setup_buffer    |       5592 |       4922 | Tighten  |
| cts__design__instance__count__hold_buffer     |       5592 |       4922 | Tighten  |
| finish__timing__setup__ws                     |      -63.9 |      -58.5 | Tighten  |
| finish__timing__setup__tns                    |     -514.0 |     -219.0 | Tighten  |


### mock-alu base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | d0a6833a306cda71e37ecddd17bb91eea73ac61d | ddc1aafae1b9232cd6bd6e02e4bd330c2936321e | Failing  |
| synth__netlist__hash                          | 40ca8160347fae3c64f7382fb857373eae66ec98 | f1075b2f768453717c3476487a23723e2c1d1f75 | Failing  |
| placeopt__design__instance__area              |       1790 |       1789 | Tighten  |
| cts__timing__setup__tns                       |   -18500.0 |   -18100.0 | Tighten  |
| finish__timing__setup__tns                    |   -19900.0 |   -18500.0 | Tighten  |


### mock-cpu base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 771a9d0326dc83e6280f73ddf3224fc1ea11b6d2 | 9b4a0ea984b4c979a35d65385194a31f2946b076 | Failing  |
| synth__netlist__hash                          | 2f58a268bf553a76653f0379ec897523fbe0e817 | 5f6596f67351c53dbaeb2691ee247853e87978d1 | Failing  |


### riscv32i-mock-sram base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | fb786d77e841d2488f5a6b7db514abf2010cf808 | fe4d66129bb218a22c28c4ac4c43f410e514e0f1 | Failing  |
| synth__netlist__hash                          | dcacb109edc520790edef0e3dafa7f41c263bb4f | 54039137968361c46540ba4a487c9228f6d6cb7a | Failing  |
| placeopt__design__instance__area              |       2291 |       2284 | Tighten  |
| placeopt__design__instance__count__stdcell    |      11655 |      11589 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1014 |       1008 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1014 |       1008 | Tighten  |
| globalroute__timing__setup__ws                |      -52.1 |      -51.4 | Tighten  |
| finish__timing__setup__tns                    |   -21300.0 |   -13300.0 | Tighten  |
| finish__design__instance__area                |       2367 |       2358 | Tighten  |


### riscv32i base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 24d1128afe4c92ecfe91e78f05b71e9f23fe18a0 | 425a17aec581e5e916644caa21f7a1b762772786 | Failing  |
| synth__netlist__hash                          | 35c991086e2870003e3a2bd8f0b533614ab30c5a | a9c4be932722e12a7d42150def0da7ad8bf918b3 | Failing  |
| placeopt__design__instance__area              |       2985 |       2972 | Tighten  |
| placeopt__design__instance__count__stdcell    |      11797 |      11671 | Tighten  |
| cts__design__instance__count__setup_buffer    |       1026 |       1015 | Tighten  |
| cts__design__instance__count__hold_buffer     |       1026 |       1015 | Tighten  |
| finish__timing__setup__tns                    |   -17000.0 |   -31800.0 | Failing  |
| finish__design__instance__area                |       3061 |       3050 | Tighten  |


### swerv_wrapper base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 68ba4d0498b5f5509620f1587c58f834db0e2ba5 | N/A        | Failing  |
| synth__netlist__hash                          | 1dad51c25993385e0c22055e59b392b87bf78f13 | N/A        | Failing  |
| synth__design__instance__area__stdcell        |    52700.0 |    16800.0 | Tighten  |
| placeopt__design__instance__count__stdcell    |     155203 |     141318 | Tighten  |
| cts__design__instance__count__setup_buffer    |      13496 |      12288 | Tighten  |
| cts__design__instance__count__hold_buffer     |      13496 |      12288 | Tighten  |
| globalroute__antenna_diodes_count             |        116 |        101 | Tighten  |
| detailedroute__antenna_diodes_count           |        116 |        101 | Tighten  |
| finish__timing__setup__ws                     |     -318.0 |      -80.0 | Tighten  |
| finish__timing__setup__tns                    |   -46800.0 |     -320.0 | Tighten  |
| finish__timing__hold__ws                      |      -88.9 |      -80.0 | Tighten  |
| finish__timing__hold__tns                     |     -338.0 |     -320.0 | Tighten  |


### uart base
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 9d22ef80013103403a033908fb53508a1d450230 | e8af99db1e484c32592029f80854985e4d1f8ac8 | Failing  |
| synth__netlist__hash                          | ce0d25d00d85be55467e23ccf3d02f7dbb38fd93 | d0d9a53a383c1cb753436991b6f1c4f072ec8c6b | Failing  |
| placeopt__design__instance__count__stdcell    |        997 |        987 | Tighten  |
| cts__design__instance__count__setup_buffer    |         87 |         86 | Tighten  |
| cts__design__instance__count__hold_buffer     |         87 |         86 | Tighten  |
| cts__timing__setup__ws                        |      -47.6 |      -41.4 | Tighten  |
| cts__timing__setup__tns                       |    -1450.0 |     -813.0 | Tighten  |
| globalroute__timing__setup__ws                |      -58.7 |      -48.4 | Tighten  |
| globalroute__timing__setup__tns               |    -2090.0 |    -1510.0 | Tighten  |
| finish__timing__setup__ws                     |      -49.1 |      -40.7 | Tighten  |
| finish__timing__setup__tns                    |    -1450.0 |     -889.0 | Tighten  |


