### PR TITLE
update metrics for public designs

### DIFF
--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1.6,
+        "value": -4.99,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1012494,
+        "value": 1000731,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -5.34,
+        "value": -3.37,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 320304,
+        "value": 320199,
         "compare": "<="
     }
 }

--- a/flow/designs/nangate45/swerv_wrapper/rules-base.json
+++ b/flow/designs/nangate45/swerv_wrapper/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.431,
+        "value": -0.429,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -415.0,
+        "value": -459.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.466,
+        "value": -0.428,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -438.0,
+        "value": -509.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 4160494,
+        "value": 4835341,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.425,
+        "value": -0.397,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -384.0,
+        "value": -426.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hd/gcd/rules-base.json
+++ b/flow/designs/sky130hd/gcd/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -1.45,
+        "value": -1.35,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -60.9,
+        "value": -58.9,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -71.6,
+        "value": -71.1,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 13026,
+        "value": 12929,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.53,
+        "value": -1.63,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -67.0,
+        "value": -66.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5996,
+        "value": 5950,
         "compare": "<="
     }
 }

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -10,7 +10,7 @@
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 677000.0,
+        "value": 676000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.32,
+        "value": -2.28,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -254.0,
+        "value": -221.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 4314,
+        "value": 4204,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -269.0,
+        "value": -261.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 2725,
+        "value": 2747,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,19 +94,19 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -227.0,
+        "value": -215.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -0.883,
+        "value": -0.808,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -3.42,
+        "value": -3.1,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5568932,
+        "value": 5567346,
         "compare": "<="
     }
 }


### PR DESCRIPTION
designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__design__instance__area__stdcell        |   677000.0 |   676000.0 | Tighten  |
| cts__timing__setup__ws                        |      -2.32 |      -2.28 | Tighten  |
| cts__timing__setup__tns                       |     -254.0 |     -221.0 | Tighten  |
| globalroute__antenna_diodes_count             |       4314 |       4204 | Tighten  |
| globalroute__timing__setup__tns               |     -269.0 |     -261.0 | Tighten  |
| detailedroute__antenna_diodes_count           |       2725 |       2747 | Failing  |
| finish__timing__setup__tns                    |     -227.0 |     -215.0 | Tighten  |
| finish__timing__hold__ws                      |     -0.883 |     -0.808 | Tighten  |
| finish__timing__hold__tns                     |      -3.42 |       -3.1 | Tighten  |
| finish__design__instance__area                |    5568932 |    5567346 | Tighten  |


designs/sky130hd/gcd/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -1.45 |      -1.35 | Tighten  |
| cts__timing__setup__tns                       |      -60.9 |      -58.9 | Tighten  |
| globalroute__timing__setup__tns               |      -71.6 |      -71.1 | Tighten  |
| detailedroute__route__wirelength              |      13026 |      12929 | Tighten  |
| finish__timing__setup__ws                     |      -1.53 |      -1.63 | Failing  |
| finish__timing__setup__tns                    |      -67.0 |      -66.0 | Tighten  |
| finish__design__instance__area                |       5996 |       5950 | Tighten  |


designs/nangate45/swerv_wrapper/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -0.431 |     -0.429 | Tighten  |
| cts__timing__setup__tns                       |     -415.0 |     -459.0 | Failing  |
| globalroute__timing__setup__ws                |     -0.466 |     -0.428 | Tighten  |
| globalroute__timing__setup__tns               |     -438.0 |     -509.0 | Failing  |
| detailedroute__route__wirelength              |    4160494 |    4835341 | Failing  |
| finish__timing__setup__ws                     |     -0.425 |     -0.397 | Tighten  |
| finish__timing__setup__tns                    |     -384.0 |     -426.0 | Failing  |


designs/ihp-sg13g2/ibex/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |       -1.6 |      -4.99 | Failing  |
| detailedroute__route__wirelength              |    1012494 |    1000731 | Tighten  |
| finish__timing__setup__tns                    |      -5.34 |      -3.37 | Tighten  |
| finish__design__instance__area                |     320304 |     320199 | Tighten  |


