### PR TITLE
flow: export variables.yaml in flow/BUILD

### DIFF
--- a/flow/BUILD
+++ b/flow/BUILD
@@ -23,7 +23,13 @@ exports_files(
 # instead of vendoring its own (drifting) copy at the bazel-orfs repo
 # root. See bazel-orfs `private/rules.bzl`.
 exports_files(
-    ["scripts/synth.tcl"],
+    [
+        "scripts/synth.tcl",
+        # Expose variables.yaml as an addressable source label so the
+        # orfs-vars MCP server (//tools/orfs_mcp) can data-dep the ORFS
+        # variable catalogue pinned to this commit.
+        "scripts/variables.yaml",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Expose `scripts/variables.yaml` as an addressable source label in `flow/BUILD` so downstream Bazel rules and tools can reference the variable catalogue directly.