### PR TITLE
update metrics forANT changes

### DIFF
--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -86,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 125,
+        "value": 106,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -41.9,
+        "value": -47.4,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
designs/sky130hd/chameleon/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| detailedroute__antenna_diodes_count           |        125 |        106 | Tighten  |
| finish__timing__setup__tns                    |      -41.9 |      -47.4 | Failing  |

OpenROAD PR: https://github.com/The-OpenROAD-Project/OpenROAD/pull/11125

## CI Could not Update Rules

[ERROR] asap7/tinyRocket skipped. File 'rules-base.json' not found. Please create the file with 'make update_rules'.

## Messages from CI
[INFO] asap7/minimal not included in CI.
[INFO] gf12 not included in the update.
[INFO] gf55 not included in the update.
[INFO] nangate45/bp_quad not included in CI.