### PR TITLE
Updated asap7 fakeram verilog

### DIFF
--- a/flow/platforms/asap7/verilog/fakeram7_2048x39.v
+++ b/flow/platforms/asap7/verilog/fakeram7_2048x39.v
@@ -39,7 +39,7 @@ module fakeram7_2048x39
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram7_2048x39
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram7_256x256.v
+++ b/flow/platforms/asap7/verilog/fakeram7_256x256.v
@@ -39,7 +39,7 @@ module fakeram7_256x256
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram7_256x256
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram7_256x32.v
+++ b/flow/platforms/asap7/verilog/fakeram7_256x32.v
@@ -39,7 +39,7 @@ module fakeram7_256x32
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram7_256x32
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram7_256x34.v
+++ b/flow/platforms/asap7/verilog/fakeram7_256x34.v
@@ -39,7 +39,7 @@ module fakeram7_256x34
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram7_256x34
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram7_64x21.v
+++ b/flow/platforms/asap7/verilog/fakeram7_64x21.v
@@ -39,7 +39,7 @@ module fakeram7_64x21
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram7_64x21
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_256x128.v
+++ b/flow/platforms/asap7/verilog/fakeram_256x128.v
@@ -39,7 +39,7 @@ module fakeram_256x128
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_256x128
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_256x64.v
+++ b/flow/platforms/asap7/verilog/fakeram_256x64.v
@@ -39,7 +39,7 @@ module fakeram_256x64
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_256x64
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_32x46.v
+++ b/flow/platforms/asap7/verilog/fakeram_32x46.v
@@ -39,7 +39,7 @@ module fakeram_32x46
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_32x46
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_512x8.v
+++ b/flow/platforms/asap7/verilog/fakeram_512x8.v
@@ -39,7 +39,7 @@ module fakeram_512x8
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_512x8
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_64x20.v
+++ b/flow/platforms/asap7/verilog/fakeram_64x20.v
@@ -39,7 +39,7 @@ module fakeram_64x20
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_64x20
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeram_64x22.v
+++ b/flow/platforms/asap7/verilog/fakeram_64x22.v
@@ -39,7 +39,7 @@ module fakeram_64x22
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeram_64x22
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeregfile_128x64.v
+++ b/flow/platforms/asap7/verilog/fakeregfile_128x64.v
@@ -39,7 +39,7 @@ module fakeregfile_128x64
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeregfile_128x64
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeregfile_32x46.v
+++ b/flow/platforms/asap7/verilog/fakeregfile_32x46.v
@@ -43,7 +43,7 @@ module fakeregfile_32x46
        end
        else if (wen_in)
        begin
-          mem[waddr_in] <= (wdata_in) | (mem[waddr_in]);
+          mem[waddr_in] <= wdata_in;
        end
    end
 
@@ -62,9 +62,6 @@ module fakeregfile_32x46
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from rclk to rdata_out
-      (posedge rclk *> rdata_out) = (0, 0);
-
       // Timing checks
       $width     (posedge rclk,           0, 0, notifier);
       $width     (negedge rclk,           0, 0, notifier);

--- a/flow/platforms/asap7/verilog/fakeregfile_64x64.v
+++ b/flow/platforms/asap7/verilog/fakeregfile_64x64.v
@@ -39,7 +39,7 @@ module fakeregfile_64x64
          end
          else if (we_in)
          begin
-            mem[addr_in] <= (wd_in) | (mem[addr_in]);
+            mem[addr_in] <= wd_in;
          end
          // read
          rd_out <= mem[addr_in];
@@ -54,9 +54,6 @@ module fakeregfile_64x64
    // Timing check placeholders (will be replaced during SDF back-annotation)
    reg notifier;
    specify
-      // Delay from clk to rd_out
-      (posedge clk *> rd_out) = (0, 0);
-
       // Timing checks
       $width     (posedge clk,            0, 0, notifier);
       $width     (negedge clk,            0, 0, notifier);


### PR DESCRIPTION
Addresses feedback from https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/4306#event-27151285528.

gemini/claude agreed with changing the write behavior.

gemini/claude were split on how to handle the specify block. Went with claude that suggested to remove the statement since it's not supported by many simulators.