### PR TITLE
Update metrics after GRT blocked tracks fix

### DIFF
--- a/flow/designs/asap7/ibex/rules-base.json
+++ b/flow/designs/asap7/ibex/rules-base.json
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -51.2,
+        "value": -51.1,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -209.0,
+        "value": -208.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -200.0,
+        "value": -436.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/riscv32i/rules-base.json
+++ b/flow/designs/asap7/riscv32i/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1480.0,
+        "value": -1890.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -81.2,
+        "value": -80.6,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -31800.0,
+        "value": -12100.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf180/aes-hybrid/rules-base.json
+++ b/flow/designs/gf180/aes-hybrid/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -123.0,
+        "value": -129.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -169.0,
+        "value": -144.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -168.0,
+        "value": -144.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf180/riscv32i/rules-base.json
+++ b/flow/designs/gf180/riscv32i/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -3.2,
+        "value": -5.5,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -2.85,
+        "value": -5.5,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1.6,
+        "value": -5.01,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1012494,
+        "value": 1000843,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -5.34,
+        "value": -3.26,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 320304,
+        "value": 320206,
         "compare": "<="
     }
 }

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -58,7 +58,7 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.466,
+        "value": -0.457,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 106,
+        "value": 105,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -384.0,
+        "value": -394.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 734366,
+        "value": 733977,
         "compare": "<="
     }
 }

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.431,
+        "value": -0.429,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -415.0,
+        "value": -459.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.457,
+        "value": -0.431,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -438.0,
+        "value": -504.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 4160494,
+        "value": 4834629,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.425,
+        "value": -0.408,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -394.0,
+        "value": -442.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.67,
+        "value": -3.26,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -114.0,
+        "value": -136.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 224,
+        "value": 179,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -2.32,
+        "value": -2.96,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -42.9,
+        "value": -48.8,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 725303,
+        "value": 853725,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -86,15 +86,15 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 158,
+        "value": 125,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.06,
+        "value": -2.66,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -39.9,
+        "value": -41.9,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 4681,
+        "value": 4663,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 552,
+        "value": 550,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -60.9,
+        "value": -64.3,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -71.6,
+        "value": -71.9,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 13026,
+        "value": 11307,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5996,
+        "value": 5812,
         "compare": "<="
     }
 }

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -64.3,
+        "value": -65.5,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -1.66,
+        "value": -1.75,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -71.9,
+        "value": -75.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 11307,
+        "value": 14559,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.53,
+        "value": -1.68,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -67.0,
+        "value": -71.2,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -34,6 +34,8 @@ export SETUP_SLACK_MARGIN = 0.2
 # GRT non-default config
 export FASTROUTE_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/fastroute.tcl
 
+export MAX_REPAIR_ANTENNAS_ITER_DRT = 2
+
 ifeq ($(SYNTH_MOCK_LARGE_MEMORIES),1)
     # ca. 3 minutes to run make synth
     #

--- a/flow/designs/sky130hd/microwatt/config.mk
+++ b/flow/designs/sky130hd/microwatt/config.mk
@@ -8,8 +8,7 @@ export VERILOG_FILES = $(sort $(wildcard $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/*
 
 export SDC_FILE      = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NICKNAME)/constraint.sdc
 
-export DIE_AREA   = 0 0 3020 3610
-export CORE_AREA  = 10 10 3010 3600
+export CORE_UTILIZATION = 55
 
 export ADDITIONAL_GDS  = $(wildcard $(DESIGN_DIR)/gds/*.gds.gz)
 

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 5408427,
+        "value": 5361392,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 181507,
+        "value": 142704,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 15783,
+        "value": 12409,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 15783,
+        "value": 12409,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -219.0,
+        "value": -232.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 4098,
+        "value": 2711,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -263.0,
+        "value": -256.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 8076674,
+        "value": 7815847,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 96,
+        "value": 72,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 2336,
+        "value": 1290,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,19 +94,19 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -221.0,
+        "value": -215.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.883,
+        "value": -0.75,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -3.42,
+        "value": -3.0,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5568093,
+        "value": 5512180,
         "compare": "<="
     }
 }

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -1,16 +1,16 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "ac96d25af26f4c444d6d33c37bcbe873ae3330f7",
+        "value": "2bfce367a7b9e450c60e37954e2129f0b0d0018c",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "ef0ae6eee3a802961bdd11bae631bb23692b1abe",
+        "value": "9ad86d2c1fc49d89f16f179403a07403d067c7b4",
         "compare": "==",
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 677000.0,
+        "value": 676000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.32,
+        "value": -2.1,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -254.0,
+        "value": -219.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 4314,
+        "value": 4098,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -269.0,
+        "value": -263.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,19 +82,19 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 8,
+        "value": 96,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 2725,
+        "value": 2336,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.16,
+        "value": -2.14,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -227.0,
+        "value": -221.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5568932,
+        "value": 5568093,
         "compare": "<="
     }
 }

--- a/flow/designs/sky130hs/jpeg/rules-base.json
+++ b/flow/designs/sky130hs/jpeg/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1.2,
+        "value": -3.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,11 +82,11 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 108,
+        "value": 100,
         "compare": "<="
     },
     "finish__timing__setup__ws": {


### PR DESCRIPTION
Microwatt is very sensitive to placement changes. I'm having timeout issues during DRT due to multiple loops after antenna repairs. To fix this, I limited the number of repair_antennas iterations during DRT (5 -> 2). I can take a deeper look later

designs/asap7/riscv32i/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |    -1480.0 |    -1890.0 | Failing  |
| finish__timing__setup__ws                     |      -81.2 |      -80.6 | Tighten  |
| finish__timing__setup__tns                    |   -31800.0 |   -12100.0 | Tighten  |

designs/gf180/aes-hybrid/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |     -123.0 |     -129.0 | Failing  |
| globalroute__timing__setup__tns               |     -169.0 |     -144.0 | Tighten  |
| finish__timing__setup__tns                    |     -168.0 |     -144.0 | Tighten  |

designs/gf180/riscv32i/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |       -3.2 |       -5.5 | Failing  |
| finish__timing__setup__tns                    |      -2.85 |       -5.5 | Failing  |

designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -2.67 |      -3.26 | Failing  |
| cts__timing__setup__tns                       |     -114.0 |     -136.0 | Failing  |
| globalroute__antenna_diodes_count             |        224 |        179 | Tighten  |
| globalroute__timing__setup__ws                |      -2.32 |      -2.96 | Failing  |
| globalroute__timing__setup__tns               |      -42.9 |      -48.8 | Failing  |
| detailedroute__route__wirelength              |     725303 |     853725 | Failing  |
| detailedroute__antenna_diodes_count           |        158 |        125 | Tighten  |
| finish__timing__setup__ws                     |      -2.06 |      -2.66 | Failing  |
| finish__timing__setup__tns                    |      -39.9 |      -41.9 | Failing  |

designs/sky130hd/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |       4681 |       4663 | Tighten  |
| placeopt__design__instance__count__stdcell    |        552 |        550 | Tighten  |
| cts__timing__setup__tns                       |      -60.9 |      -64.3 | Failing  |
| globalroute__timing__setup__tns               |      -71.6 |      -71.9 | Failing  |
| detailedroute__route__wirelength              |      13026 |      11307 | Tighten  |
| finish__design__instance__area                |       5996 |       5812 | Tighten  |

designs/sky130hs/jpeg/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |       -1.2 |       -3.0 | Failing  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |        108 |        100 | Tighten  |

designs/nangate45/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__ws                |     -0.466 |     -0.457 | Tighten  |
| detailedroute__antenna_diodes_count           |        106 |        105 | Tighten  |
| finish__timing__setup__tns                    |     -384.0 |     -394.0 | Failing  |
| finish__design__instance__area                |     734366 |     733977 | Tighten  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | ac96d25af26f4c444d6d33c37bcbe873ae3330f7 | 2bfce367a7b9e450c60e37954e2129f0b0d0018c | Failing  |
| synth__netlist__hash                          | ef0ae6eee3a802961bdd11bae631bb23692b1abe | 9ad86d2c1fc49d89f16f179403a07403d067c7b4 | Failing  |
| synth__design__instance__area__stdcell        |   677000.0 |   676000.0 | Tighten  |
| cts__timing__setup__ws                        |      -2.32 |       -2.1 | Tighten  |
| cts__timing__setup__tns                       |     -254.0 |     -219.0 | Tighten  |
| globalroute__antenna_diodes_count             |       4314 |       4098 | Tighten  |
| globalroute__timing__setup__tns               |     -269.0 |     -263.0 | Tighten  |
| detailedroute__antenna__violating__nets       |          8 |         96 | Failing  |
| detailedroute__antenna_diodes_count           |       2725 |       2336 | Tighten  |
| finish__timing__setup__ws                     |      -2.16 |      -2.14 | Tighten  |
| finish__timing__setup__tns                    |     -227.0 |     -221.0 | Tighten  |
| finish__design__instance__area                |    5568932 |    5568093 | Tighten  |

Related to [#11093](https://github.com/The-OpenROAD-Project/OpenROAD/pull/11093)

## CI Could not Update Rules

[ERROR] asap7/tinyRocket skipped. File 'rules-base.json' not found. Please create the file with 'make update_rules'.

## Messages from CI
[INFO] asap7/minimal not included in CI.
[INFO] gf12 not included in the update.
[INFO] gf55 not included in the update.
[INFO] nangate45/bp_quad not included in CI.