### PR TITLE
[DO NOT MERGE] Neighbor-check CI eval: three arms (rule vs model isolation)

### DIFF
--- a/flow/scripts/util.tcl
+++ b/flow/scripts/util.tcl
@@ -40,6 +40,9 @@ proc repair_timing_helper { args } {
   append_env_var additional_args SKIP_VT_SWAP -skip_vt_swap 0
   append_env_var additional_args SKIP_CRIT_VT_SWAP -skip_crit_vt_swap 0
   append_env_var additional_args MATCH_CELL_FOOTPRINT -match_cell_footprint 0
+  # DO NOT MERGE: neighbor-check CI eval -- force the (off-by-default)
+  # neighbor feasibility check on for every repair_timing call.
+  lappend additional_args -neighbor_check
   lappend additional_args {*}$args -verbose
 
   log_cmd repair_timing {*}$additional_args


### PR DESCRIPTION
CI QoR evaluation of the resizer neighbor feasibility check (`repair_timing -neighbor_check`, off by default upstream; forced on here). Three stacked arms, bumped through this PR sequentially so consecutive diffs isolate one change each:

| arm | OpenROAD branch | timing model | veto rule |
|---|---|---|---|
| 1 | VLSIDA:neighbor-check | lumped R*dC | lambda harm/gain trade |
| 2 | VLSIDA:neighbor-check-wns | lumped R*dC | local-WNS degradation |
| 3 | VLSIDA:neighbor-check-sta | frozen-boundary subgraph STA (ArcDelayCalc) | local-WNS degradation |

Current head: **arm 3** (df28de9e10). Replaces #4326.