### PR TITLE
update metrics for private designs

### DIFF
--- a/flow/designs/gf12/ariane/rules-base.json
+++ b/flow/designs/gf12/ariane/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 212649,
+        "value": 211858,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 224376,
+        "value": 220675,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 19511,
+        "value": 19189,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 19511,
+        "value": 19189,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -57400.0,
+        "value": -112000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 178,
+        "value": 175,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 3544090,
+        "value": 3473208,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 178,
+        "value": 175,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 214910,
+        "value": 214224,
         "compare": "<="
     }
 }

--- a/flow/designs/gf12/bp_quad/rules-base.json
+++ b/flow/designs/gf12/bp_quad/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 1497196,
+        "value": 1491642,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 1455380,
+        "value": 1425603,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 126555,
+        "value": 123966,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 126555,
+        "value": 123966,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -313.0,
+        "value": -534.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -638000.0,
+        "value": -338000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 1107,
+        "value": 1087,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -8020.0,
+        "value": -1430.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -70,7 +70,7 @@
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -519.0,
+        "value": -476.0,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
@@ -86,11 +86,11 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1110,
+        "value": 1090,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -208.0,
+        "value": -203.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
@@ -102,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -400.0,
+        "value": -818.0,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION

designs/gf12/ariane/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |     212649 |     211858 | Tighten  |
| placeopt__design__instance__count__stdcell    |     224376 |     220675 | Tighten  |
| cts__design__instance__count__setup_buffer    |      19511 |      19189 | Tighten  |
| cts__design__instance__count__hold_buffer     |      19511 |      19189 | Tighten  |
| cts__timing__setup__tns                       |   -57400.0 |  -112000.0 | Failing  |
| globalroute__antenna_diodes_count             |        178 |        175 | Tighten  |
| detailedroute__route__wirelength              |    3544090 |    3473208 | Tighten  |
| detailedroute__antenna_diodes_count           |        178 |        175 | Tighten  |
| finish__design__instance__area                |     214910 |     214224 | Tighten  |


designs/gf12/bp_quad/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |    1497196 |    1491642 | Tighten  |
| placeopt__design__instance__count__stdcell    |    1455380 |    1425603 | Tighten  |
| cts__design__instance__count__setup_buffer    |     126555 |     123966 | Tighten  |
| cts__design__instance__count__hold_buffer     |     126555 |     123966 | Tighten  |
| cts__timing__setup__ws                        |     -313.0 |     -534.0 | Failing  |
| cts__timing__setup__tns                       |  -638000.0 |  -338000.0 | Tighten  |
| globalroute__antenna_diodes_count             |       1107 |       1087 | Tighten  |
| globalroute__timing__setup__tns               |    -8020.0 |    -1430.0 | Tighten  |
| globalroute__timing__hold__tns                |     -519.0 |     -476.0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1110 |       1090 | Tighten  |
| finish__timing__setup__ws                     |     -208.0 |     -203.0 | Tighten  |
| finish__timing__hold__tns                     |     -400.0 |     -818.0 | Failing  |