### PR TITLE
temporarily disable LEC for gf12 coyote

### DIFF
--- a/flow/designs/gf12/coyote/config.mk
+++ b/flow/designs/gf12/coyote/config.mk
@@ -39,3 +39,6 @@ endif
 
 export SWAP_ARITH_OPERATORS = 1
 export OPENROAD_HIERARCHICAL = 1
+
+# Temporarily disable LEC until RAM issue can be resolved with KF
+export LEC_CHECK = 0


### PR DESCRIPTION
Temporarily disable LEC due to KF issues with STOV pin in RAMs.
