### PR TITLE
updated asap7 riscv32i metrics

### DIFF
--- a/flow/designs/asap7/riscv32i/rules-base.json
+++ b/flow/designs/asap7/riscv32i/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "612325c2e655e1f63b7b83e22444e3dd096de0fc",
+        "value": "c67baf189d772ea20946128e24bbc48e15f36447",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "b47cc59368a33db822ad84e5ef0c1fe206bb1577",
+        "value": "31ff4a8ace33b0c4d399cb29998df185c75a77c3",
         "compare": "==",
         "level": "warning"
     },
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1480.0,
+        "value": -1430.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -9310.0,
+        "value": -18100.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/riscv32i/rules-base.json
+++ b/flow/designs/asap7/riscv32i/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "425a17aec581e5e916644caa21f7a1b762772786",
+        "value": "612325c2e655e1f63b7b83e22444e3dd096de0fc",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "a9c4be932722e12a7d42150def0da7ad8bf918b3",
+        "value": "b47cc59368a33db822ad84e5ef0c1fe206bb1577",
         "compare": "==",
         "level": "warning"
     },
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -206.0,
+        "value": -522.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -81.2,
+        "value": -70.8,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -31800.0,
+        "value": -9310.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
## asap7 riscv32i:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 425a17aec581e5e916644caa21f7a1b762772786 | 612325c2e655e1f63b7b83e22444e3dd096de0fc | Failing  |
| synth__netlist__hash                          | a9c4be932722e12a7d42150def0da7ad8bf918b3 | b47cc59368a33db822ad84e5ef0c1fe206bb1577 | Failing  |
| globalroute__timing__setup__tns               |     -206.0 |     -522.0 | Failing  |
| finish__timing__setup__ws                     |      -81.2 |      -70.8 | Tighten  |
| finish__timing__setup__tns                    |   -31800.0 |    -9310.0 | Tighten  |

Improves the finish timing setup TNS number. Not quite sure why the GRT TNS number goes up.