### PR TITLE
test: Rebase GF12 failing metrics

### DIFF
--- a/flow/designs/gf12/bp_dual/rules-base.json
+++ b/flow/designs/gf12/bp_dual/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -614.0,
+        "value": -764.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1500000.0,
+        "value": -1640000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {

--- a/flow/designs/gf12/ca53/rules-base.json
+++ b/flow/designs/gf12/ca53/rules-base.json
@@ -74,7 +74,7 @@
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
-        "value": 0,
+        "value": 1,
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {


### PR DESCRIPTION
- Rebase only the failing `gf12/bp_dual` and `gf12/ca53` secure CI metrics from Secure-Run-GCP-1 #1960.

| Design | Metric | Old | New |
|---|---|---:|---:|
| `gf12/bp_dual` | `cts__timing__setup__ws` | -614.0 | -764.0 |
| `gf12/bp_dual` | `cts__timing__setup__tns` | -1500000.0 | -1640000.0 |
| `gf12/ca53` | `detailedroute__route__drc_errors` | 0 | 1 |


