### PR TITLE
added REMOVE_LIBS_FOR_LEC flow variable

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -247,6 +247,7 @@ configuration file.
 | <a name="RECOVER_POWER"></a>RECOVER_POWER| Specifies how many percent of paths with positive slacks can be slowed for power savings [0-100].| 0|
 | <a name="REMOVE_ABC_BUFFERS"></a>REMOVE_ABC_BUFFERS (deprecated)| Remove abc buffers from the netlist. If timing repair in floorplanning is taking too long, use a SETUP/HOLD_SLACK_MARGIN to terminate timing repair early instead of using REMOVE_ABC_BUFFERS or set SKIP_LAST_GASP=1.| 0|
 | <a name="REMOVE_CELLS_FOR_LEC"></a>REMOVE_CELLS_FOR_LEC| String patterns directly passed to write_verilog -remove_cells <> for lec checks.| |
+| <a name="REMOVE_LIBS_FOR_LEC"></a>REMOVE_LIBS_FOR_LEC| List of Liberty files to exclude from LEC. This is required for cases where a Verilog black box needs to be used instead of a Liberty file.| |
 | <a name="REPAIR_PDN_VIA_LAYER"></a>REPAIR_PDN_VIA_LAYER| Remove power grid vias which generate DRC violations after detailed routing.| |
 | <a name="REPORT_CLOCK_SKEW"></a>REPORT_CLOCK_SKEW| Report clock skew as part of reporting metrics, starting at CTS, before which there is no clock skew. This metric can be quite time-consuming, so it can be useful to disable.| 1|
 | <a name="ROUTING_LAYER_ADJUSTMENT"></a>ROUTING_LAYER_ADJUSTMENT| Adjusts routing layer capacities to manage congestion and improve detailed routing. High values ease detailed routing but risk excessive detours and long global routing times, while low values reduce global routing failure but can complicate detailed routing. The global routing running time normally reduces dramatically (entirely design specific, but going from hours to minutes has been observed) when the value is low (such as 0.10). Sometimes, global routing will succeed with lower values and fail with higher values. Exploring results with different values can help shed light on the problem. Start with a too low value, such as 0.10, and bisect to value that works by doing multiple global routing runs. As a last resort, `make global_route_issue` and using the tools/OpenROAD/etc/whittle.py can be useful to debug global routing errors. If there is something specific that is impossible to route, such as a clock line over a macro, global routing will terminate with DRC errors routes that could have been routed were it not for the specific impossible routes. whittle.py should weed out the possible routes and leave a minimal failing case that pinpoints the problem.| 0.5|
@@ -518,6 +519,7 @@ configuration file.
 - [MATCH_CELL_FOOTPRINT](#MATCH_CELL_FOOTPRINT)
 - [POST_CTS_TCL](#POST_CTS_TCL)
 - [PRE_CTS_TCL](#PRE_CTS_TCL)
+- [REMOVE_LIBS_FOR_LEC](#REMOVE_LIBS_FOR_LEC)
 - [REPORT_CLOCK_SKEW](#REPORT_CLOCK_SKEW)
 - [SETUP_MOVE_SEQUENCE](#SETUP_MOVE_SEQUENCE)
 - [SETUP_SLACK_MARGIN](#SETUP_SLACK_MARGIN)

--- a/flow/scripts/lec_check.tcl
+++ b/flow/scripts/lec_check.tcl
@@ -33,13 +33,25 @@ proc write_lec_verilog { filename } {
 }
 
 proc write_lec_script { step file1 file2 } {
+  # Exclude select Liberty files from being passed to kepler-formal
+  if { [env_var_exists_and_non_empty REMOVE_LIBS_FOR_LEC] } {
+    foreach lib_to_remove $::env(REMOVE_LIBS_FOR_LEC) {
+      set remove_libs_set($lib_to_remove) 1
+    }
+    set lib_list [lmap item $::env(LIB_FILES) {
+      if { [info exists remove_libs_set($item)] } { continue }
+      set item
+    }]
+  } else {
+    set lib_list $::env(LIB_FILES)
+  }
   set outfile [open "$::env(OBJECTS_DIR)/${step}_lec_test.yml" w]
   puts $outfile "format: verilog"
   puts $outfile "input_paths:"
   puts $outfile "  - $::env(RESULTS_DIR)/${file1}"
   puts $outfile "  - $::env(RESULTS_DIR)/${file2}"
   puts $outfile "liberty_files:"
-  foreach libFile $::env(LIB_FILES) {
+  foreach libFile $lib_list {
     puts $outfile " - $libFile"
   }
   puts $outfile "log_file: $::env(LOG_DIR)/${step}_lec_check.log"

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -936,6 +936,12 @@
     "description": "String patterns directly passed to write_verilog -remove_cells <> for lec checks.\n",
     "type": "string"
   },
+  "REMOVE_LIBS_FOR_LEC": {
+    "description": "List of Liberty files to exclude from LEC. This is required for cases where a Verilog black box needs to be used instead of a Liberty file.\n",
+    "stages": [
+      "cts"
+    ]
+  },
   "REPAIR_PDN_VIA_LAYER": {
     "description": "Remove power grid vias which generate DRC violations after detailed routing.\n"
   },

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1599,6 +1599,12 @@ LEC_AUX_VERILOG_FILES:
     running the formal equivalence check.
   stages:
     - cts
+REMOVE_LIBS_FOR_LEC:
+  description: >
+    List of Liberty files to exclude from LEC. This is required for cases where
+    a Verilog black box needs to be used instead of a Liberty file.
+  stages:
+    - cts
 REMOVE_CELLS_FOR_LEC:
   description: >
     String patterns directly passed to write_verilog -remove_cells <> for


### PR DESCRIPTION
Added ability to remove selected liberty files from being passed to lec. Required for cases where we need to use a verilog black box instead of a liberty file, due to issues with the liberty file and kepler-formal.
