### PR TITLE
Updated several gf12 designs to pass LEC

### DIFF
--- a/flow/designs/gf12/bp_dual/config.mk
+++ b/flow/designs/gf12/bp_dual/config.mk
@@ -68,3 +68,11 @@ export PDN_TCL = $(PLATFORM_DIR)/cfg/pdn_grid_strategy_13m_9T.top.tcl
 export MACRO_PLACE_HALO = 7 7
 
 export OPT_POST_GRT_WNS = 0
+
+# Have to use Verilog stubs for LEC for some of the RF's, since they have
+# a pin that has a condition that references multiple clocks. These two settings
+# use the Verilog stubs and remove the Liberty files from the kepler-formal
+# configuration file
+export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
+export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
+			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/bp_quad/config.mk
+++ b/flow/designs/gf12/bp_quad/config.mk
@@ -70,3 +70,11 @@ export PDN_TCL = $(PLATFORM_DIR)/cfg/pdn_grid_strategy_13m_9T.top.tcl
 export MACRO_PLACE_HALO = 7 7
 
 export OPT_POST_GRT_WNS = 0
+
+# Have to use Verilog stubs for LEC for some of the RF's, since they have
+# a pin that has a condition that references multiple clocks. These two settings
+# use the Verilog stubs and remove the Liberty files from the kepler-formal
+# configuration file
+export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
+export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
+			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/bp_single/config.mk
+++ b/flow/designs/gf12/bp_single/config.mk
@@ -72,3 +72,11 @@ export SETUP_SLACK_MARGIN ?= 100
 export SWAP_ARITH_OPERATORS = 1
 export OPENROAD_HIERARCHICAL = 1
 export OPT_POST_GRT_WNS = 0
+
+# Have to use Verilog stubs for LEC for some of the RF's, since they have
+# a pin that has a condition that references multiple clocks. These two settings
+# use the Verilog stubs and remove the Liberty files from the kepler-formal
+# configuration file
+export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
+export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
+			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/coyote/config.mk
+++ b/flow/designs/gf12/coyote/config.mk
@@ -40,5 +40,13 @@ endif
 export SWAP_ARITH_OPERATORS = 1
 export OPENROAD_HIERARCHICAL = 1
 
-# Temporarily disable LEC until RAM issue can be resolved with KF
-export LEC_CHECK = 0
+# Have to use Verilog stubs for LEC for some of the RF's, since they have
+# a pin that has a condition that references multiple clocks. These two settings
+# use the Verilog stubs and remove the Liberty files from the kepler-formal
+# configuration file
+export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_2rf_lg6_w44_bit.v \
+			       $(PLATFORM_DIR)/verilog/gf12_2rf_lg8_w64_bit.v
+export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_2rf_lg6_w44_bit_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
+	                       $(PLATFORM_DIR)/lib/gf12_2rf_lg8_w64_bit_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
+			       $(OBJECTS_DIR)/gf12_2rf_lg6_w44_bit_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib \
+			       $(OBJECTS_DIR)/gf12_2rf_lg8_w64_bit_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib


### PR DESCRIPTION
Updated gf12 bp_dual, bp_quad, bp_single and coyote to pass a blackbox verilog file instead of the liberty files to LEC. Works around KF issues with the RAM macros.

@joaomai , @eder-matheus I went ahead and updated the bp_* configs so that it should all go through with the OR update + halo updates.