### PR TITLE
global_route: catch failures to generate deterministic artifacts

### DIFF
--- a/flow/scripts/global_route.tcl
+++ b/flow/scripts/global_route.tcl
@@ -21,6 +21,21 @@ proc global_route_helper { } {
     }
   }
 
+  proc run_global_route_and_catch_failures { args } {
+    set result [catch { log_cmd global_route {*}$args } errMsg]
+
+    if { $result != 0 } {
+      if { !$::env(GENERATE_ARTIFACTS_ON_FAILURE) } {
+        log_cmd write_db $::env(RESULTS_DIR)/5_1_grt-failed.odb
+        error $errMsg
+      }
+      orfs_write_sdc $::env(RESULTS_DIR)/5_1_grt.sdc
+      orfs_write_db $::env(RESULTS_DIR)/5_1_grt.odb
+      return 0
+    }
+    return 1
+  }
+
   proc do_global_route { res_aware use_cugr } {
     set_grt_seed
     # CUGR runs a full 3D maze pass per iteration; use a tighter default.
@@ -32,7 +47,7 @@ proc global_route_helper { } {
       -congestion_report_file $::global_route_congestion_report] \
       $cong_iters $::env(GLOBAL_ROUTE_ARGS) {*}$res_aware {*}$use_cugr]
 
-    log_cmd global_route {*}$all_args
+    return [run_global_route_and_catch_failures {*}$all_args]
   }
   set additional_args ""
   append_env_var additional_args dbProcessNode -db_process_node 1
@@ -41,15 +56,7 @@ proc global_route_helper { } {
 
   log_cmd pin_access {*}$additional_args
 
-  set result [catch { do_global_route $res_aware $use_cugr } errMsg]
-
-  if { $result != 0 } {
-    if { !$::env(GENERATE_ARTIFACTS_ON_FAILURE) } {
-      orfs_write_db $::env(RESULTS_DIR)/5_1_grt-failed.odb
-      error $errMsg
-    }
-    orfs_write_sdc $::env(RESULTS_DIR)/5_1_grt.sdc
-    orfs_write_db $::env(RESULTS_DIR)/5_1_grt.odb
+  if { ![do_global_route $res_aware $use_cugr] } {
     return
   }
 
@@ -80,8 +87,12 @@ proc global_route_helper { } {
     log_cmd global_route -start_incremental
     log_cmd detailed_placement
     # Route only the modified net by DPL
-    log_cmd global_route -end_incremental {*}$res_aware \
-      -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_design.rpt
+    if {
+      ![run_global_route_and_catch_failures -end_incremental {*}$res_aware \
+        -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_design.rpt]
+    } {
+      return
+    }
 
     # Repair timing using global route parasitics
     puts "Repair setup and hold violations..."
@@ -97,8 +108,12 @@ proc global_route_helper { } {
     log_cmd detailed_placement
     log_cmd check_placement -verbose
     # Route only the modified net by DPL
-    log_cmd global_route -end_incremental {*}$res_aware \
-      -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt
+    if {
+      ![run_global_route_and_catch_failures -end_incremental {*}$res_aware \
+        -congestion_report_file $::env(REPORTS_DIR)/congestion_post_repair_timing.rpt]
+    } {
+      return
+    }
 
     log_cmd estimate_parasitics -global_routing
 
@@ -123,8 +138,12 @@ proc global_route_helper { } {
     log_cmd global_route -start_incremental
     recover_power_helper
     # Route the modified nets by rsz journal restore
-    log_cmd global_route -end_incremental {*}$res_aware \
-      -congestion_report_file $::env(REPORTS_DIR)/congestion_post_recover_power.rpt
+    if {
+      ![run_global_route_and_catch_failures -end_incremental {*}$res_aware \
+        -congestion_report_file $::env(REPORTS_DIR)/congestion_post_recover_power.rpt]
+    } {
+      return
+    }
   }
 
   if {


### PR DESCRIPTION
Consistent handling with the original GENERATE_ARTIFACTS_ON_FAILURE_POLICY by using a wrapper function.

Wraps all incremental global_route invocations (e.g. post repair_design or recover_power iterations) in proper catch blocks. If global_route fails or becomes infeasible mid-flow, it writes out a deterministic 5_1_grt-failed.odb rather than crashing without diagnostic artifacts.