### PR TITLE
bazel: expose and alias reusable //:fix_lint linter target

### DIFF
--- a/flow/BUILD
+++ b/flow/BUILD
@@ -178,4 +178,17 @@ filegroup(
     "nangate45",
     "sky130hd",
     "sky130hs",
-]]
+]
+
+# Shared linter targets from tools/OpenROAD
+alias(
+    name = "fix_lint",
+    actual = "//tools/OpenROAD:fix_lint",
+    visibility = ["//visibility:public"],
+)
+
+alias(
+    name = "lint_test",
+    actual = "//tools/OpenROAD:lint_test",
+    visibility = ["//visibility:public"],
+)

--- a/patches/openroad/0001-Expose-fix_lint-and-lint_test-targets.patch
+++ b/patches/openroad/0001-Expose-fix_lint-and-lint_test-targets.patch
@@ -1,0 +1,18 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 971fb4ec7e..be42fbcb3a 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -651,6 +651,7 @@ test_suite(
+         ":lint_bzl_test",
+         ":lint_tcl_test",
+     ],
++    visibility = ["//visibility:public"],
+ )
+ 
+ # Linting is done here (not just formatting) because not all lint violations
+@@ -682,4 +683,5 @@ sh_binary(
+         "@buildifier_prebuilt//:buildifier",
+         "@git",
+     ],
++    visibility = ["//visibility:public"],
+ )


### PR DESCRIPTION
## Summary
This PR exposes the Bazel-managed linter/formatter target (`//:fix_lint` and `//:lint_test`) from `tools/OpenROAD` so that OpenROAD-flow-scripts (ORFS) can reuse OpenROAD's version-pinned linter toolchain (`tclint`, `tclfmt`, `buildifier`) as a Single Source of Truth (SOT).

## Key Changes
- **ORFS `flow/BUILD`**: Added top-level `fix_lint` and `lint_test` alias targets pointing to `//tools/OpenROAD:fix_lint` and `//tools/OpenROAD:lint_test`.
- **`patches/openroad/`**: Carries a patch setting `visibility = ["//visibility:public"]`.

## Usage
Running `bazelisk run //:fix_lint` in ORFS executes the version-pinned linter toolchain on ORFS files (`flow/scripts/**/*.tcl`, `flow/BUILD`, `MODULE.bazel`).