### PR TITLE
flow: add RTLMP_KEEP_CLUSTERING option

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -255,6 +255,7 @@ configuration file.
 | <a name="RTLMP_FENCE_LY"></a>RTLMP_FENCE_LY| Defines the lower left Y coordinate for the global fence bounding box in microns.| 0.0|
 | <a name="RTLMP_FENCE_UX"></a>RTLMP_FENCE_UX| Defines the upper right X coordinate for the global fence bounding box in microns.| 0.0|
 | <a name="RTLMP_FENCE_UY"></a>RTLMP_FENCE_UY| Defines the upper right Y coordinate for the global fence bounding box in microns.| 0.0|
+| <a name="RTLMP_KEEP_CLUSTERING"></a>RTLMP_KEEP_CLUSTERING| Set to 1 to store the RTL macro placer's clustering hierarchy in the ODB as nested dbGroups.| 0|
 | <a name="RTLMP_MAX_INST"></a>RTLMP_MAX_INST| Maximum number of standard cells in a cluster. If unset, rtl_macro_placer will calculate a value based on the design attributes.| |
 | <a name="RTLMP_MAX_LEVEL"></a>RTLMP_MAX_LEVEL| Maximum depth of the physical hierarchy tree.| 2|
 | <a name="RTLMP_MAX_MACRO"></a>RTLMP_MAX_MACRO| Maximum number of macros in a cluster. If unset, rtl_macro_placer will calculate a value based on the design attributes.| |
@@ -429,6 +430,7 @@ configuration file.
 - [RTLMP_FENCE_LY](#RTLMP_FENCE_LY)
 - [RTLMP_FENCE_UX](#RTLMP_FENCE_UX)
 - [RTLMP_FENCE_UY](#RTLMP_FENCE_UY)
+- [RTLMP_KEEP_CLUSTERING](#RTLMP_KEEP_CLUSTERING)
 - [RTLMP_MAX_INST](#RTLMP_MAX_INST)
 - [RTLMP_MAX_LEVEL](#RTLMP_MAX_LEVEL)
 - [RTLMP_MAX_MACRO](#RTLMP_MAX_MACRO)

--- a/flow/scripts/macro_place_util.tcl
+++ b/flow/scripts/macro_place_util.tcl
@@ -53,6 +53,8 @@ if { [find_macros] != "" } {
   append_env_var additional_rtlmp_args RTLMP_BOUNDARY_WT -boundary_weight 1
   append_env_var additional_rtlmp_args RTLMP_NOTCH_WT -notch_weight 1
   append_env_var additional_rtlmp_args RTLMP_RPT_DIR -report_directory 1
+  append_env_var additional_rtlmp_args RTLMP_KEEP_CLUSTERING \
+    -keep_clustering_data 0
   append_env_var additional_rtlmp_args RTLMP_FENCE_LX -fence_lx 1
   append_env_var additional_rtlmp_args RTLMP_FENCE_LY -fence_ly 1
   append_env_var additional_rtlmp_args RTLMP_FENCE_UX -fence_ux 1

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -998,6 +998,13 @@
       "floorplan"
     ]
   },
+  "RTLMP_KEEP_CLUSTERING": {
+    "default": 0,
+    "description": "Set to 1 to store the RTL macro placer's clustering hierarchy in the ODB as nested dbGroups.\n",
+    "stages": [
+      "floorplan"
+    ]
+  },
   "RTLMP_MAX_INST": {
     "description": "Maximum number of standard cells in a cluster. If unset, rtl_macro_placer will calculate a value based on the design attributes.\n",
     "stages": [

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1448,6 +1448,13 @@ RTLMP_ARGS:
     Overrides all other RTL macro placer arguments.
   stages:
     - floorplan
+RTLMP_KEEP_CLUSTERING:
+  description: >
+    Set to 1 to store the RTL macro placer's clustering hierarchy in the ODB as
+    nested dbGroups.
+  default: 0
+  stages:
+    - floorplan
 GDS_ALLOW_EMPTY:
   description: >
     Single regular expression of module names of macros that have no .gds file


### PR DESCRIPTION
rtl_macro_placer can run with the -keep_clustering_data flag (which is off by default), so the physical hierarchy that its clustering engine builds is kept in the database as dbGroups and stays inspectable after the run: The Web GUI Hierarchy Browser panel lists the clusters, and save_image -web -display_option {cluster_view true} plots it headless.


Part of issue [#7959](https://github.com/The-OpenROAD-Project/OpenROAD/issues/7959)