### PR TITLE
flow: add CVA6 support for Nangate45

### DIFF
--- a/flow/designs/nangate45/cva6/BUILD
+++ b/flow/designs/nangate45/cva6/BUILD
@@ -1,0 +1,3 @@
+load("//flow/designs:design.bzl", "design")
+
+design(config = "config.mk")

--- a/flow/designs/nangate45/cva6/canonicalize.tcl
+++ b/flow/designs/nangate45/cva6/canonicalize.tcl
@@ -1,0 +1,4 @@
+# Remove rvfi_probes_o interface since contributes 4k ports and connections
+# (many of which are buffers tied to tie cells)
+
+delete cva6/o:rvfi_probes_o*

--- a/flow/designs/nangate45/cva6/config.mk
+++ b/flow/designs/nangate45/cva6/config.mk
@@ -1,0 +1,106 @@
+export PLATFORM               = nangate45
+
+export DESIGN_NAME            = cva6
+
+# Some files are listed specifically vs. sorted wildcard to control the order
+# (makes Verific happy)
+export SRC_HOME = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)
+export VERILOG_FILES          = $(sort $(wildcard $(SRC_HOME)/common/local/util/*.sv)) \
+	$(SRC_HOME)/core/include/config_pkg.sv \
+	$(SRC_HOME)/core/include/cv32a65x_config_pkg.sv \
+	$(SRC_HOME)/core/include/riscv_pkg.sv \
+	$(SRC_HOME)/core/include/ariane_pkg.sv \
+	$(SRC_HOME)/core/include/build_config_pkg.sv \
+	$(SRC_HOME)/core/include/std_cache_pkg.sv \
+	$(SRC_HOME)/core/include/wt_cache_pkg.sv \
+	$(sort $(wildcard $(SRC_HOME)/vendor/pulp-platform/common_cells/src/*.sv)) \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_pkg.sv \
+	$(sort $(wildcard $(SRC_HOME)/vendor/pulp-platform/axi/src/*.sv)) \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_cast_multi.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_classifier.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_divsqrt_multi.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_fma.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_fma_multi.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_noncomp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_opgroup_block.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_opgroup_fmt_slice.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_opgroup_multifmt_slice.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_rounding.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpnew_top.sv \
+	$(sort $(wildcard $(SRC_HOME)/core/*.sv)) \
+	$(sort $(wildcard $(SRC_HOME)/core/pmp/src/*.sv)) \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_pkg.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_amo.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_cmo.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_core_arbiter.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_ctrl.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_ctrl_pe.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_flush.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_memctrl.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_miss_handler.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_mshr.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_rtab.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_uncached.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_plru.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_random.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_victim_sel.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hpdcache_wbuf.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_pkg.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_arb.sv \
+	$(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/hwpf_stride/hwpf_stride_wrapper.sv \
+	$(sort $(wildcard $(SRC_HOME)/core/cache_subsystem/*.sv)) \
+	$(sort $(wildcard $(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/common/*.sv)) \
+	$(sort $(wildcard $(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/common/macros/blackbox/*.sv)) \
+	$(sort $(wildcard $(SRC_HOME)/core/cache_subsystem/hpdcache/rtl/src/utils/*.sv)) \
+	$(sort $(wildcard $(SRC_HOME)/core/cva6_mmu/*.sv)) \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/defs_div_sqrt_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/control_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/div_sqrt_top_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/iteration_div_sqrt_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/norm_div_sqrt_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/nrbd_nrsc_mvp.sv \
+	$(SRC_HOME)/core/cvfpu/src/fpu_div_sqrt_mvp/hdl/preprocess_mvp.sv \
+	$(SRC_HOME)/core/cvxif_example/include/cvxif_instr_pkg.sv \
+	$(sort $(wildcard $(SRC_HOME)/core/frontend/*.sv)) \
+	$(SRC_HOME)/vendor/pulp-platform/tech_cells_generic/src/rtl/tc_sram.sv \
+	$(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/macros.v
+
+export VERILOG_INCLUDE_DIRS = $(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/include \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cvfpu/src/common_cells/include \
+	$(DESIGN_HOME)/src/$(DESIGN_NICKNAME)/core/cache_subsystem/hpdcache/rtl/include
+
+export VERILOG_DEFINES += -D HPDCACHE_ASSERT_OFF
+
+export ADDITIONAL_LEFS = $(PLATFORM_DIR)/lef/fakeram45_64x256.lef \
+			 $(PLATFORM_DIR)/lef/fakeram45_128x64.lef \
+			 $(PLATFORM_DIR)/lef/fakeram45_64x28.lef \
+			 $(PLATFORM_DIR)/lef/fakeram45_64x25.lef
+
+export ADDITIONAL_LIBS = $(PLATFORM_DIR)/lib/fakeram45_64x256.lib \
+			 $(PLATFORM_DIR)/lib/fakeram45_128x64.lib \
+			 $(PLATFORM_DIR)/lib/fakeram45_64x28.lib \
+			 $(PLATFORM_DIR)/lib/fakeram45_64x25.lib
+
+export SDC_FILE               = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/constraint.sdc
+
+export CORE_UTILIZATION       = 60
+export CORE_MARGIN            = 2
+export MACRO_PLACE_HALO       = 10 10
+export PLACE_DENSITY          = 0.75
+
+# a smoketest for this option, there are a
+# few last gasp iterations
+#export SKIP_LAST_GASP ?= 1
+
+# For use with SYNTH_HIERARCHICAL
+export SYNTH_MINIMUM_KEEP_SIZE ?= 40000
+
+export SYNTH_HDL_FRONTEND = slang
+
+# Remove rvfi_probes_o interface
+export SYNTH_CANONICALIZE_TCL = $(DESIGN_HOME)/$(PLATFORM)/$(DESIGN_NAME)/canonicalize.tcl
+
+export SWAP_ARITH_OPERATORS = 1
+export OPENROAD_HIERARCHICAL = 1

--- a/flow/designs/nangate45/cva6/constraint.sdc
+++ b/flow/designs/nangate45/cva6/constraint.sdc
@@ -1,0 +1,37 @@
+# Derived from cva6_synth.tcl and Makefiles
+
+set clk_name main_clk
+set clk_port clk_i
+set clk_ports_list [list $clk_port]
+set clk_period 1000
+set input_delay 0.46
+set output_delay 0.11
+create_clock [get_ports $clk_port] -name $clk_name -period $clk_period
+
+# #set_dont_touch to keep sram as black boxes
+# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams[*].i_tag_sram
+# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks[*].i_data_sram
+# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].data_sram
+# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].tag_sram
+# #constraint the timing to and from the sram black boxes
+# set_input_delay -clock main_clk -max $input_delay \
+#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay \
+#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay \
+#   i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+# set_input_delay -clock main_clk -max $input_delay \
+#   i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
+
+# set_output_delay $output_delay -max -clock main_clk \
+#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk \
+#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk \
+#   i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+# set_output_delay $output_delay -max -clock main_clk \
+#   i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
+
+
+set_false_path -to [get_ports {rvfi_probes_o}]
+set_max_fanout 10 [current_design]

--- a/flow/designs/nangate45/cva6/constraint.sdc
+++ b/flow/designs/nangate45/cva6/constraint.sdc
@@ -33,5 +33,4 @@ create_clock [get_ports $clk_port] -name $clk_name -period $clk_period
 #   i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
 
 
-set_false_path -to [get_ports {rvfi_probes_o}]
 set_max_fanout 10 [current_design]

--- a/flow/designs/nangate45/cva6/macros.v
+++ b/flow/designs/nangate45/cva6/macros.v
@@ -1,0 +1,75 @@
+module fakeram7_64x256 (
+  output [255:0] rd_out,
+  input [5:0] addr_in,
+  input we_in,
+  input [255:0] wd_in,
+  input clk,
+  input ce_in
+);
+  fakeram45_64x256 mem (
+    .rd_out(rd_out),
+    .addr_in(addr_in),
+    .we_in(we_in),
+    .wd_in(wd_in),
+    .w_mask_in({256{1'b1}}),
+    .clk(clk),
+    .ce_in(ce_in)
+  );
+endmodule
+
+module fakeram7_128x64 (
+  output [63:0] rd_out,
+  input [6:0] addr_in,
+  input we_in,
+  input [63:0] wd_in,
+  input clk,
+  input ce_in
+);
+  fakeram45_128x64 mem (
+    .rd_out(rd_out),
+    .addr_in(addr_in),
+    .we_in(we_in),
+    .wd_in(wd_in),
+    .w_mask_in({64{1'b1}}),
+    .clk(clk),
+    .ce_in(ce_in)
+  );
+endmodule
+
+module fakeram7_64x28 (
+  output [27:0] rd_out,
+  input [5:0] addr_in,
+  input we_in,
+  input [27:0] wd_in,
+  input clk,
+  input ce_in
+);
+  fakeram45_64x28 mem (
+    .rd_out(rd_out),
+    .addr_in(addr_in),
+    .we_in(we_in),
+    .wd_in(wd_in),
+    .w_mask_in({28{1'b1}}),
+    .clk(clk),
+    .ce_in(ce_in)
+  );
+endmodule
+
+module fakeram7_64x25 (
+  output [24:0] rd_out,
+  input [5:0] addr_in,
+  input we_in,
+  input [24:0] wd_in,
+  input clk,
+  input ce_in
+);
+  fakeram45_64x25 mem (
+    .rd_out(rd_out),
+    .addr_in(addr_in),
+    .we_in(we_in),
+    .wd_in(wd_in),
+    .w_mask_in({25{1'b1}}),
+    .clk(clk),
+    .ce_in(ce_in)
+  );
+endmodule

--- a/flow/designs/nangate45/cva6/rules-base.json
+++ b/flow/designs/nangate45/cva6/rules-base.json
@@ -1,0 +1,112 @@
+{
+    "synth__canonical_netlist__hash": {
+        "value": "a6e7399ec64d71ce8fec5c22f41a539dd3c51090",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__netlist__hash": {
+        "value": "b71fbf82e3881b7cbe01957220b1b9b8ec605e5c",
+        "compare": "==",
+        "level": "warning"
+    },
+    "synth__design__instance__area__stdcell": {
+        "value": 178000.0,
+        "compare": "<="
+    },
+    "constraints__clocks__count": {
+        "value": 1,
+        "compare": "=="
+    },
+    "placeopt__design__instance__area": {
+        "value": 286611,
+        "compare": "<="
+    },
+    "placeopt__design__instance__count__stdcell": {
+        "value": 117185,
+        "compare": "<="
+    },
+    "detailedplace__design__violations": {
+        "value": 0,
+        "compare": "=="
+    },
+    "cts__design__instance__count__setup_buffer": {
+        "value": 10190,
+        "compare": "<="
+    },
+    "cts__design__instance__count__hold_buffer": {
+        "value": 10190,
+        "compare": "<="
+    },
+    "cts__timing__setup__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "cts__timing__setup__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "cts__timing__hold__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "cts__timing__hold__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "globalroute__antenna_diodes_count": {
+        "value": 115,
+        "compare": "<="
+    },
+    "globalroute__timing__setup__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "globalroute__timing__setup__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "globalroute__timing__hold__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "globalroute__timing__hold__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "detailedroute__route__wirelength": {
+        "value": 2496218,
+        "compare": "<="
+    },
+    "detailedroute__route__drc_errors": {
+        "value": 0,
+        "compare": "<="
+    },
+    "detailedroute__antenna__violating__nets": {
+        "value": 0,
+        "compare": "<="
+    },
+    "detailedroute__antenna_diodes_count": {
+        "value": 115,
+        "compare": "<="
+    },
+    "finish__timing__setup__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "finish__timing__setup__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "finish__timing__hold__ws": {
+        "value": -50.0,
+        "compare": ">="
+    },
+    "finish__timing__hold__tns": {
+        "value": -200.0,
+        "compare": ">="
+    },
+    "finish__design__instance__area": {
+        "value": 289845,
+        "compare": "<="
+    }
+}

--- a/flow/platforms/nangate45/fakeram.cfg
+++ b/flow/platforms/nangate45/fakeram.cfg
@@ -15,6 +15,7 @@
 #   fakeram45_64x64     snapHeight_nm = 62200
 #   fakeram45_64x96     snapHeight_nm = 44700
 #   fakeram45_64x124    snapHeight_nm = 112600
+#   fakeram45_64x256    snapHeight_nm = 223900
 #   fakeram45_128x256   snapHeight_nm = 223900
 {
   # The process node. This is used to tell cacti what technology to use when
@@ -61,12 +62,16 @@
     {"name": "fakeram45_64x7",    "width": 7,   "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x15",   "width": 15,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x21",   "width": 21,  "depth": 64,   "banks": 1},
+    {"name": "fakeram45_64x25",   "width": 25,  "depth": 64,   "banks": 1},
+    {"name": "fakeram45_64x28",   "width": 28,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x32",   "width": 32,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x62",   "width": 62,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x64",   "width": 64,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x96",   "width": 96,  "depth": 64,   "banks": 1},
     {"name": "fakeram45_64x124",  "width": 124, "depth": 64,   "banks": 1},
+    {"name": "fakeram45_64x256",  "width": 256, "depth": 64,   "banks": 1},
     {"name": "fakeram45_128x32",  "width": 32,  "depth": 128,  "banks": 1},
+    {"name": "fakeram45_128x64",  "width": 64,  "depth": 128,  "banks": 1},
     {"name": "fakeram45_128x116", "width": 116, "depth": 128,  "banks": 1},
     {"name": "fakeram45_128x256", "width": 256, "depth": 128,  "banks": 1},
     {"name": "fakeram45_256x16",  "width": 16,  "depth": 256,  "banks": 1},

--- a/flow/platforms/nangate45/fakeram.tcl
+++ b/flow/platforms/nangate45/fakeram.tcl
@@ -5,6 +5,7 @@ set design_rams {
   black_parrot {64x7 64x96 512x64 256x95 64x15}
   bp_multi_top {64x7 32x64 64x96 512x64 256x96 64x15}
   bp_fe_top {64x7 64x96 512x64}
+  cva6 {64x25 64x28 64x256 128x64}
 }
 
 set results_dir "~/import/fakeram/results"

--- a/flow/platforms/nangate45/lef/fakeram45_128x64.lef
+++ b/flow/platforms/nangate45/lef/fakeram45_128x64.lef
@@ -1,0 +1,2125 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram45_128x64
+  FOREIGN fakeram45_128x64 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 78.280 BY 70.000 ;
+  CLASS BLOCK ;
+  PIN w_mask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 2.800 0.070 2.870 ;
+    END
+  END w_mask_in[0]
+  PIN w_mask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.080 0.070 3.150 ;
+    END
+  END w_mask_in[1]
+  PIN w_mask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.360 0.070 3.430 ;
+    END
+  END w_mask_in[2]
+  PIN w_mask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.640 0.070 3.710 ;
+    END
+  END w_mask_in[3]
+  PIN w_mask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.920 0.070 3.990 ;
+    END
+  END w_mask_in[4]
+  PIN w_mask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.200 0.070 4.270 ;
+    END
+  END w_mask_in[5]
+  PIN w_mask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.480 0.070 4.550 ;
+    END
+  END w_mask_in[6]
+  PIN w_mask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.760 0.070 4.830 ;
+    END
+  END w_mask_in[7]
+  PIN w_mask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.040 0.070 5.110 ;
+    END
+  END w_mask_in[8]
+  PIN w_mask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.320 0.070 5.390 ;
+    END
+  END w_mask_in[9]
+  PIN w_mask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.600 0.070 5.670 ;
+    END
+  END w_mask_in[10]
+  PIN w_mask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.880 0.070 5.950 ;
+    END
+  END w_mask_in[11]
+  PIN w_mask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.160 0.070 6.230 ;
+    END
+  END w_mask_in[12]
+  PIN w_mask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.440 0.070 6.510 ;
+    END
+  END w_mask_in[13]
+  PIN w_mask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.720 0.070 6.790 ;
+    END
+  END w_mask_in[14]
+  PIN w_mask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.000 0.070 7.070 ;
+    END
+  END w_mask_in[15]
+  PIN w_mask_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.280 0.070 7.350 ;
+    END
+  END w_mask_in[16]
+  PIN w_mask_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.560 0.070 7.630 ;
+    END
+  END w_mask_in[17]
+  PIN w_mask_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.840 0.070 7.910 ;
+    END
+  END w_mask_in[18]
+  PIN w_mask_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.120 0.070 8.190 ;
+    END
+  END w_mask_in[19]
+  PIN w_mask_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.400 0.070 8.470 ;
+    END
+  END w_mask_in[20]
+  PIN w_mask_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.680 0.070 8.750 ;
+    END
+  END w_mask_in[21]
+  PIN w_mask_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.960 0.070 9.030 ;
+    END
+  END w_mask_in[22]
+  PIN w_mask_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.240 0.070 9.310 ;
+    END
+  END w_mask_in[23]
+  PIN w_mask_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.520 0.070 9.590 ;
+    END
+  END w_mask_in[24]
+  PIN w_mask_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.800 0.070 9.870 ;
+    END
+  END w_mask_in[25]
+  PIN w_mask_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.080 0.070 10.150 ;
+    END
+  END w_mask_in[26]
+  PIN w_mask_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.360 0.070 10.430 ;
+    END
+  END w_mask_in[27]
+  PIN w_mask_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.640 0.070 10.710 ;
+    END
+  END w_mask_in[28]
+  PIN w_mask_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.920 0.070 10.990 ;
+    END
+  END w_mask_in[29]
+  PIN w_mask_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.200 0.070 11.270 ;
+    END
+  END w_mask_in[30]
+  PIN w_mask_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.480 0.070 11.550 ;
+    END
+  END w_mask_in[31]
+  PIN w_mask_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.760 0.070 11.830 ;
+    END
+  END w_mask_in[32]
+  PIN w_mask_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.040 0.070 12.110 ;
+    END
+  END w_mask_in[33]
+  PIN w_mask_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.320 0.070 12.390 ;
+    END
+  END w_mask_in[34]
+  PIN w_mask_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.600 0.070 12.670 ;
+    END
+  END w_mask_in[35]
+  PIN w_mask_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.880 0.070 12.950 ;
+    END
+  END w_mask_in[36]
+  PIN w_mask_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.160 0.070 13.230 ;
+    END
+  END w_mask_in[37]
+  PIN w_mask_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.440 0.070 13.510 ;
+    END
+  END w_mask_in[38]
+  PIN w_mask_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.720 0.070 13.790 ;
+    END
+  END w_mask_in[39]
+  PIN w_mask_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.000 0.070 14.070 ;
+    END
+  END w_mask_in[40]
+  PIN w_mask_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.280 0.070 14.350 ;
+    END
+  END w_mask_in[41]
+  PIN w_mask_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.560 0.070 14.630 ;
+    END
+  END w_mask_in[42]
+  PIN w_mask_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.840 0.070 14.910 ;
+    END
+  END w_mask_in[43]
+  PIN w_mask_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.120 0.070 15.190 ;
+    END
+  END w_mask_in[44]
+  PIN w_mask_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.400 0.070 15.470 ;
+    END
+  END w_mask_in[45]
+  PIN w_mask_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.680 0.070 15.750 ;
+    END
+  END w_mask_in[46]
+  PIN w_mask_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.960 0.070 16.030 ;
+    END
+  END w_mask_in[47]
+  PIN w_mask_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.240 0.070 16.310 ;
+    END
+  END w_mask_in[48]
+  PIN w_mask_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.520 0.070 16.590 ;
+    END
+  END w_mask_in[49]
+  PIN w_mask_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.800 0.070 16.870 ;
+    END
+  END w_mask_in[50]
+  PIN w_mask_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.080 0.070 17.150 ;
+    END
+  END w_mask_in[51]
+  PIN w_mask_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.360 0.070 17.430 ;
+    END
+  END w_mask_in[52]
+  PIN w_mask_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.640 0.070 17.710 ;
+    END
+  END w_mask_in[53]
+  PIN w_mask_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.920 0.070 17.990 ;
+    END
+  END w_mask_in[54]
+  PIN w_mask_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.200 0.070 18.270 ;
+    END
+  END w_mask_in[55]
+  PIN w_mask_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.480 0.070 18.550 ;
+    END
+  END w_mask_in[56]
+  PIN w_mask_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.760 0.070 18.830 ;
+    END
+  END w_mask_in[57]
+  PIN w_mask_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.040 0.070 19.110 ;
+    END
+  END w_mask_in[58]
+  PIN w_mask_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.320 0.070 19.390 ;
+    END
+  END w_mask_in[59]
+  PIN w_mask_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.600 0.070 19.670 ;
+    END
+  END w_mask_in[60]
+  PIN w_mask_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.880 0.070 19.950 ;
+    END
+  END w_mask_in[61]
+  PIN w_mask_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.160 0.070 20.230 ;
+    END
+  END w_mask_in[62]
+  PIN w_mask_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.440 0.070 20.510 ;
+    END
+  END w_mask_in[63]
+  PIN rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.400 0.070 22.470 ;
+    END
+  END rd_out[0]
+  PIN rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.680 0.070 22.750 ;
+    END
+  END rd_out[1]
+  PIN rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.960 0.070 23.030 ;
+    END
+  END rd_out[2]
+  PIN rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.240 0.070 23.310 ;
+    END
+  END rd_out[3]
+  PIN rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.520 0.070 23.590 ;
+    END
+  END rd_out[4]
+  PIN rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.800 0.070 23.870 ;
+    END
+  END rd_out[5]
+  PIN rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.080 0.070 24.150 ;
+    END
+  END rd_out[6]
+  PIN rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.360 0.070 24.430 ;
+    END
+  END rd_out[7]
+  PIN rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.640 0.070 24.710 ;
+    END
+  END rd_out[8]
+  PIN rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.920 0.070 24.990 ;
+    END
+  END rd_out[9]
+  PIN rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.200 0.070 25.270 ;
+    END
+  END rd_out[10]
+  PIN rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.480 0.070 25.550 ;
+    END
+  END rd_out[11]
+  PIN rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.760 0.070 25.830 ;
+    END
+  END rd_out[12]
+  PIN rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.040 0.070 26.110 ;
+    END
+  END rd_out[13]
+  PIN rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.320 0.070 26.390 ;
+    END
+  END rd_out[14]
+  PIN rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.600 0.070 26.670 ;
+    END
+  END rd_out[15]
+  PIN rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.880 0.070 26.950 ;
+    END
+  END rd_out[16]
+  PIN rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.160 0.070 27.230 ;
+    END
+  END rd_out[17]
+  PIN rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.440 0.070 27.510 ;
+    END
+  END rd_out[18]
+  PIN rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.720 0.070 27.790 ;
+    END
+  END rd_out[19]
+  PIN rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.000 0.070 28.070 ;
+    END
+  END rd_out[20]
+  PIN rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.280 0.070 28.350 ;
+    END
+  END rd_out[21]
+  PIN rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.560 0.070 28.630 ;
+    END
+  END rd_out[22]
+  PIN rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.840 0.070 28.910 ;
+    END
+  END rd_out[23]
+  PIN rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.120 0.070 29.190 ;
+    END
+  END rd_out[24]
+  PIN rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.400 0.070 29.470 ;
+    END
+  END rd_out[25]
+  PIN rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.680 0.070 29.750 ;
+    END
+  END rd_out[26]
+  PIN rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.960 0.070 30.030 ;
+    END
+  END rd_out[27]
+  PIN rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.240 0.070 30.310 ;
+    END
+  END rd_out[28]
+  PIN rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.520 0.070 30.590 ;
+    END
+  END rd_out[29]
+  PIN rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.800 0.070 30.870 ;
+    END
+  END rd_out[30]
+  PIN rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.080 0.070 31.150 ;
+    END
+  END rd_out[31]
+  PIN rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.360 0.070 31.430 ;
+    END
+  END rd_out[32]
+  PIN rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.640 0.070 31.710 ;
+    END
+  END rd_out[33]
+  PIN rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.920 0.070 31.990 ;
+    END
+  END rd_out[34]
+  PIN rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.200 0.070 32.270 ;
+    END
+  END rd_out[35]
+  PIN rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.480 0.070 32.550 ;
+    END
+  END rd_out[36]
+  PIN rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.760 0.070 32.830 ;
+    END
+  END rd_out[37]
+  PIN rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.040 0.070 33.110 ;
+    END
+  END rd_out[38]
+  PIN rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.320 0.070 33.390 ;
+    END
+  END rd_out[39]
+  PIN rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.600 0.070 33.670 ;
+    END
+  END rd_out[40]
+  PIN rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.880 0.070 33.950 ;
+    END
+  END rd_out[41]
+  PIN rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.160 0.070 34.230 ;
+    END
+  END rd_out[42]
+  PIN rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.440 0.070 34.510 ;
+    END
+  END rd_out[43]
+  PIN rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.720 0.070 34.790 ;
+    END
+  END rd_out[44]
+  PIN rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.000 0.070 35.070 ;
+    END
+  END rd_out[45]
+  PIN rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.280 0.070 35.350 ;
+    END
+  END rd_out[46]
+  PIN rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.560 0.070 35.630 ;
+    END
+  END rd_out[47]
+  PIN rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.840 0.070 35.910 ;
+    END
+  END rd_out[48]
+  PIN rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.120 0.070 36.190 ;
+    END
+  END rd_out[49]
+  PIN rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.400 0.070 36.470 ;
+    END
+  END rd_out[50]
+  PIN rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.680 0.070 36.750 ;
+    END
+  END rd_out[51]
+  PIN rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.960 0.070 37.030 ;
+    END
+  END rd_out[52]
+  PIN rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.240 0.070 37.310 ;
+    END
+  END rd_out[53]
+  PIN rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.520 0.070 37.590 ;
+    END
+  END rd_out[54]
+  PIN rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.800 0.070 37.870 ;
+    END
+  END rd_out[55]
+  PIN rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.080 0.070 38.150 ;
+    END
+  END rd_out[56]
+  PIN rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.360 0.070 38.430 ;
+    END
+  END rd_out[57]
+  PIN rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.640 0.070 38.710 ;
+    END
+  END rd_out[58]
+  PIN rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.920 0.070 38.990 ;
+    END
+  END rd_out[59]
+  PIN rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.200 0.070 39.270 ;
+    END
+  END rd_out[60]
+  PIN rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.480 0.070 39.550 ;
+    END
+  END rd_out[61]
+  PIN rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.760 0.070 39.830 ;
+    END
+  END rd_out[62]
+  PIN rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.040 0.070 40.110 ;
+    END
+  END rd_out[63]
+  PIN wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.000 0.070 42.070 ;
+    END
+  END wd_in[0]
+  PIN wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.280 0.070 42.350 ;
+    END
+  END wd_in[1]
+  PIN wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.560 0.070 42.630 ;
+    END
+  END wd_in[2]
+  PIN wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.840 0.070 42.910 ;
+    END
+  END wd_in[3]
+  PIN wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.120 0.070 43.190 ;
+    END
+  END wd_in[4]
+  PIN wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.400 0.070 43.470 ;
+    END
+  END wd_in[5]
+  PIN wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.680 0.070 43.750 ;
+    END
+  END wd_in[6]
+  PIN wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.960 0.070 44.030 ;
+    END
+  END wd_in[7]
+  PIN wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.240 0.070 44.310 ;
+    END
+  END wd_in[8]
+  PIN wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.520 0.070 44.590 ;
+    END
+  END wd_in[9]
+  PIN wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.800 0.070 44.870 ;
+    END
+  END wd_in[10]
+  PIN wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.080 0.070 45.150 ;
+    END
+  END wd_in[11]
+  PIN wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.360 0.070 45.430 ;
+    END
+  END wd_in[12]
+  PIN wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.640 0.070 45.710 ;
+    END
+  END wd_in[13]
+  PIN wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.920 0.070 45.990 ;
+    END
+  END wd_in[14]
+  PIN wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.200 0.070 46.270 ;
+    END
+  END wd_in[15]
+  PIN wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.480 0.070 46.550 ;
+    END
+  END wd_in[16]
+  PIN wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.760 0.070 46.830 ;
+    END
+  END wd_in[17]
+  PIN wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.040 0.070 47.110 ;
+    END
+  END wd_in[18]
+  PIN wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.320 0.070 47.390 ;
+    END
+  END wd_in[19]
+  PIN wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.600 0.070 47.670 ;
+    END
+  END wd_in[20]
+  PIN wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.880 0.070 47.950 ;
+    END
+  END wd_in[21]
+  PIN wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.160 0.070 48.230 ;
+    END
+  END wd_in[22]
+  PIN wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.440 0.070 48.510 ;
+    END
+  END wd_in[23]
+  PIN wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.720 0.070 48.790 ;
+    END
+  END wd_in[24]
+  PIN wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.000 0.070 49.070 ;
+    END
+  END wd_in[25]
+  PIN wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.280 0.070 49.350 ;
+    END
+  END wd_in[26]
+  PIN wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.560 0.070 49.630 ;
+    END
+  END wd_in[27]
+  PIN wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.840 0.070 49.910 ;
+    END
+  END wd_in[28]
+  PIN wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.120 0.070 50.190 ;
+    END
+  END wd_in[29]
+  PIN wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.400 0.070 50.470 ;
+    END
+  END wd_in[30]
+  PIN wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.680 0.070 50.750 ;
+    END
+  END wd_in[31]
+  PIN wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.960 0.070 51.030 ;
+    END
+  END wd_in[32]
+  PIN wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.240 0.070 51.310 ;
+    END
+  END wd_in[33]
+  PIN wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.520 0.070 51.590 ;
+    END
+  END wd_in[34]
+  PIN wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.800 0.070 51.870 ;
+    END
+  END wd_in[35]
+  PIN wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.080 0.070 52.150 ;
+    END
+  END wd_in[36]
+  PIN wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.360 0.070 52.430 ;
+    END
+  END wd_in[37]
+  PIN wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.640 0.070 52.710 ;
+    END
+  END wd_in[38]
+  PIN wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.920 0.070 52.990 ;
+    END
+  END wd_in[39]
+  PIN wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.200 0.070 53.270 ;
+    END
+  END wd_in[40]
+  PIN wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.480 0.070 53.550 ;
+    END
+  END wd_in[41]
+  PIN wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.760 0.070 53.830 ;
+    END
+  END wd_in[42]
+  PIN wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.040 0.070 54.110 ;
+    END
+  END wd_in[43]
+  PIN wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.320 0.070 54.390 ;
+    END
+  END wd_in[44]
+  PIN wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.600 0.070 54.670 ;
+    END
+  END wd_in[45]
+  PIN wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.880 0.070 54.950 ;
+    END
+  END wd_in[46]
+  PIN wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.160 0.070 55.230 ;
+    END
+  END wd_in[47]
+  PIN wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.440 0.070 55.510 ;
+    END
+  END wd_in[48]
+  PIN wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.720 0.070 55.790 ;
+    END
+  END wd_in[49]
+  PIN wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.000 0.070 56.070 ;
+    END
+  END wd_in[50]
+  PIN wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.280 0.070 56.350 ;
+    END
+  END wd_in[51]
+  PIN wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.560 0.070 56.630 ;
+    END
+  END wd_in[52]
+  PIN wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.840 0.070 56.910 ;
+    END
+  END wd_in[53]
+  PIN wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.120 0.070 57.190 ;
+    END
+  END wd_in[54]
+  PIN wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.400 0.070 57.470 ;
+    END
+  END wd_in[55]
+  PIN wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.680 0.070 57.750 ;
+    END
+  END wd_in[56]
+  PIN wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.960 0.070 58.030 ;
+    END
+  END wd_in[57]
+  PIN wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.240 0.070 58.310 ;
+    END
+  END wd_in[58]
+  PIN wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.520 0.070 58.590 ;
+    END
+  END wd_in[59]
+  PIN wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.800 0.070 58.870 ;
+    END
+  END wd_in[60]
+  PIN wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.080 0.070 59.150 ;
+    END
+  END wd_in[61]
+  PIN wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.360 0.070 59.430 ;
+    END
+  END wd_in[62]
+  PIN wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.640 0.070 59.710 ;
+    END
+  END wd_in[63]
+  PIN addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.600 0.070 61.670 ;
+    END
+  END addr_in[0]
+  PIN addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.880 0.070 61.950 ;
+    END
+  END addr_in[1]
+  PIN addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.160 0.070 62.230 ;
+    END
+  END addr_in[2]
+  PIN addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.440 0.070 62.510 ;
+    END
+  END addr_in[3]
+  PIN addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.720 0.070 62.790 ;
+    END
+  END addr_in[4]
+  PIN addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.000 0.070 63.070 ;
+    END
+  END addr_in[5]
+  PIN addr_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.280 0.070 63.350 ;
+    END
+  END addr_in[6]
+  PIN we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.240 0.070 65.310 ;
+    END
+  END we_in
+  PIN ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.520 0.070 65.590 ;
+    END
+  END ce_in
+  PIN clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.800 0.070 65.870 ;
+    END
+  END clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 2.660 2.800 2.940 67.200 ;
+      RECT 7.140 2.800 7.420 67.200 ;
+      RECT 11.620 2.800 11.900 67.200 ;
+      RECT 16.100 2.800 16.380 67.200 ;
+      RECT 20.580 2.800 20.860 67.200 ;
+      RECT 25.060 2.800 25.340 67.200 ;
+      RECT 29.540 2.800 29.820 67.200 ;
+      RECT 34.020 2.800 34.300 67.200 ;
+      RECT 38.500 2.800 38.780 67.200 ;
+      RECT 42.980 2.800 43.260 67.200 ;
+      RECT 47.460 2.800 47.740 67.200 ;
+      RECT 51.940 2.800 52.220 67.200 ;
+      RECT 56.420 2.800 56.700 67.200 ;
+      RECT 60.900 2.800 61.180 67.200 ;
+      RECT 65.380 2.800 65.660 67.200 ;
+      RECT 69.860 2.800 70.140 67.200 ;
+      RECT 74.340 2.800 74.620 67.200 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 4.900 2.800 5.180 67.200 ;
+      RECT 9.380 2.800 9.660 67.200 ;
+      RECT 13.860 2.800 14.140 67.200 ;
+      RECT 18.340 2.800 18.620 67.200 ;
+      RECT 22.820 2.800 23.100 67.200 ;
+      RECT 27.300 2.800 27.580 67.200 ;
+      RECT 31.780 2.800 32.060 67.200 ;
+      RECT 36.260 2.800 36.540 67.200 ;
+      RECT 40.740 2.800 41.020 67.200 ;
+      RECT 45.220 2.800 45.500 67.200 ;
+      RECT 49.700 2.800 49.980 67.200 ;
+      RECT 54.180 2.800 54.460 67.200 ;
+      RECT 58.660 2.800 58.940 67.200 ;
+      RECT 63.140 2.800 63.420 67.200 ;
+      RECT 67.620 2.800 67.900 67.200 ;
+      RECT 72.100 2.800 72.380 67.200 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 78.280 70.000 ;
+    LAYER metal2 ;
+    RECT 0 0 78.280 70.000 ;
+    LAYER metal3 ;
+    RECT 0.070 0 78.280 70.000 ;
+    RECT 0 0.000 0.070 2.800 ;
+    RECT 0 2.870 0.070 3.080 ;
+    RECT 0 3.150 0.070 3.360 ;
+    RECT 0 3.430 0.070 3.640 ;
+    RECT 0 3.710 0.070 3.920 ;
+    RECT 0 3.990 0.070 4.200 ;
+    RECT 0 4.270 0.070 4.480 ;
+    RECT 0 4.550 0.070 4.760 ;
+    RECT 0 4.830 0.070 5.040 ;
+    RECT 0 5.110 0.070 5.320 ;
+    RECT 0 5.390 0.070 5.600 ;
+    RECT 0 5.670 0.070 5.880 ;
+    RECT 0 5.950 0.070 6.160 ;
+    RECT 0 6.230 0.070 6.440 ;
+    RECT 0 6.510 0.070 6.720 ;
+    RECT 0 6.790 0.070 7.000 ;
+    RECT 0 7.070 0.070 7.280 ;
+    RECT 0 7.350 0.070 7.560 ;
+    RECT 0 7.630 0.070 7.840 ;
+    RECT 0 7.910 0.070 8.120 ;
+    RECT 0 8.190 0.070 8.400 ;
+    RECT 0 8.470 0.070 8.680 ;
+    RECT 0 8.750 0.070 8.960 ;
+    RECT 0 9.030 0.070 9.240 ;
+    RECT 0 9.310 0.070 9.520 ;
+    RECT 0 9.590 0.070 9.800 ;
+    RECT 0 9.870 0.070 10.080 ;
+    RECT 0 10.150 0.070 10.360 ;
+    RECT 0 10.430 0.070 10.640 ;
+    RECT 0 10.710 0.070 10.920 ;
+    RECT 0 10.990 0.070 11.200 ;
+    RECT 0 11.270 0.070 11.480 ;
+    RECT 0 11.550 0.070 11.760 ;
+    RECT 0 11.830 0.070 12.040 ;
+    RECT 0 12.110 0.070 12.320 ;
+    RECT 0 12.390 0.070 12.600 ;
+    RECT 0 12.670 0.070 12.880 ;
+    RECT 0 12.950 0.070 13.160 ;
+    RECT 0 13.230 0.070 13.440 ;
+    RECT 0 13.510 0.070 13.720 ;
+    RECT 0 13.790 0.070 14.000 ;
+    RECT 0 14.070 0.070 14.280 ;
+    RECT 0 14.350 0.070 14.560 ;
+    RECT 0 14.630 0.070 14.840 ;
+    RECT 0 14.910 0.070 15.120 ;
+    RECT 0 15.190 0.070 15.400 ;
+    RECT 0 15.470 0.070 15.680 ;
+    RECT 0 15.750 0.070 15.960 ;
+    RECT 0 16.030 0.070 16.240 ;
+    RECT 0 16.310 0.070 16.520 ;
+    RECT 0 16.590 0.070 16.800 ;
+    RECT 0 16.870 0.070 17.080 ;
+    RECT 0 17.150 0.070 17.360 ;
+    RECT 0 17.430 0.070 17.640 ;
+    RECT 0 17.710 0.070 17.920 ;
+    RECT 0 17.990 0.070 18.200 ;
+    RECT 0 18.270 0.070 18.480 ;
+    RECT 0 18.550 0.070 18.760 ;
+    RECT 0 18.830 0.070 19.040 ;
+    RECT 0 19.110 0.070 19.320 ;
+    RECT 0 19.390 0.070 19.600 ;
+    RECT 0 19.670 0.070 19.880 ;
+    RECT 0 19.950 0.070 20.160 ;
+    RECT 0 20.230 0.070 20.440 ;
+    RECT 0 20.510 0.070 22.400 ;
+    RECT 0 22.470 0.070 22.680 ;
+    RECT 0 22.750 0.070 22.960 ;
+    RECT 0 23.030 0.070 23.240 ;
+    RECT 0 23.310 0.070 23.520 ;
+    RECT 0 23.590 0.070 23.800 ;
+    RECT 0 23.870 0.070 24.080 ;
+    RECT 0 24.150 0.070 24.360 ;
+    RECT 0 24.430 0.070 24.640 ;
+    RECT 0 24.710 0.070 24.920 ;
+    RECT 0 24.990 0.070 25.200 ;
+    RECT 0 25.270 0.070 25.480 ;
+    RECT 0 25.550 0.070 25.760 ;
+    RECT 0 25.830 0.070 26.040 ;
+    RECT 0 26.110 0.070 26.320 ;
+    RECT 0 26.390 0.070 26.600 ;
+    RECT 0 26.670 0.070 26.880 ;
+    RECT 0 26.950 0.070 27.160 ;
+    RECT 0 27.230 0.070 27.440 ;
+    RECT 0 27.510 0.070 27.720 ;
+    RECT 0 27.790 0.070 28.000 ;
+    RECT 0 28.070 0.070 28.280 ;
+    RECT 0 28.350 0.070 28.560 ;
+    RECT 0 28.630 0.070 28.840 ;
+    RECT 0 28.910 0.070 29.120 ;
+    RECT 0 29.190 0.070 29.400 ;
+    RECT 0 29.470 0.070 29.680 ;
+    RECT 0 29.750 0.070 29.960 ;
+    RECT 0 30.030 0.070 30.240 ;
+    RECT 0 30.310 0.070 30.520 ;
+    RECT 0 30.590 0.070 30.800 ;
+    RECT 0 30.870 0.070 31.080 ;
+    RECT 0 31.150 0.070 31.360 ;
+    RECT 0 31.430 0.070 31.640 ;
+    RECT 0 31.710 0.070 31.920 ;
+    RECT 0 31.990 0.070 32.200 ;
+    RECT 0 32.270 0.070 32.480 ;
+    RECT 0 32.550 0.070 32.760 ;
+    RECT 0 32.830 0.070 33.040 ;
+    RECT 0 33.110 0.070 33.320 ;
+    RECT 0 33.390 0.070 33.600 ;
+    RECT 0 33.670 0.070 33.880 ;
+    RECT 0 33.950 0.070 34.160 ;
+    RECT 0 34.230 0.070 34.440 ;
+    RECT 0 34.510 0.070 34.720 ;
+    RECT 0 34.790 0.070 35.000 ;
+    RECT 0 35.070 0.070 35.280 ;
+    RECT 0 35.350 0.070 35.560 ;
+    RECT 0 35.630 0.070 35.840 ;
+    RECT 0 35.910 0.070 36.120 ;
+    RECT 0 36.190 0.070 36.400 ;
+    RECT 0 36.470 0.070 36.680 ;
+    RECT 0 36.750 0.070 36.960 ;
+    RECT 0 37.030 0.070 37.240 ;
+    RECT 0 37.310 0.070 37.520 ;
+    RECT 0 37.590 0.070 37.800 ;
+    RECT 0 37.870 0.070 38.080 ;
+    RECT 0 38.150 0.070 38.360 ;
+    RECT 0 38.430 0.070 38.640 ;
+    RECT 0 38.710 0.070 38.920 ;
+    RECT 0 38.990 0.070 39.200 ;
+    RECT 0 39.270 0.070 39.480 ;
+    RECT 0 39.550 0.070 39.760 ;
+    RECT 0 39.830 0.070 40.040 ;
+    RECT 0 40.110 0.070 42.000 ;
+    RECT 0 42.070 0.070 42.280 ;
+    RECT 0 42.350 0.070 42.560 ;
+    RECT 0 42.630 0.070 42.840 ;
+    RECT 0 42.910 0.070 43.120 ;
+    RECT 0 43.190 0.070 43.400 ;
+    RECT 0 43.470 0.070 43.680 ;
+    RECT 0 43.750 0.070 43.960 ;
+    RECT 0 44.030 0.070 44.240 ;
+    RECT 0 44.310 0.070 44.520 ;
+    RECT 0 44.590 0.070 44.800 ;
+    RECT 0 44.870 0.070 45.080 ;
+    RECT 0 45.150 0.070 45.360 ;
+    RECT 0 45.430 0.070 45.640 ;
+    RECT 0 45.710 0.070 45.920 ;
+    RECT 0 45.990 0.070 46.200 ;
+    RECT 0 46.270 0.070 46.480 ;
+    RECT 0 46.550 0.070 46.760 ;
+    RECT 0 46.830 0.070 47.040 ;
+    RECT 0 47.110 0.070 47.320 ;
+    RECT 0 47.390 0.070 47.600 ;
+    RECT 0 47.670 0.070 47.880 ;
+    RECT 0 47.950 0.070 48.160 ;
+    RECT 0 48.230 0.070 48.440 ;
+    RECT 0 48.510 0.070 48.720 ;
+    RECT 0 48.790 0.070 49.000 ;
+    RECT 0 49.070 0.070 49.280 ;
+    RECT 0 49.350 0.070 49.560 ;
+    RECT 0 49.630 0.070 49.840 ;
+    RECT 0 49.910 0.070 50.120 ;
+    RECT 0 50.190 0.070 50.400 ;
+    RECT 0 50.470 0.070 50.680 ;
+    RECT 0 50.750 0.070 50.960 ;
+    RECT 0 51.030 0.070 51.240 ;
+    RECT 0 51.310 0.070 51.520 ;
+    RECT 0 51.590 0.070 51.800 ;
+    RECT 0 51.870 0.070 52.080 ;
+    RECT 0 52.150 0.070 52.360 ;
+    RECT 0 52.430 0.070 52.640 ;
+    RECT 0 52.710 0.070 52.920 ;
+    RECT 0 52.990 0.070 53.200 ;
+    RECT 0 53.270 0.070 53.480 ;
+    RECT 0 53.550 0.070 53.760 ;
+    RECT 0 53.830 0.070 54.040 ;
+    RECT 0 54.110 0.070 54.320 ;
+    RECT 0 54.390 0.070 54.600 ;
+    RECT 0 54.670 0.070 54.880 ;
+    RECT 0 54.950 0.070 55.160 ;
+    RECT 0 55.230 0.070 55.440 ;
+    RECT 0 55.510 0.070 55.720 ;
+    RECT 0 55.790 0.070 56.000 ;
+    RECT 0 56.070 0.070 56.280 ;
+    RECT 0 56.350 0.070 56.560 ;
+    RECT 0 56.630 0.070 56.840 ;
+    RECT 0 56.910 0.070 57.120 ;
+    RECT 0 57.190 0.070 57.400 ;
+    RECT 0 57.470 0.070 57.680 ;
+    RECT 0 57.750 0.070 57.960 ;
+    RECT 0 58.030 0.070 58.240 ;
+    RECT 0 58.310 0.070 58.520 ;
+    RECT 0 58.590 0.070 58.800 ;
+    RECT 0 58.870 0.070 59.080 ;
+    RECT 0 59.150 0.070 59.360 ;
+    RECT 0 59.430 0.070 59.640 ;
+    RECT 0 59.710 0.070 61.600 ;
+    RECT 0 61.670 0.070 61.880 ;
+    RECT 0 61.950 0.070 62.160 ;
+    RECT 0 62.230 0.070 62.440 ;
+    RECT 0 62.510 0.070 62.720 ;
+    RECT 0 62.790 0.070 63.000 ;
+    RECT 0 63.070 0.070 63.280 ;
+    RECT 0 63.350 0.070 65.240 ;
+    RECT 0 65.310 0.070 65.520 ;
+    RECT 0 65.590 0.070 65.800 ;
+    RECT 0 65.870 0.070 70.000 ;
+    LAYER metal4 ;
+    RECT 0 0 78.280 2.800 ;
+    RECT 0 67.200 78.280 70.000 ;
+    RECT 0.000 2.800 2.660 67.200 ;
+    RECT 2.940 2.800 4.900 67.200 ;
+    RECT 5.180 2.800 7.140 67.200 ;
+    RECT 7.420 2.800 9.380 67.200 ;
+    RECT 9.660 2.800 11.620 67.200 ;
+    RECT 11.900 2.800 13.860 67.200 ;
+    RECT 14.140 2.800 16.100 67.200 ;
+    RECT 16.380 2.800 18.340 67.200 ;
+    RECT 18.620 2.800 20.580 67.200 ;
+    RECT 20.860 2.800 22.820 67.200 ;
+    RECT 23.100 2.800 25.060 67.200 ;
+    RECT 25.340 2.800 27.300 67.200 ;
+    RECT 27.580 2.800 29.540 67.200 ;
+    RECT 29.820 2.800 31.780 67.200 ;
+    RECT 32.060 2.800 34.020 67.200 ;
+    RECT 34.300 2.800 36.260 67.200 ;
+    RECT 36.540 2.800 38.500 67.200 ;
+    RECT 38.780 2.800 40.740 67.200 ;
+    RECT 41.020 2.800 42.980 67.200 ;
+    RECT 43.260 2.800 45.220 67.200 ;
+    RECT 45.500 2.800 47.460 67.200 ;
+    RECT 47.740 2.800 49.700 67.200 ;
+    RECT 49.980 2.800 51.940 67.200 ;
+    RECT 52.220 2.800 54.180 67.200 ;
+    RECT 54.460 2.800 56.420 67.200 ;
+    RECT 56.700 2.800 58.660 67.200 ;
+    RECT 58.940 2.800 60.900 67.200 ;
+    RECT 61.180 2.800 63.140 67.200 ;
+    RECT 63.420 2.800 65.380 67.200 ;
+    RECT 65.660 2.800 67.620 67.200 ;
+    RECT 67.900 2.800 69.860 67.200 ;
+    RECT 70.140 2.800 72.100 67.200 ;
+    RECT 72.380 2.800 74.340 67.200 ;
+    RECT 74.620 2.800 78.280 67.200 ;
+    LAYER OVERLAP ;
+    RECT 0 0 78.280 70.000 ;
+  END
+END fakeram45_128x64
+
+END LIBRARY

--- a/flow/platforms/nangate45/lef/fakeram45_64x25.lef
+++ b/flow/platforms/nangate45/lef/fakeram45_64x25.lef
@@ -1,0 +1,893 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram45_64x25
+  FOREIGN fakeram45_64x25 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 20.140 BY 61.600 ;
+  CLASS BLOCK ;
+  PIN w_mask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 2.800 0.070 2.870 ;
+    END
+  END w_mask_in[0]
+  PIN w_mask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.360 0.070 3.430 ;
+    END
+  END w_mask_in[1]
+  PIN w_mask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.920 0.070 3.990 ;
+    END
+  END w_mask_in[2]
+  PIN w_mask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.480 0.070 4.550 ;
+    END
+  END w_mask_in[3]
+  PIN w_mask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.040 0.070 5.110 ;
+    END
+  END w_mask_in[4]
+  PIN w_mask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.600 0.070 5.670 ;
+    END
+  END w_mask_in[5]
+  PIN w_mask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.160 0.070 6.230 ;
+    END
+  END w_mask_in[6]
+  PIN w_mask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.720 0.070 6.790 ;
+    END
+  END w_mask_in[7]
+  PIN w_mask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.280 0.070 7.350 ;
+    END
+  END w_mask_in[8]
+  PIN w_mask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.840 0.070 7.910 ;
+    END
+  END w_mask_in[9]
+  PIN w_mask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.400 0.070 8.470 ;
+    END
+  END w_mask_in[10]
+  PIN w_mask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.960 0.070 9.030 ;
+    END
+  END w_mask_in[11]
+  PIN w_mask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.520 0.070 9.590 ;
+    END
+  END w_mask_in[12]
+  PIN w_mask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.080 0.070 10.150 ;
+    END
+  END w_mask_in[13]
+  PIN w_mask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.640 0.070 10.710 ;
+    END
+  END w_mask_in[14]
+  PIN w_mask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.200 0.070 11.270 ;
+    END
+  END w_mask_in[15]
+  PIN w_mask_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.760 0.070 11.830 ;
+    END
+  END w_mask_in[16]
+  PIN w_mask_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.320 0.070 12.390 ;
+    END
+  END w_mask_in[17]
+  PIN w_mask_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.880 0.070 12.950 ;
+    END
+  END w_mask_in[18]
+  PIN w_mask_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.440 0.070 13.510 ;
+    END
+  END w_mask_in[19]
+  PIN w_mask_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.000 0.070 14.070 ;
+    END
+  END w_mask_in[20]
+  PIN w_mask_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.560 0.070 14.630 ;
+    END
+  END w_mask_in[21]
+  PIN w_mask_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.120 0.070 15.190 ;
+    END
+  END w_mask_in[22]
+  PIN w_mask_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.680 0.070 15.750 ;
+    END
+  END w_mask_in[23]
+  PIN w_mask_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.240 0.070 16.310 ;
+    END
+  END w_mask_in[24]
+  PIN rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.200 0.070 18.270 ;
+    END
+  END rd_out[0]
+  PIN rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.760 0.070 18.830 ;
+    END
+  END rd_out[1]
+  PIN rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.320 0.070 19.390 ;
+    END
+  END rd_out[2]
+  PIN rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.880 0.070 19.950 ;
+    END
+  END rd_out[3]
+  PIN rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.440 0.070 20.510 ;
+    END
+  END rd_out[4]
+  PIN rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.000 0.070 21.070 ;
+    END
+  END rd_out[5]
+  PIN rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.560 0.070 21.630 ;
+    END
+  END rd_out[6]
+  PIN rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.120 0.070 22.190 ;
+    END
+  END rd_out[7]
+  PIN rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.680 0.070 22.750 ;
+    END
+  END rd_out[8]
+  PIN rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.240 0.070 23.310 ;
+    END
+  END rd_out[9]
+  PIN rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.800 0.070 23.870 ;
+    END
+  END rd_out[10]
+  PIN rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.360 0.070 24.430 ;
+    END
+  END rd_out[11]
+  PIN rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.920 0.070 24.990 ;
+    END
+  END rd_out[12]
+  PIN rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.480 0.070 25.550 ;
+    END
+  END rd_out[13]
+  PIN rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.040 0.070 26.110 ;
+    END
+  END rd_out[14]
+  PIN rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.600 0.070 26.670 ;
+    END
+  END rd_out[15]
+  PIN rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.160 0.070 27.230 ;
+    END
+  END rd_out[16]
+  PIN rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.720 0.070 27.790 ;
+    END
+  END rd_out[17]
+  PIN rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.280 0.070 28.350 ;
+    END
+  END rd_out[18]
+  PIN rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.840 0.070 28.910 ;
+    END
+  END rd_out[19]
+  PIN rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.400 0.070 29.470 ;
+    END
+  END rd_out[20]
+  PIN rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.960 0.070 30.030 ;
+    END
+  END rd_out[21]
+  PIN rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.520 0.070 30.590 ;
+    END
+  END rd_out[22]
+  PIN rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.080 0.070 31.150 ;
+    END
+  END rd_out[23]
+  PIN rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.640 0.070 31.710 ;
+    END
+  END rd_out[24]
+  PIN wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.600 0.070 33.670 ;
+    END
+  END wd_in[0]
+  PIN wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.160 0.070 34.230 ;
+    END
+  END wd_in[1]
+  PIN wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.720 0.070 34.790 ;
+    END
+  END wd_in[2]
+  PIN wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.280 0.070 35.350 ;
+    END
+  END wd_in[3]
+  PIN wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.840 0.070 35.910 ;
+    END
+  END wd_in[4]
+  PIN wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.400 0.070 36.470 ;
+    END
+  END wd_in[5]
+  PIN wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.960 0.070 37.030 ;
+    END
+  END wd_in[6]
+  PIN wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.520 0.070 37.590 ;
+    END
+  END wd_in[7]
+  PIN wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.080 0.070 38.150 ;
+    END
+  END wd_in[8]
+  PIN wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.640 0.070 38.710 ;
+    END
+  END wd_in[9]
+  PIN wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.200 0.070 39.270 ;
+    END
+  END wd_in[10]
+  PIN wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.760 0.070 39.830 ;
+    END
+  END wd_in[11]
+  PIN wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.320 0.070 40.390 ;
+    END
+  END wd_in[12]
+  PIN wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.880 0.070 40.950 ;
+    END
+  END wd_in[13]
+  PIN wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 41.440 0.070 41.510 ;
+    END
+  END wd_in[14]
+  PIN wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.000 0.070 42.070 ;
+    END
+  END wd_in[15]
+  PIN wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.560 0.070 42.630 ;
+    END
+  END wd_in[16]
+  PIN wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.120 0.070 43.190 ;
+    END
+  END wd_in[17]
+  PIN wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.680 0.070 43.750 ;
+    END
+  END wd_in[18]
+  PIN wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.240 0.070 44.310 ;
+    END
+  END wd_in[19]
+  PIN wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.800 0.070 44.870 ;
+    END
+  END wd_in[20]
+  PIN wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.360 0.070 45.430 ;
+    END
+  END wd_in[21]
+  PIN wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.920 0.070 45.990 ;
+    END
+  END wd_in[22]
+  PIN wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.480 0.070 46.550 ;
+    END
+  END wd_in[23]
+  PIN wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.040 0.070 47.110 ;
+    END
+  END wd_in[24]
+  PIN addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.000 0.070 49.070 ;
+    END
+  END addr_in[0]
+  PIN addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.560 0.070 49.630 ;
+    END
+  END addr_in[1]
+  PIN addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.120 0.070 50.190 ;
+    END
+  END addr_in[2]
+  PIN addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.680 0.070 50.750 ;
+    END
+  END addr_in[3]
+  PIN addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.240 0.070 51.310 ;
+    END
+  END addr_in[4]
+  PIN addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.800 0.070 51.870 ;
+    END
+  END addr_in[5]
+  PIN we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.760 0.070 53.830 ;
+    END
+  END we_in
+  PIN ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.320 0.070 54.390 ;
+    END
+  END ce_in
+  PIN clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.880 0.070 54.950 ;
+    END
+  END clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 2.660 2.800 2.940 58.800 ;
+      RECT 7.140 2.800 7.420 58.800 ;
+      RECT 11.620 2.800 11.900 58.800 ;
+      RECT 16.100 2.800 16.380 58.800 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 4.900 2.800 5.180 58.800 ;
+      RECT 9.380 2.800 9.660 58.800 ;
+      RECT 13.860 2.800 14.140 58.800 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 20.140 61.600 ;
+    LAYER metal2 ;
+    RECT 0 0 20.140 61.600 ;
+    LAYER metal3 ;
+    RECT 0.070 0 20.140 61.600 ;
+    RECT 0 0.000 0.070 2.800 ;
+    RECT 0 2.870 0.070 3.360 ;
+    RECT 0 3.430 0.070 3.920 ;
+    RECT 0 3.990 0.070 4.480 ;
+    RECT 0 4.550 0.070 5.040 ;
+    RECT 0 5.110 0.070 5.600 ;
+    RECT 0 5.670 0.070 6.160 ;
+    RECT 0 6.230 0.070 6.720 ;
+    RECT 0 6.790 0.070 7.280 ;
+    RECT 0 7.350 0.070 7.840 ;
+    RECT 0 7.910 0.070 8.400 ;
+    RECT 0 8.470 0.070 8.960 ;
+    RECT 0 9.030 0.070 9.520 ;
+    RECT 0 9.590 0.070 10.080 ;
+    RECT 0 10.150 0.070 10.640 ;
+    RECT 0 10.710 0.070 11.200 ;
+    RECT 0 11.270 0.070 11.760 ;
+    RECT 0 11.830 0.070 12.320 ;
+    RECT 0 12.390 0.070 12.880 ;
+    RECT 0 12.950 0.070 13.440 ;
+    RECT 0 13.510 0.070 14.000 ;
+    RECT 0 14.070 0.070 14.560 ;
+    RECT 0 14.630 0.070 15.120 ;
+    RECT 0 15.190 0.070 15.680 ;
+    RECT 0 15.750 0.070 16.240 ;
+    RECT 0 16.310 0.070 18.200 ;
+    RECT 0 18.270 0.070 18.760 ;
+    RECT 0 18.830 0.070 19.320 ;
+    RECT 0 19.390 0.070 19.880 ;
+    RECT 0 19.950 0.070 20.440 ;
+    RECT 0 20.510 0.070 21.000 ;
+    RECT 0 21.070 0.070 21.560 ;
+    RECT 0 21.630 0.070 22.120 ;
+    RECT 0 22.190 0.070 22.680 ;
+    RECT 0 22.750 0.070 23.240 ;
+    RECT 0 23.310 0.070 23.800 ;
+    RECT 0 23.870 0.070 24.360 ;
+    RECT 0 24.430 0.070 24.920 ;
+    RECT 0 24.990 0.070 25.480 ;
+    RECT 0 25.550 0.070 26.040 ;
+    RECT 0 26.110 0.070 26.600 ;
+    RECT 0 26.670 0.070 27.160 ;
+    RECT 0 27.230 0.070 27.720 ;
+    RECT 0 27.790 0.070 28.280 ;
+    RECT 0 28.350 0.070 28.840 ;
+    RECT 0 28.910 0.070 29.400 ;
+    RECT 0 29.470 0.070 29.960 ;
+    RECT 0 30.030 0.070 30.520 ;
+    RECT 0 30.590 0.070 31.080 ;
+    RECT 0 31.150 0.070 31.640 ;
+    RECT 0 31.710 0.070 33.600 ;
+    RECT 0 33.670 0.070 34.160 ;
+    RECT 0 34.230 0.070 34.720 ;
+    RECT 0 34.790 0.070 35.280 ;
+    RECT 0 35.350 0.070 35.840 ;
+    RECT 0 35.910 0.070 36.400 ;
+    RECT 0 36.470 0.070 36.960 ;
+    RECT 0 37.030 0.070 37.520 ;
+    RECT 0 37.590 0.070 38.080 ;
+    RECT 0 38.150 0.070 38.640 ;
+    RECT 0 38.710 0.070 39.200 ;
+    RECT 0 39.270 0.070 39.760 ;
+    RECT 0 39.830 0.070 40.320 ;
+    RECT 0 40.390 0.070 40.880 ;
+    RECT 0 40.950 0.070 41.440 ;
+    RECT 0 41.510 0.070 42.000 ;
+    RECT 0 42.070 0.070 42.560 ;
+    RECT 0 42.630 0.070 43.120 ;
+    RECT 0 43.190 0.070 43.680 ;
+    RECT 0 43.750 0.070 44.240 ;
+    RECT 0 44.310 0.070 44.800 ;
+    RECT 0 44.870 0.070 45.360 ;
+    RECT 0 45.430 0.070 45.920 ;
+    RECT 0 45.990 0.070 46.480 ;
+    RECT 0 46.550 0.070 47.040 ;
+    RECT 0 47.110 0.070 49.000 ;
+    RECT 0 49.070 0.070 49.560 ;
+    RECT 0 49.630 0.070 50.120 ;
+    RECT 0 50.190 0.070 50.680 ;
+    RECT 0 50.750 0.070 51.240 ;
+    RECT 0 51.310 0.070 51.800 ;
+    RECT 0 51.870 0.070 53.760 ;
+    RECT 0 53.830 0.070 54.320 ;
+    RECT 0 54.390 0.070 54.880 ;
+    RECT 0 54.950 0.070 61.600 ;
+    LAYER metal4 ;
+    RECT 0 0 20.140 2.800 ;
+    RECT 0 58.800 20.140 61.600 ;
+    RECT 0.000 2.800 2.660 58.800 ;
+    RECT 2.940 2.800 4.900 58.800 ;
+    RECT 5.180 2.800 7.140 58.800 ;
+    RECT 7.420 2.800 9.380 58.800 ;
+    RECT 9.660 2.800 11.620 58.800 ;
+    RECT 11.900 2.800 13.860 58.800 ;
+    RECT 14.140 2.800 16.100 58.800 ;
+    RECT 16.380 2.800 20.140 58.800 ;
+    LAYER OVERLAP ;
+    RECT 0 0 20.140 61.600 ;
+  END
+END fakeram45_64x25
+
+END LIBRARY

--- a/flow/platforms/nangate45/lef/fakeram45_64x256.lef
+++ b/flow/platforms/nangate45/lef/fakeram45_64x256.lef
@@ -1,0 +1,7941 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram45_64x256
+  FOREIGN fakeram45_64x256 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 151.810 BY 223.900 ;
+  CLASS BLOCK ;
+  PIN w_mask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 2.800 0.070 2.870 ;
+    END
+  END w_mask_in[0]
+  PIN w_mask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.080 0.070 3.150 ;
+    END
+  END w_mask_in[1]
+  PIN w_mask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.360 0.070 3.430 ;
+    END
+  END w_mask_in[2]
+  PIN w_mask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.640 0.070 3.710 ;
+    END
+  END w_mask_in[3]
+  PIN w_mask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.920 0.070 3.990 ;
+    END
+  END w_mask_in[4]
+  PIN w_mask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.200 0.070 4.270 ;
+    END
+  END w_mask_in[5]
+  PIN w_mask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.480 0.070 4.550 ;
+    END
+  END w_mask_in[6]
+  PIN w_mask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.760 0.070 4.830 ;
+    END
+  END w_mask_in[7]
+  PIN w_mask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.040 0.070 5.110 ;
+    END
+  END w_mask_in[8]
+  PIN w_mask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.320 0.070 5.390 ;
+    END
+  END w_mask_in[9]
+  PIN w_mask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.600 0.070 5.670 ;
+    END
+  END w_mask_in[10]
+  PIN w_mask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.880 0.070 5.950 ;
+    END
+  END w_mask_in[11]
+  PIN w_mask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.160 0.070 6.230 ;
+    END
+  END w_mask_in[12]
+  PIN w_mask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.440 0.070 6.510 ;
+    END
+  END w_mask_in[13]
+  PIN w_mask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.720 0.070 6.790 ;
+    END
+  END w_mask_in[14]
+  PIN w_mask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.000 0.070 7.070 ;
+    END
+  END w_mask_in[15]
+  PIN w_mask_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.280 0.070 7.350 ;
+    END
+  END w_mask_in[16]
+  PIN w_mask_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.560 0.070 7.630 ;
+    END
+  END w_mask_in[17]
+  PIN w_mask_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.840 0.070 7.910 ;
+    END
+  END w_mask_in[18]
+  PIN w_mask_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.120 0.070 8.190 ;
+    END
+  END w_mask_in[19]
+  PIN w_mask_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.400 0.070 8.470 ;
+    END
+  END w_mask_in[20]
+  PIN w_mask_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.680 0.070 8.750 ;
+    END
+  END w_mask_in[21]
+  PIN w_mask_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.960 0.070 9.030 ;
+    END
+  END w_mask_in[22]
+  PIN w_mask_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.240 0.070 9.310 ;
+    END
+  END w_mask_in[23]
+  PIN w_mask_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.520 0.070 9.590 ;
+    END
+  END w_mask_in[24]
+  PIN w_mask_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.800 0.070 9.870 ;
+    END
+  END w_mask_in[25]
+  PIN w_mask_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.080 0.070 10.150 ;
+    END
+  END w_mask_in[26]
+  PIN w_mask_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.360 0.070 10.430 ;
+    END
+  END w_mask_in[27]
+  PIN w_mask_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.640 0.070 10.710 ;
+    END
+  END w_mask_in[28]
+  PIN w_mask_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.920 0.070 10.990 ;
+    END
+  END w_mask_in[29]
+  PIN w_mask_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.200 0.070 11.270 ;
+    END
+  END w_mask_in[30]
+  PIN w_mask_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.480 0.070 11.550 ;
+    END
+  END w_mask_in[31]
+  PIN w_mask_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.760 0.070 11.830 ;
+    END
+  END w_mask_in[32]
+  PIN w_mask_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.040 0.070 12.110 ;
+    END
+  END w_mask_in[33]
+  PIN w_mask_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.320 0.070 12.390 ;
+    END
+  END w_mask_in[34]
+  PIN w_mask_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.600 0.070 12.670 ;
+    END
+  END w_mask_in[35]
+  PIN w_mask_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.880 0.070 12.950 ;
+    END
+  END w_mask_in[36]
+  PIN w_mask_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.160 0.070 13.230 ;
+    END
+  END w_mask_in[37]
+  PIN w_mask_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.440 0.070 13.510 ;
+    END
+  END w_mask_in[38]
+  PIN w_mask_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.720 0.070 13.790 ;
+    END
+  END w_mask_in[39]
+  PIN w_mask_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.000 0.070 14.070 ;
+    END
+  END w_mask_in[40]
+  PIN w_mask_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.280 0.070 14.350 ;
+    END
+  END w_mask_in[41]
+  PIN w_mask_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.560 0.070 14.630 ;
+    END
+  END w_mask_in[42]
+  PIN w_mask_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.840 0.070 14.910 ;
+    END
+  END w_mask_in[43]
+  PIN w_mask_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.120 0.070 15.190 ;
+    END
+  END w_mask_in[44]
+  PIN w_mask_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.400 0.070 15.470 ;
+    END
+  END w_mask_in[45]
+  PIN w_mask_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.680 0.070 15.750 ;
+    END
+  END w_mask_in[46]
+  PIN w_mask_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.960 0.070 16.030 ;
+    END
+  END w_mask_in[47]
+  PIN w_mask_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.240 0.070 16.310 ;
+    END
+  END w_mask_in[48]
+  PIN w_mask_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.520 0.070 16.590 ;
+    END
+  END w_mask_in[49]
+  PIN w_mask_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.800 0.070 16.870 ;
+    END
+  END w_mask_in[50]
+  PIN w_mask_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.080 0.070 17.150 ;
+    END
+  END w_mask_in[51]
+  PIN w_mask_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.360 0.070 17.430 ;
+    END
+  END w_mask_in[52]
+  PIN w_mask_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.640 0.070 17.710 ;
+    END
+  END w_mask_in[53]
+  PIN w_mask_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.920 0.070 17.990 ;
+    END
+  END w_mask_in[54]
+  PIN w_mask_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.200 0.070 18.270 ;
+    END
+  END w_mask_in[55]
+  PIN w_mask_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.480 0.070 18.550 ;
+    END
+  END w_mask_in[56]
+  PIN w_mask_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.760 0.070 18.830 ;
+    END
+  END w_mask_in[57]
+  PIN w_mask_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.040 0.070 19.110 ;
+    END
+  END w_mask_in[58]
+  PIN w_mask_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.320 0.070 19.390 ;
+    END
+  END w_mask_in[59]
+  PIN w_mask_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.600 0.070 19.670 ;
+    END
+  END w_mask_in[60]
+  PIN w_mask_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.880 0.070 19.950 ;
+    END
+  END w_mask_in[61]
+  PIN w_mask_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.160 0.070 20.230 ;
+    END
+  END w_mask_in[62]
+  PIN w_mask_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.440 0.070 20.510 ;
+    END
+  END w_mask_in[63]
+  PIN w_mask_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.720 0.070 20.790 ;
+    END
+  END w_mask_in[64]
+  PIN w_mask_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.000 0.070 21.070 ;
+    END
+  END w_mask_in[65]
+  PIN w_mask_in[66]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.280 0.070 21.350 ;
+    END
+  END w_mask_in[66]
+  PIN w_mask_in[67]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.560 0.070 21.630 ;
+    END
+  END w_mask_in[67]
+  PIN w_mask_in[68]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.840 0.070 21.910 ;
+    END
+  END w_mask_in[68]
+  PIN w_mask_in[69]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.120 0.070 22.190 ;
+    END
+  END w_mask_in[69]
+  PIN w_mask_in[70]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.400 0.070 22.470 ;
+    END
+  END w_mask_in[70]
+  PIN w_mask_in[71]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.680 0.070 22.750 ;
+    END
+  END w_mask_in[71]
+  PIN w_mask_in[72]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.960 0.070 23.030 ;
+    END
+  END w_mask_in[72]
+  PIN w_mask_in[73]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.240 0.070 23.310 ;
+    END
+  END w_mask_in[73]
+  PIN w_mask_in[74]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.520 0.070 23.590 ;
+    END
+  END w_mask_in[74]
+  PIN w_mask_in[75]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.800 0.070 23.870 ;
+    END
+  END w_mask_in[75]
+  PIN w_mask_in[76]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.080 0.070 24.150 ;
+    END
+  END w_mask_in[76]
+  PIN w_mask_in[77]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.360 0.070 24.430 ;
+    END
+  END w_mask_in[77]
+  PIN w_mask_in[78]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.640 0.070 24.710 ;
+    END
+  END w_mask_in[78]
+  PIN w_mask_in[79]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.920 0.070 24.990 ;
+    END
+  END w_mask_in[79]
+  PIN w_mask_in[80]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.200 0.070 25.270 ;
+    END
+  END w_mask_in[80]
+  PIN w_mask_in[81]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.480 0.070 25.550 ;
+    END
+  END w_mask_in[81]
+  PIN w_mask_in[82]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.760 0.070 25.830 ;
+    END
+  END w_mask_in[82]
+  PIN w_mask_in[83]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.040 0.070 26.110 ;
+    END
+  END w_mask_in[83]
+  PIN w_mask_in[84]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.320 0.070 26.390 ;
+    END
+  END w_mask_in[84]
+  PIN w_mask_in[85]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.600 0.070 26.670 ;
+    END
+  END w_mask_in[85]
+  PIN w_mask_in[86]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.880 0.070 26.950 ;
+    END
+  END w_mask_in[86]
+  PIN w_mask_in[87]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.160 0.070 27.230 ;
+    END
+  END w_mask_in[87]
+  PIN w_mask_in[88]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.440 0.070 27.510 ;
+    END
+  END w_mask_in[88]
+  PIN w_mask_in[89]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.720 0.070 27.790 ;
+    END
+  END w_mask_in[89]
+  PIN w_mask_in[90]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.000 0.070 28.070 ;
+    END
+  END w_mask_in[90]
+  PIN w_mask_in[91]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.280 0.070 28.350 ;
+    END
+  END w_mask_in[91]
+  PIN w_mask_in[92]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.560 0.070 28.630 ;
+    END
+  END w_mask_in[92]
+  PIN w_mask_in[93]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.840 0.070 28.910 ;
+    END
+  END w_mask_in[93]
+  PIN w_mask_in[94]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.120 0.070 29.190 ;
+    END
+  END w_mask_in[94]
+  PIN w_mask_in[95]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.400 0.070 29.470 ;
+    END
+  END w_mask_in[95]
+  PIN w_mask_in[96]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.680 0.070 29.750 ;
+    END
+  END w_mask_in[96]
+  PIN w_mask_in[97]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.960 0.070 30.030 ;
+    END
+  END w_mask_in[97]
+  PIN w_mask_in[98]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.240 0.070 30.310 ;
+    END
+  END w_mask_in[98]
+  PIN w_mask_in[99]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.520 0.070 30.590 ;
+    END
+  END w_mask_in[99]
+  PIN w_mask_in[100]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.800 0.070 30.870 ;
+    END
+  END w_mask_in[100]
+  PIN w_mask_in[101]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.080 0.070 31.150 ;
+    END
+  END w_mask_in[101]
+  PIN w_mask_in[102]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.360 0.070 31.430 ;
+    END
+  END w_mask_in[102]
+  PIN w_mask_in[103]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.640 0.070 31.710 ;
+    END
+  END w_mask_in[103]
+  PIN w_mask_in[104]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.920 0.070 31.990 ;
+    END
+  END w_mask_in[104]
+  PIN w_mask_in[105]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.200 0.070 32.270 ;
+    END
+  END w_mask_in[105]
+  PIN w_mask_in[106]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.480 0.070 32.550 ;
+    END
+  END w_mask_in[106]
+  PIN w_mask_in[107]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.760 0.070 32.830 ;
+    END
+  END w_mask_in[107]
+  PIN w_mask_in[108]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.040 0.070 33.110 ;
+    END
+  END w_mask_in[108]
+  PIN w_mask_in[109]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.320 0.070 33.390 ;
+    END
+  END w_mask_in[109]
+  PIN w_mask_in[110]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.600 0.070 33.670 ;
+    END
+  END w_mask_in[110]
+  PIN w_mask_in[111]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.880 0.070 33.950 ;
+    END
+  END w_mask_in[111]
+  PIN w_mask_in[112]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.160 0.070 34.230 ;
+    END
+  END w_mask_in[112]
+  PIN w_mask_in[113]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.440 0.070 34.510 ;
+    END
+  END w_mask_in[113]
+  PIN w_mask_in[114]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.720 0.070 34.790 ;
+    END
+  END w_mask_in[114]
+  PIN w_mask_in[115]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.000 0.070 35.070 ;
+    END
+  END w_mask_in[115]
+  PIN w_mask_in[116]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.280 0.070 35.350 ;
+    END
+  END w_mask_in[116]
+  PIN w_mask_in[117]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.560 0.070 35.630 ;
+    END
+  END w_mask_in[117]
+  PIN w_mask_in[118]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.840 0.070 35.910 ;
+    END
+  END w_mask_in[118]
+  PIN w_mask_in[119]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.120 0.070 36.190 ;
+    END
+  END w_mask_in[119]
+  PIN w_mask_in[120]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.400 0.070 36.470 ;
+    END
+  END w_mask_in[120]
+  PIN w_mask_in[121]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.680 0.070 36.750 ;
+    END
+  END w_mask_in[121]
+  PIN w_mask_in[122]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.960 0.070 37.030 ;
+    END
+  END w_mask_in[122]
+  PIN w_mask_in[123]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.240 0.070 37.310 ;
+    END
+  END w_mask_in[123]
+  PIN w_mask_in[124]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.520 0.070 37.590 ;
+    END
+  END w_mask_in[124]
+  PIN w_mask_in[125]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.800 0.070 37.870 ;
+    END
+  END w_mask_in[125]
+  PIN w_mask_in[126]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.080 0.070 38.150 ;
+    END
+  END w_mask_in[126]
+  PIN w_mask_in[127]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.360 0.070 38.430 ;
+    END
+  END w_mask_in[127]
+  PIN w_mask_in[128]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.640 0.070 38.710 ;
+    END
+  END w_mask_in[128]
+  PIN w_mask_in[129]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.920 0.070 38.990 ;
+    END
+  END w_mask_in[129]
+  PIN w_mask_in[130]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.200 0.070 39.270 ;
+    END
+  END w_mask_in[130]
+  PIN w_mask_in[131]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.480 0.070 39.550 ;
+    END
+  END w_mask_in[131]
+  PIN w_mask_in[132]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.760 0.070 39.830 ;
+    END
+  END w_mask_in[132]
+  PIN w_mask_in[133]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.040 0.070 40.110 ;
+    END
+  END w_mask_in[133]
+  PIN w_mask_in[134]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.320 0.070 40.390 ;
+    END
+  END w_mask_in[134]
+  PIN w_mask_in[135]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.600 0.070 40.670 ;
+    END
+  END w_mask_in[135]
+  PIN w_mask_in[136]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.880 0.070 40.950 ;
+    END
+  END w_mask_in[136]
+  PIN w_mask_in[137]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 41.160 0.070 41.230 ;
+    END
+  END w_mask_in[137]
+  PIN w_mask_in[138]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 41.440 0.070 41.510 ;
+    END
+  END w_mask_in[138]
+  PIN w_mask_in[139]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 41.720 0.070 41.790 ;
+    END
+  END w_mask_in[139]
+  PIN w_mask_in[140]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.000 0.070 42.070 ;
+    END
+  END w_mask_in[140]
+  PIN w_mask_in[141]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.280 0.070 42.350 ;
+    END
+  END w_mask_in[141]
+  PIN w_mask_in[142]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.560 0.070 42.630 ;
+    END
+  END w_mask_in[142]
+  PIN w_mask_in[143]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.840 0.070 42.910 ;
+    END
+  END w_mask_in[143]
+  PIN w_mask_in[144]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.120 0.070 43.190 ;
+    END
+  END w_mask_in[144]
+  PIN w_mask_in[145]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.400 0.070 43.470 ;
+    END
+  END w_mask_in[145]
+  PIN w_mask_in[146]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.680 0.070 43.750 ;
+    END
+  END w_mask_in[146]
+  PIN w_mask_in[147]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.960 0.070 44.030 ;
+    END
+  END w_mask_in[147]
+  PIN w_mask_in[148]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.240 0.070 44.310 ;
+    END
+  END w_mask_in[148]
+  PIN w_mask_in[149]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.520 0.070 44.590 ;
+    END
+  END w_mask_in[149]
+  PIN w_mask_in[150]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.800 0.070 44.870 ;
+    END
+  END w_mask_in[150]
+  PIN w_mask_in[151]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.080 0.070 45.150 ;
+    END
+  END w_mask_in[151]
+  PIN w_mask_in[152]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.360 0.070 45.430 ;
+    END
+  END w_mask_in[152]
+  PIN w_mask_in[153]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.640 0.070 45.710 ;
+    END
+  END w_mask_in[153]
+  PIN w_mask_in[154]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.920 0.070 45.990 ;
+    END
+  END w_mask_in[154]
+  PIN w_mask_in[155]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.200 0.070 46.270 ;
+    END
+  END w_mask_in[155]
+  PIN w_mask_in[156]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.480 0.070 46.550 ;
+    END
+  END w_mask_in[156]
+  PIN w_mask_in[157]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.760 0.070 46.830 ;
+    END
+  END w_mask_in[157]
+  PIN w_mask_in[158]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.040 0.070 47.110 ;
+    END
+  END w_mask_in[158]
+  PIN w_mask_in[159]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.320 0.070 47.390 ;
+    END
+  END w_mask_in[159]
+  PIN w_mask_in[160]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.600 0.070 47.670 ;
+    END
+  END w_mask_in[160]
+  PIN w_mask_in[161]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.880 0.070 47.950 ;
+    END
+  END w_mask_in[161]
+  PIN w_mask_in[162]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.160 0.070 48.230 ;
+    END
+  END w_mask_in[162]
+  PIN w_mask_in[163]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.440 0.070 48.510 ;
+    END
+  END w_mask_in[163]
+  PIN w_mask_in[164]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.720 0.070 48.790 ;
+    END
+  END w_mask_in[164]
+  PIN w_mask_in[165]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.000 0.070 49.070 ;
+    END
+  END w_mask_in[165]
+  PIN w_mask_in[166]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.280 0.070 49.350 ;
+    END
+  END w_mask_in[166]
+  PIN w_mask_in[167]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.560 0.070 49.630 ;
+    END
+  END w_mask_in[167]
+  PIN w_mask_in[168]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.840 0.070 49.910 ;
+    END
+  END w_mask_in[168]
+  PIN w_mask_in[169]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.120 0.070 50.190 ;
+    END
+  END w_mask_in[169]
+  PIN w_mask_in[170]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.400 0.070 50.470 ;
+    END
+  END w_mask_in[170]
+  PIN w_mask_in[171]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.680 0.070 50.750 ;
+    END
+  END w_mask_in[171]
+  PIN w_mask_in[172]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.960 0.070 51.030 ;
+    END
+  END w_mask_in[172]
+  PIN w_mask_in[173]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.240 0.070 51.310 ;
+    END
+  END w_mask_in[173]
+  PIN w_mask_in[174]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.520 0.070 51.590 ;
+    END
+  END w_mask_in[174]
+  PIN w_mask_in[175]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.800 0.070 51.870 ;
+    END
+  END w_mask_in[175]
+  PIN w_mask_in[176]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.080 0.070 52.150 ;
+    END
+  END w_mask_in[176]
+  PIN w_mask_in[177]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.360 0.070 52.430 ;
+    END
+  END w_mask_in[177]
+  PIN w_mask_in[178]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.640 0.070 52.710 ;
+    END
+  END w_mask_in[178]
+  PIN w_mask_in[179]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.920 0.070 52.990 ;
+    END
+  END w_mask_in[179]
+  PIN w_mask_in[180]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.200 0.070 53.270 ;
+    END
+  END w_mask_in[180]
+  PIN w_mask_in[181]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.480 0.070 53.550 ;
+    END
+  END w_mask_in[181]
+  PIN w_mask_in[182]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.760 0.070 53.830 ;
+    END
+  END w_mask_in[182]
+  PIN w_mask_in[183]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.040 0.070 54.110 ;
+    END
+  END w_mask_in[183]
+  PIN w_mask_in[184]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.320 0.070 54.390 ;
+    END
+  END w_mask_in[184]
+  PIN w_mask_in[185]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.600 0.070 54.670 ;
+    END
+  END w_mask_in[185]
+  PIN w_mask_in[186]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.880 0.070 54.950 ;
+    END
+  END w_mask_in[186]
+  PIN w_mask_in[187]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.160 0.070 55.230 ;
+    END
+  END w_mask_in[187]
+  PIN w_mask_in[188]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.440 0.070 55.510 ;
+    END
+  END w_mask_in[188]
+  PIN w_mask_in[189]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.720 0.070 55.790 ;
+    END
+  END w_mask_in[189]
+  PIN w_mask_in[190]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.000 0.070 56.070 ;
+    END
+  END w_mask_in[190]
+  PIN w_mask_in[191]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.280 0.070 56.350 ;
+    END
+  END w_mask_in[191]
+  PIN w_mask_in[192]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.560 0.070 56.630 ;
+    END
+  END w_mask_in[192]
+  PIN w_mask_in[193]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 56.840 0.070 56.910 ;
+    END
+  END w_mask_in[193]
+  PIN w_mask_in[194]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.120 0.070 57.190 ;
+    END
+  END w_mask_in[194]
+  PIN w_mask_in[195]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.400 0.070 57.470 ;
+    END
+  END w_mask_in[195]
+  PIN w_mask_in[196]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.680 0.070 57.750 ;
+    END
+  END w_mask_in[196]
+  PIN w_mask_in[197]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 57.960 0.070 58.030 ;
+    END
+  END w_mask_in[197]
+  PIN w_mask_in[198]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.240 0.070 58.310 ;
+    END
+  END w_mask_in[198]
+  PIN w_mask_in[199]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.520 0.070 58.590 ;
+    END
+  END w_mask_in[199]
+  PIN w_mask_in[200]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 58.800 0.070 58.870 ;
+    END
+  END w_mask_in[200]
+  PIN w_mask_in[201]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.080 0.070 59.150 ;
+    END
+  END w_mask_in[201]
+  PIN w_mask_in[202]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.360 0.070 59.430 ;
+    END
+  END w_mask_in[202]
+  PIN w_mask_in[203]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.640 0.070 59.710 ;
+    END
+  END w_mask_in[203]
+  PIN w_mask_in[204]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 59.920 0.070 59.990 ;
+    END
+  END w_mask_in[204]
+  PIN w_mask_in[205]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 60.200 0.070 60.270 ;
+    END
+  END w_mask_in[205]
+  PIN w_mask_in[206]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 60.480 0.070 60.550 ;
+    END
+  END w_mask_in[206]
+  PIN w_mask_in[207]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 60.760 0.070 60.830 ;
+    END
+  END w_mask_in[207]
+  PIN w_mask_in[208]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.040 0.070 61.110 ;
+    END
+  END w_mask_in[208]
+  PIN w_mask_in[209]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.320 0.070 61.390 ;
+    END
+  END w_mask_in[209]
+  PIN w_mask_in[210]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.600 0.070 61.670 ;
+    END
+  END w_mask_in[210]
+  PIN w_mask_in[211]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 61.880 0.070 61.950 ;
+    END
+  END w_mask_in[211]
+  PIN w_mask_in[212]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.160 0.070 62.230 ;
+    END
+  END w_mask_in[212]
+  PIN w_mask_in[213]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.440 0.070 62.510 ;
+    END
+  END w_mask_in[213]
+  PIN w_mask_in[214]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 62.720 0.070 62.790 ;
+    END
+  END w_mask_in[214]
+  PIN w_mask_in[215]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.000 0.070 63.070 ;
+    END
+  END w_mask_in[215]
+  PIN w_mask_in[216]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.280 0.070 63.350 ;
+    END
+  END w_mask_in[216]
+  PIN w_mask_in[217]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.560 0.070 63.630 ;
+    END
+  END w_mask_in[217]
+  PIN w_mask_in[218]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 63.840 0.070 63.910 ;
+    END
+  END w_mask_in[218]
+  PIN w_mask_in[219]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 64.120 0.070 64.190 ;
+    END
+  END w_mask_in[219]
+  PIN w_mask_in[220]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 64.400 0.070 64.470 ;
+    END
+  END w_mask_in[220]
+  PIN w_mask_in[221]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 64.680 0.070 64.750 ;
+    END
+  END w_mask_in[221]
+  PIN w_mask_in[222]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 64.960 0.070 65.030 ;
+    END
+  END w_mask_in[222]
+  PIN w_mask_in[223]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.240 0.070 65.310 ;
+    END
+  END w_mask_in[223]
+  PIN w_mask_in[224]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.520 0.070 65.590 ;
+    END
+  END w_mask_in[224]
+  PIN w_mask_in[225]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 65.800 0.070 65.870 ;
+    END
+  END w_mask_in[225]
+  PIN w_mask_in[226]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 66.080 0.070 66.150 ;
+    END
+  END w_mask_in[226]
+  PIN w_mask_in[227]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 66.360 0.070 66.430 ;
+    END
+  END w_mask_in[227]
+  PIN w_mask_in[228]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 66.640 0.070 66.710 ;
+    END
+  END w_mask_in[228]
+  PIN w_mask_in[229]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 66.920 0.070 66.990 ;
+    END
+  END w_mask_in[229]
+  PIN w_mask_in[230]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 67.200 0.070 67.270 ;
+    END
+  END w_mask_in[230]
+  PIN w_mask_in[231]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 67.480 0.070 67.550 ;
+    END
+  END w_mask_in[231]
+  PIN w_mask_in[232]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 67.760 0.070 67.830 ;
+    END
+  END w_mask_in[232]
+  PIN w_mask_in[233]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 68.040 0.070 68.110 ;
+    END
+  END w_mask_in[233]
+  PIN w_mask_in[234]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 68.320 0.070 68.390 ;
+    END
+  END w_mask_in[234]
+  PIN w_mask_in[235]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 68.600 0.070 68.670 ;
+    END
+  END w_mask_in[235]
+  PIN w_mask_in[236]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 68.880 0.070 68.950 ;
+    END
+  END w_mask_in[236]
+  PIN w_mask_in[237]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 69.160 0.070 69.230 ;
+    END
+  END w_mask_in[237]
+  PIN w_mask_in[238]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 69.440 0.070 69.510 ;
+    END
+  END w_mask_in[238]
+  PIN w_mask_in[239]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 69.720 0.070 69.790 ;
+    END
+  END w_mask_in[239]
+  PIN w_mask_in[240]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 70.000 0.070 70.070 ;
+    END
+  END w_mask_in[240]
+  PIN w_mask_in[241]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 70.280 0.070 70.350 ;
+    END
+  END w_mask_in[241]
+  PIN w_mask_in[242]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 70.560 0.070 70.630 ;
+    END
+  END w_mask_in[242]
+  PIN w_mask_in[243]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 70.840 0.070 70.910 ;
+    END
+  END w_mask_in[243]
+  PIN w_mask_in[244]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 71.120 0.070 71.190 ;
+    END
+  END w_mask_in[244]
+  PIN w_mask_in[245]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 71.400 0.070 71.470 ;
+    END
+  END w_mask_in[245]
+  PIN w_mask_in[246]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 71.680 0.070 71.750 ;
+    END
+  END w_mask_in[246]
+  PIN w_mask_in[247]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 71.960 0.070 72.030 ;
+    END
+  END w_mask_in[247]
+  PIN w_mask_in[248]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 72.240 0.070 72.310 ;
+    END
+  END w_mask_in[248]
+  PIN w_mask_in[249]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 72.520 0.070 72.590 ;
+    END
+  END w_mask_in[249]
+  PIN w_mask_in[250]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 72.800 0.070 72.870 ;
+    END
+  END w_mask_in[250]
+  PIN w_mask_in[251]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 73.080 0.070 73.150 ;
+    END
+  END w_mask_in[251]
+  PIN w_mask_in[252]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 73.360 0.070 73.430 ;
+    END
+  END w_mask_in[252]
+  PIN w_mask_in[253]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 73.640 0.070 73.710 ;
+    END
+  END w_mask_in[253]
+  PIN w_mask_in[254]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 73.920 0.070 73.990 ;
+    END
+  END w_mask_in[254]
+  PIN w_mask_in[255]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 74.200 0.070 74.270 ;
+    END
+  END w_mask_in[255]
+  PIN rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 74.480 0.070 74.550 ;
+    END
+  END rd_out[0]
+  PIN rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 74.760 0.070 74.830 ;
+    END
+  END rd_out[1]
+  PIN rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 75.040 0.070 75.110 ;
+    END
+  END rd_out[2]
+  PIN rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 75.320 0.070 75.390 ;
+    END
+  END rd_out[3]
+  PIN rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 75.600 0.070 75.670 ;
+    END
+  END rd_out[4]
+  PIN rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 75.880 0.070 75.950 ;
+    END
+  END rd_out[5]
+  PIN rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 76.160 0.070 76.230 ;
+    END
+  END rd_out[6]
+  PIN rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 76.440 0.070 76.510 ;
+    END
+  END rd_out[7]
+  PIN rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 76.720 0.070 76.790 ;
+    END
+  END rd_out[8]
+  PIN rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 77.000 0.070 77.070 ;
+    END
+  END rd_out[9]
+  PIN rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 77.280 0.070 77.350 ;
+    END
+  END rd_out[10]
+  PIN rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 77.560 0.070 77.630 ;
+    END
+  END rd_out[11]
+  PIN rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 77.840 0.070 77.910 ;
+    END
+  END rd_out[12]
+  PIN rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 78.120 0.070 78.190 ;
+    END
+  END rd_out[13]
+  PIN rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 78.400 0.070 78.470 ;
+    END
+  END rd_out[14]
+  PIN rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 78.680 0.070 78.750 ;
+    END
+  END rd_out[15]
+  PIN rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 78.960 0.070 79.030 ;
+    END
+  END rd_out[16]
+  PIN rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 79.240 0.070 79.310 ;
+    END
+  END rd_out[17]
+  PIN rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 79.520 0.070 79.590 ;
+    END
+  END rd_out[18]
+  PIN rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 79.800 0.070 79.870 ;
+    END
+  END rd_out[19]
+  PIN rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 80.080 0.070 80.150 ;
+    END
+  END rd_out[20]
+  PIN rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 80.360 0.070 80.430 ;
+    END
+  END rd_out[21]
+  PIN rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 80.640 0.070 80.710 ;
+    END
+  END rd_out[22]
+  PIN rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 80.920 0.070 80.990 ;
+    END
+  END rd_out[23]
+  PIN rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 81.200 0.070 81.270 ;
+    END
+  END rd_out[24]
+  PIN rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 81.480 0.070 81.550 ;
+    END
+  END rd_out[25]
+  PIN rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 81.760 0.070 81.830 ;
+    END
+  END rd_out[26]
+  PIN rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 82.040 0.070 82.110 ;
+    END
+  END rd_out[27]
+  PIN rd_out[28]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 82.320 0.070 82.390 ;
+    END
+  END rd_out[28]
+  PIN rd_out[29]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 82.600 0.070 82.670 ;
+    END
+  END rd_out[29]
+  PIN rd_out[30]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 82.880 0.070 82.950 ;
+    END
+  END rd_out[30]
+  PIN rd_out[31]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 83.160 0.070 83.230 ;
+    END
+  END rd_out[31]
+  PIN rd_out[32]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 83.440 0.070 83.510 ;
+    END
+  END rd_out[32]
+  PIN rd_out[33]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 83.720 0.070 83.790 ;
+    END
+  END rd_out[33]
+  PIN rd_out[34]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 84.000 0.070 84.070 ;
+    END
+  END rd_out[34]
+  PIN rd_out[35]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 84.280 0.070 84.350 ;
+    END
+  END rd_out[35]
+  PIN rd_out[36]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 84.560 0.070 84.630 ;
+    END
+  END rd_out[36]
+  PIN rd_out[37]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 84.840 0.070 84.910 ;
+    END
+  END rd_out[37]
+  PIN rd_out[38]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 85.120 0.070 85.190 ;
+    END
+  END rd_out[38]
+  PIN rd_out[39]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 85.400 0.070 85.470 ;
+    END
+  END rd_out[39]
+  PIN rd_out[40]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 85.680 0.070 85.750 ;
+    END
+  END rd_out[40]
+  PIN rd_out[41]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 85.960 0.070 86.030 ;
+    END
+  END rd_out[41]
+  PIN rd_out[42]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 86.240 0.070 86.310 ;
+    END
+  END rd_out[42]
+  PIN rd_out[43]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 86.520 0.070 86.590 ;
+    END
+  END rd_out[43]
+  PIN rd_out[44]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 86.800 0.070 86.870 ;
+    END
+  END rd_out[44]
+  PIN rd_out[45]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 87.080 0.070 87.150 ;
+    END
+  END rd_out[45]
+  PIN rd_out[46]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 87.360 0.070 87.430 ;
+    END
+  END rd_out[46]
+  PIN rd_out[47]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 87.640 0.070 87.710 ;
+    END
+  END rd_out[47]
+  PIN rd_out[48]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 87.920 0.070 87.990 ;
+    END
+  END rd_out[48]
+  PIN rd_out[49]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 88.200 0.070 88.270 ;
+    END
+  END rd_out[49]
+  PIN rd_out[50]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 88.480 0.070 88.550 ;
+    END
+  END rd_out[50]
+  PIN rd_out[51]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 88.760 0.070 88.830 ;
+    END
+  END rd_out[51]
+  PIN rd_out[52]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 89.040 0.070 89.110 ;
+    END
+  END rd_out[52]
+  PIN rd_out[53]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 89.320 0.070 89.390 ;
+    END
+  END rd_out[53]
+  PIN rd_out[54]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 89.600 0.070 89.670 ;
+    END
+  END rd_out[54]
+  PIN rd_out[55]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 89.880 0.070 89.950 ;
+    END
+  END rd_out[55]
+  PIN rd_out[56]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 90.160 0.070 90.230 ;
+    END
+  END rd_out[56]
+  PIN rd_out[57]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 90.440 0.070 90.510 ;
+    END
+  END rd_out[57]
+  PIN rd_out[58]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 90.720 0.070 90.790 ;
+    END
+  END rd_out[58]
+  PIN rd_out[59]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 91.000 0.070 91.070 ;
+    END
+  END rd_out[59]
+  PIN rd_out[60]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 91.280 0.070 91.350 ;
+    END
+  END rd_out[60]
+  PIN rd_out[61]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 91.560 0.070 91.630 ;
+    END
+  END rd_out[61]
+  PIN rd_out[62]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 91.840 0.070 91.910 ;
+    END
+  END rd_out[62]
+  PIN rd_out[63]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 92.120 0.070 92.190 ;
+    END
+  END rd_out[63]
+  PIN rd_out[64]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 92.400 0.070 92.470 ;
+    END
+  END rd_out[64]
+  PIN rd_out[65]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 92.680 0.070 92.750 ;
+    END
+  END rd_out[65]
+  PIN rd_out[66]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 92.960 0.070 93.030 ;
+    END
+  END rd_out[66]
+  PIN rd_out[67]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 93.240 0.070 93.310 ;
+    END
+  END rd_out[67]
+  PIN rd_out[68]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 93.520 0.070 93.590 ;
+    END
+  END rd_out[68]
+  PIN rd_out[69]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 93.800 0.070 93.870 ;
+    END
+  END rd_out[69]
+  PIN rd_out[70]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 94.080 0.070 94.150 ;
+    END
+  END rd_out[70]
+  PIN rd_out[71]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 94.360 0.070 94.430 ;
+    END
+  END rd_out[71]
+  PIN rd_out[72]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 94.640 0.070 94.710 ;
+    END
+  END rd_out[72]
+  PIN rd_out[73]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 94.920 0.070 94.990 ;
+    END
+  END rd_out[73]
+  PIN rd_out[74]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 95.200 0.070 95.270 ;
+    END
+  END rd_out[74]
+  PIN rd_out[75]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 95.480 0.070 95.550 ;
+    END
+  END rd_out[75]
+  PIN rd_out[76]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 95.760 0.070 95.830 ;
+    END
+  END rd_out[76]
+  PIN rd_out[77]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 96.040 0.070 96.110 ;
+    END
+  END rd_out[77]
+  PIN rd_out[78]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 96.320 0.070 96.390 ;
+    END
+  END rd_out[78]
+  PIN rd_out[79]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 96.600 0.070 96.670 ;
+    END
+  END rd_out[79]
+  PIN rd_out[80]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 96.880 0.070 96.950 ;
+    END
+  END rd_out[80]
+  PIN rd_out[81]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 97.160 0.070 97.230 ;
+    END
+  END rd_out[81]
+  PIN rd_out[82]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 97.440 0.070 97.510 ;
+    END
+  END rd_out[82]
+  PIN rd_out[83]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 97.720 0.070 97.790 ;
+    END
+  END rd_out[83]
+  PIN rd_out[84]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 98.000 0.070 98.070 ;
+    END
+  END rd_out[84]
+  PIN rd_out[85]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 98.280 0.070 98.350 ;
+    END
+  END rd_out[85]
+  PIN rd_out[86]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 98.560 0.070 98.630 ;
+    END
+  END rd_out[86]
+  PIN rd_out[87]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 98.840 0.070 98.910 ;
+    END
+  END rd_out[87]
+  PIN rd_out[88]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 99.120 0.070 99.190 ;
+    END
+  END rd_out[88]
+  PIN rd_out[89]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 99.400 0.070 99.470 ;
+    END
+  END rd_out[89]
+  PIN rd_out[90]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 99.680 0.070 99.750 ;
+    END
+  END rd_out[90]
+  PIN rd_out[91]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 99.960 0.070 100.030 ;
+    END
+  END rd_out[91]
+  PIN rd_out[92]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 100.240 0.070 100.310 ;
+    END
+  END rd_out[92]
+  PIN rd_out[93]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 100.520 0.070 100.590 ;
+    END
+  END rd_out[93]
+  PIN rd_out[94]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 100.800 0.070 100.870 ;
+    END
+  END rd_out[94]
+  PIN rd_out[95]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 101.080 0.070 101.150 ;
+    END
+  END rd_out[95]
+  PIN rd_out[96]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 101.360 0.070 101.430 ;
+    END
+  END rd_out[96]
+  PIN rd_out[97]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 101.640 0.070 101.710 ;
+    END
+  END rd_out[97]
+  PIN rd_out[98]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 101.920 0.070 101.990 ;
+    END
+  END rd_out[98]
+  PIN rd_out[99]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 102.200 0.070 102.270 ;
+    END
+  END rd_out[99]
+  PIN rd_out[100]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 102.480 0.070 102.550 ;
+    END
+  END rd_out[100]
+  PIN rd_out[101]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 102.760 0.070 102.830 ;
+    END
+  END rd_out[101]
+  PIN rd_out[102]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 103.040 0.070 103.110 ;
+    END
+  END rd_out[102]
+  PIN rd_out[103]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 103.320 0.070 103.390 ;
+    END
+  END rd_out[103]
+  PIN rd_out[104]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 103.600 0.070 103.670 ;
+    END
+  END rd_out[104]
+  PIN rd_out[105]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 103.880 0.070 103.950 ;
+    END
+  END rd_out[105]
+  PIN rd_out[106]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 104.160 0.070 104.230 ;
+    END
+  END rd_out[106]
+  PIN rd_out[107]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 104.440 0.070 104.510 ;
+    END
+  END rd_out[107]
+  PIN rd_out[108]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 104.720 0.070 104.790 ;
+    END
+  END rd_out[108]
+  PIN rd_out[109]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 105.000 0.070 105.070 ;
+    END
+  END rd_out[109]
+  PIN rd_out[110]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 105.280 0.070 105.350 ;
+    END
+  END rd_out[110]
+  PIN rd_out[111]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 105.560 0.070 105.630 ;
+    END
+  END rd_out[111]
+  PIN rd_out[112]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 105.840 0.070 105.910 ;
+    END
+  END rd_out[112]
+  PIN rd_out[113]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 106.120 0.070 106.190 ;
+    END
+  END rd_out[113]
+  PIN rd_out[114]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 106.400 0.070 106.470 ;
+    END
+  END rd_out[114]
+  PIN rd_out[115]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 106.680 0.070 106.750 ;
+    END
+  END rd_out[115]
+  PIN rd_out[116]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 106.960 0.070 107.030 ;
+    END
+  END rd_out[116]
+  PIN rd_out[117]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 107.240 0.070 107.310 ;
+    END
+  END rd_out[117]
+  PIN rd_out[118]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 107.520 0.070 107.590 ;
+    END
+  END rd_out[118]
+  PIN rd_out[119]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 107.800 0.070 107.870 ;
+    END
+  END rd_out[119]
+  PIN rd_out[120]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 108.080 0.070 108.150 ;
+    END
+  END rd_out[120]
+  PIN rd_out[121]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 108.360 0.070 108.430 ;
+    END
+  END rd_out[121]
+  PIN rd_out[122]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 108.640 0.070 108.710 ;
+    END
+  END rd_out[122]
+  PIN rd_out[123]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 108.920 0.070 108.990 ;
+    END
+  END rd_out[123]
+  PIN rd_out[124]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 109.200 0.070 109.270 ;
+    END
+  END rd_out[124]
+  PIN rd_out[125]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 109.480 0.070 109.550 ;
+    END
+  END rd_out[125]
+  PIN rd_out[126]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 109.760 0.070 109.830 ;
+    END
+  END rd_out[126]
+  PIN rd_out[127]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 110.040 0.070 110.110 ;
+    END
+  END rd_out[127]
+  PIN rd_out[128]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 110.320 0.070 110.390 ;
+    END
+  END rd_out[128]
+  PIN rd_out[129]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 110.600 0.070 110.670 ;
+    END
+  END rd_out[129]
+  PIN rd_out[130]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 110.880 0.070 110.950 ;
+    END
+  END rd_out[130]
+  PIN rd_out[131]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 111.160 0.070 111.230 ;
+    END
+  END rd_out[131]
+  PIN rd_out[132]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 111.440 0.070 111.510 ;
+    END
+  END rd_out[132]
+  PIN rd_out[133]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 111.720 0.070 111.790 ;
+    END
+  END rd_out[133]
+  PIN rd_out[134]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 112.000 0.070 112.070 ;
+    END
+  END rd_out[134]
+  PIN rd_out[135]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 112.280 0.070 112.350 ;
+    END
+  END rd_out[135]
+  PIN rd_out[136]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 112.560 0.070 112.630 ;
+    END
+  END rd_out[136]
+  PIN rd_out[137]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 112.840 0.070 112.910 ;
+    END
+  END rd_out[137]
+  PIN rd_out[138]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 113.120 0.070 113.190 ;
+    END
+  END rd_out[138]
+  PIN rd_out[139]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 113.400 0.070 113.470 ;
+    END
+  END rd_out[139]
+  PIN rd_out[140]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 113.680 0.070 113.750 ;
+    END
+  END rd_out[140]
+  PIN rd_out[141]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 113.960 0.070 114.030 ;
+    END
+  END rd_out[141]
+  PIN rd_out[142]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 114.240 0.070 114.310 ;
+    END
+  END rd_out[142]
+  PIN rd_out[143]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 114.520 0.070 114.590 ;
+    END
+  END rd_out[143]
+  PIN rd_out[144]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 114.800 0.070 114.870 ;
+    END
+  END rd_out[144]
+  PIN rd_out[145]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 115.080 0.070 115.150 ;
+    END
+  END rd_out[145]
+  PIN rd_out[146]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 115.360 0.070 115.430 ;
+    END
+  END rd_out[146]
+  PIN rd_out[147]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 115.640 0.070 115.710 ;
+    END
+  END rd_out[147]
+  PIN rd_out[148]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 115.920 0.070 115.990 ;
+    END
+  END rd_out[148]
+  PIN rd_out[149]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 116.200 0.070 116.270 ;
+    END
+  END rd_out[149]
+  PIN rd_out[150]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 116.480 0.070 116.550 ;
+    END
+  END rd_out[150]
+  PIN rd_out[151]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 116.760 0.070 116.830 ;
+    END
+  END rd_out[151]
+  PIN rd_out[152]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 117.040 0.070 117.110 ;
+    END
+  END rd_out[152]
+  PIN rd_out[153]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 117.320 0.070 117.390 ;
+    END
+  END rd_out[153]
+  PIN rd_out[154]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 117.600 0.070 117.670 ;
+    END
+  END rd_out[154]
+  PIN rd_out[155]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 117.880 0.070 117.950 ;
+    END
+  END rd_out[155]
+  PIN rd_out[156]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 118.160 0.070 118.230 ;
+    END
+  END rd_out[156]
+  PIN rd_out[157]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 118.440 0.070 118.510 ;
+    END
+  END rd_out[157]
+  PIN rd_out[158]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 118.720 0.070 118.790 ;
+    END
+  END rd_out[158]
+  PIN rd_out[159]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 119.000 0.070 119.070 ;
+    END
+  END rd_out[159]
+  PIN rd_out[160]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 119.280 0.070 119.350 ;
+    END
+  END rd_out[160]
+  PIN rd_out[161]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 119.560 0.070 119.630 ;
+    END
+  END rd_out[161]
+  PIN rd_out[162]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 119.840 0.070 119.910 ;
+    END
+  END rd_out[162]
+  PIN rd_out[163]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 120.120 0.070 120.190 ;
+    END
+  END rd_out[163]
+  PIN rd_out[164]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 120.400 0.070 120.470 ;
+    END
+  END rd_out[164]
+  PIN rd_out[165]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 120.680 0.070 120.750 ;
+    END
+  END rd_out[165]
+  PIN rd_out[166]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 120.960 0.070 121.030 ;
+    END
+  END rd_out[166]
+  PIN rd_out[167]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 121.240 0.070 121.310 ;
+    END
+  END rd_out[167]
+  PIN rd_out[168]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 121.520 0.070 121.590 ;
+    END
+  END rd_out[168]
+  PIN rd_out[169]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 121.800 0.070 121.870 ;
+    END
+  END rd_out[169]
+  PIN rd_out[170]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 122.080 0.070 122.150 ;
+    END
+  END rd_out[170]
+  PIN rd_out[171]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 122.360 0.070 122.430 ;
+    END
+  END rd_out[171]
+  PIN rd_out[172]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 122.640 0.070 122.710 ;
+    END
+  END rd_out[172]
+  PIN rd_out[173]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 122.920 0.070 122.990 ;
+    END
+  END rd_out[173]
+  PIN rd_out[174]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 123.200 0.070 123.270 ;
+    END
+  END rd_out[174]
+  PIN rd_out[175]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 123.480 0.070 123.550 ;
+    END
+  END rd_out[175]
+  PIN rd_out[176]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 123.760 0.070 123.830 ;
+    END
+  END rd_out[176]
+  PIN rd_out[177]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 124.040 0.070 124.110 ;
+    END
+  END rd_out[177]
+  PIN rd_out[178]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 124.320 0.070 124.390 ;
+    END
+  END rd_out[178]
+  PIN rd_out[179]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 124.600 0.070 124.670 ;
+    END
+  END rd_out[179]
+  PIN rd_out[180]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 124.880 0.070 124.950 ;
+    END
+  END rd_out[180]
+  PIN rd_out[181]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 125.160 0.070 125.230 ;
+    END
+  END rd_out[181]
+  PIN rd_out[182]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 125.440 0.070 125.510 ;
+    END
+  END rd_out[182]
+  PIN rd_out[183]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 125.720 0.070 125.790 ;
+    END
+  END rd_out[183]
+  PIN rd_out[184]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 126.000 0.070 126.070 ;
+    END
+  END rd_out[184]
+  PIN rd_out[185]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 126.280 0.070 126.350 ;
+    END
+  END rd_out[185]
+  PIN rd_out[186]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 126.560 0.070 126.630 ;
+    END
+  END rd_out[186]
+  PIN rd_out[187]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 126.840 0.070 126.910 ;
+    END
+  END rd_out[187]
+  PIN rd_out[188]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 127.120 0.070 127.190 ;
+    END
+  END rd_out[188]
+  PIN rd_out[189]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 127.400 0.070 127.470 ;
+    END
+  END rd_out[189]
+  PIN rd_out[190]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 127.680 0.070 127.750 ;
+    END
+  END rd_out[190]
+  PIN rd_out[191]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 127.960 0.070 128.030 ;
+    END
+  END rd_out[191]
+  PIN rd_out[192]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 128.240 0.070 128.310 ;
+    END
+  END rd_out[192]
+  PIN rd_out[193]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 128.520 0.070 128.590 ;
+    END
+  END rd_out[193]
+  PIN rd_out[194]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 128.800 0.070 128.870 ;
+    END
+  END rd_out[194]
+  PIN rd_out[195]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 129.080 0.070 129.150 ;
+    END
+  END rd_out[195]
+  PIN rd_out[196]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 129.360 0.070 129.430 ;
+    END
+  END rd_out[196]
+  PIN rd_out[197]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 129.640 0.070 129.710 ;
+    END
+  END rd_out[197]
+  PIN rd_out[198]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 129.920 0.070 129.990 ;
+    END
+  END rd_out[198]
+  PIN rd_out[199]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 130.200 0.070 130.270 ;
+    END
+  END rd_out[199]
+  PIN rd_out[200]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 130.480 0.070 130.550 ;
+    END
+  END rd_out[200]
+  PIN rd_out[201]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 130.760 0.070 130.830 ;
+    END
+  END rd_out[201]
+  PIN rd_out[202]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 131.040 0.070 131.110 ;
+    END
+  END rd_out[202]
+  PIN rd_out[203]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 131.320 0.070 131.390 ;
+    END
+  END rd_out[203]
+  PIN rd_out[204]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 131.600 0.070 131.670 ;
+    END
+  END rd_out[204]
+  PIN rd_out[205]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 131.880 0.070 131.950 ;
+    END
+  END rd_out[205]
+  PIN rd_out[206]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 132.160 0.070 132.230 ;
+    END
+  END rd_out[206]
+  PIN rd_out[207]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 132.440 0.070 132.510 ;
+    END
+  END rd_out[207]
+  PIN rd_out[208]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 132.720 0.070 132.790 ;
+    END
+  END rd_out[208]
+  PIN rd_out[209]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 133.000 0.070 133.070 ;
+    END
+  END rd_out[209]
+  PIN rd_out[210]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 133.280 0.070 133.350 ;
+    END
+  END rd_out[210]
+  PIN rd_out[211]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 133.560 0.070 133.630 ;
+    END
+  END rd_out[211]
+  PIN rd_out[212]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 133.840 0.070 133.910 ;
+    END
+  END rd_out[212]
+  PIN rd_out[213]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 134.120 0.070 134.190 ;
+    END
+  END rd_out[213]
+  PIN rd_out[214]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 134.400 0.070 134.470 ;
+    END
+  END rd_out[214]
+  PIN rd_out[215]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 134.680 0.070 134.750 ;
+    END
+  END rd_out[215]
+  PIN rd_out[216]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 134.960 0.070 135.030 ;
+    END
+  END rd_out[216]
+  PIN rd_out[217]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 135.240 0.070 135.310 ;
+    END
+  END rd_out[217]
+  PIN rd_out[218]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 135.520 0.070 135.590 ;
+    END
+  END rd_out[218]
+  PIN rd_out[219]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 135.800 0.070 135.870 ;
+    END
+  END rd_out[219]
+  PIN rd_out[220]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 136.080 0.070 136.150 ;
+    END
+  END rd_out[220]
+  PIN rd_out[221]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 136.360 0.070 136.430 ;
+    END
+  END rd_out[221]
+  PIN rd_out[222]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 136.640 0.070 136.710 ;
+    END
+  END rd_out[222]
+  PIN rd_out[223]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 136.920 0.070 136.990 ;
+    END
+  END rd_out[223]
+  PIN rd_out[224]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 137.200 0.070 137.270 ;
+    END
+  END rd_out[224]
+  PIN rd_out[225]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 137.480 0.070 137.550 ;
+    END
+  END rd_out[225]
+  PIN rd_out[226]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 137.760 0.070 137.830 ;
+    END
+  END rd_out[226]
+  PIN rd_out[227]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 138.040 0.070 138.110 ;
+    END
+  END rd_out[227]
+  PIN rd_out[228]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 138.320 0.070 138.390 ;
+    END
+  END rd_out[228]
+  PIN rd_out[229]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 138.600 0.070 138.670 ;
+    END
+  END rd_out[229]
+  PIN rd_out[230]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 138.880 0.070 138.950 ;
+    END
+  END rd_out[230]
+  PIN rd_out[231]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 139.160 0.070 139.230 ;
+    END
+  END rd_out[231]
+  PIN rd_out[232]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 139.440 0.070 139.510 ;
+    END
+  END rd_out[232]
+  PIN rd_out[233]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 139.720 0.070 139.790 ;
+    END
+  END rd_out[233]
+  PIN rd_out[234]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 140.000 0.070 140.070 ;
+    END
+  END rd_out[234]
+  PIN rd_out[235]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 140.280 0.070 140.350 ;
+    END
+  END rd_out[235]
+  PIN rd_out[236]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 140.560 0.070 140.630 ;
+    END
+  END rd_out[236]
+  PIN rd_out[237]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 140.840 0.070 140.910 ;
+    END
+  END rd_out[237]
+  PIN rd_out[238]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 141.120 0.070 141.190 ;
+    END
+  END rd_out[238]
+  PIN rd_out[239]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 141.400 0.070 141.470 ;
+    END
+  END rd_out[239]
+  PIN rd_out[240]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 141.680 0.070 141.750 ;
+    END
+  END rd_out[240]
+  PIN rd_out[241]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 141.960 0.070 142.030 ;
+    END
+  END rd_out[241]
+  PIN rd_out[242]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 142.240 0.070 142.310 ;
+    END
+  END rd_out[242]
+  PIN rd_out[243]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 142.520 0.070 142.590 ;
+    END
+  END rd_out[243]
+  PIN rd_out[244]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 142.800 0.070 142.870 ;
+    END
+  END rd_out[244]
+  PIN rd_out[245]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 143.080 0.070 143.150 ;
+    END
+  END rd_out[245]
+  PIN rd_out[246]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 143.360 0.070 143.430 ;
+    END
+  END rd_out[246]
+  PIN rd_out[247]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 143.640 0.070 143.710 ;
+    END
+  END rd_out[247]
+  PIN rd_out[248]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 143.920 0.070 143.990 ;
+    END
+  END rd_out[248]
+  PIN rd_out[249]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 144.200 0.070 144.270 ;
+    END
+  END rd_out[249]
+  PIN rd_out[250]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 144.480 0.070 144.550 ;
+    END
+  END rd_out[250]
+  PIN rd_out[251]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 144.760 0.070 144.830 ;
+    END
+  END rd_out[251]
+  PIN rd_out[252]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 145.040 0.070 145.110 ;
+    END
+  END rd_out[252]
+  PIN rd_out[253]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 145.320 0.070 145.390 ;
+    END
+  END rd_out[253]
+  PIN rd_out[254]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 145.600 0.070 145.670 ;
+    END
+  END rd_out[254]
+  PIN rd_out[255]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 145.880 0.070 145.950 ;
+    END
+  END rd_out[255]
+  PIN wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 146.160 0.070 146.230 ;
+    END
+  END wd_in[0]
+  PIN wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 146.440 0.070 146.510 ;
+    END
+  END wd_in[1]
+  PIN wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 146.720 0.070 146.790 ;
+    END
+  END wd_in[2]
+  PIN wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 147.000 0.070 147.070 ;
+    END
+  END wd_in[3]
+  PIN wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 147.280 0.070 147.350 ;
+    END
+  END wd_in[4]
+  PIN wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 147.560 0.070 147.630 ;
+    END
+  END wd_in[5]
+  PIN wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 147.840 0.070 147.910 ;
+    END
+  END wd_in[6]
+  PIN wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 148.120 0.070 148.190 ;
+    END
+  END wd_in[7]
+  PIN wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 148.400 0.070 148.470 ;
+    END
+  END wd_in[8]
+  PIN wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 148.680 0.070 148.750 ;
+    END
+  END wd_in[9]
+  PIN wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 148.960 0.070 149.030 ;
+    END
+  END wd_in[10]
+  PIN wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 149.240 0.070 149.310 ;
+    END
+  END wd_in[11]
+  PIN wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 149.520 0.070 149.590 ;
+    END
+  END wd_in[12]
+  PIN wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 149.800 0.070 149.870 ;
+    END
+  END wd_in[13]
+  PIN wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 150.080 0.070 150.150 ;
+    END
+  END wd_in[14]
+  PIN wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 150.360 0.070 150.430 ;
+    END
+  END wd_in[15]
+  PIN wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 150.640 0.070 150.710 ;
+    END
+  END wd_in[16]
+  PIN wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 150.920 0.070 150.990 ;
+    END
+  END wd_in[17]
+  PIN wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 151.200 0.070 151.270 ;
+    END
+  END wd_in[18]
+  PIN wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 151.480 0.070 151.550 ;
+    END
+  END wd_in[19]
+  PIN wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 151.760 0.070 151.830 ;
+    END
+  END wd_in[20]
+  PIN wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 152.040 0.070 152.110 ;
+    END
+  END wd_in[21]
+  PIN wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 152.320 0.070 152.390 ;
+    END
+  END wd_in[22]
+  PIN wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 152.600 0.070 152.670 ;
+    END
+  END wd_in[23]
+  PIN wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 152.880 0.070 152.950 ;
+    END
+  END wd_in[24]
+  PIN wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 153.160 0.070 153.230 ;
+    END
+  END wd_in[25]
+  PIN wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 153.440 0.070 153.510 ;
+    END
+  END wd_in[26]
+  PIN wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 153.720 0.070 153.790 ;
+    END
+  END wd_in[27]
+  PIN wd_in[28]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 154.000 0.070 154.070 ;
+    END
+  END wd_in[28]
+  PIN wd_in[29]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 154.280 0.070 154.350 ;
+    END
+  END wd_in[29]
+  PIN wd_in[30]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 154.560 0.070 154.630 ;
+    END
+  END wd_in[30]
+  PIN wd_in[31]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 154.840 0.070 154.910 ;
+    END
+  END wd_in[31]
+  PIN wd_in[32]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 155.120 0.070 155.190 ;
+    END
+  END wd_in[32]
+  PIN wd_in[33]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 155.400 0.070 155.470 ;
+    END
+  END wd_in[33]
+  PIN wd_in[34]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 155.680 0.070 155.750 ;
+    END
+  END wd_in[34]
+  PIN wd_in[35]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 155.960 0.070 156.030 ;
+    END
+  END wd_in[35]
+  PIN wd_in[36]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 156.240 0.070 156.310 ;
+    END
+  END wd_in[36]
+  PIN wd_in[37]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 156.520 0.070 156.590 ;
+    END
+  END wd_in[37]
+  PIN wd_in[38]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 156.800 0.070 156.870 ;
+    END
+  END wd_in[38]
+  PIN wd_in[39]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 157.080 0.070 157.150 ;
+    END
+  END wd_in[39]
+  PIN wd_in[40]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 157.360 0.070 157.430 ;
+    END
+  END wd_in[40]
+  PIN wd_in[41]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 157.640 0.070 157.710 ;
+    END
+  END wd_in[41]
+  PIN wd_in[42]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 157.920 0.070 157.990 ;
+    END
+  END wd_in[42]
+  PIN wd_in[43]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 158.200 0.070 158.270 ;
+    END
+  END wd_in[43]
+  PIN wd_in[44]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 158.480 0.070 158.550 ;
+    END
+  END wd_in[44]
+  PIN wd_in[45]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 158.760 0.070 158.830 ;
+    END
+  END wd_in[45]
+  PIN wd_in[46]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 159.040 0.070 159.110 ;
+    END
+  END wd_in[46]
+  PIN wd_in[47]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 159.320 0.070 159.390 ;
+    END
+  END wd_in[47]
+  PIN wd_in[48]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 159.600 0.070 159.670 ;
+    END
+  END wd_in[48]
+  PIN wd_in[49]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 159.880 0.070 159.950 ;
+    END
+  END wd_in[49]
+  PIN wd_in[50]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 160.160 0.070 160.230 ;
+    END
+  END wd_in[50]
+  PIN wd_in[51]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 160.440 0.070 160.510 ;
+    END
+  END wd_in[51]
+  PIN wd_in[52]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 160.720 0.070 160.790 ;
+    END
+  END wd_in[52]
+  PIN wd_in[53]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 161.000 0.070 161.070 ;
+    END
+  END wd_in[53]
+  PIN wd_in[54]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 161.280 0.070 161.350 ;
+    END
+  END wd_in[54]
+  PIN wd_in[55]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 161.560 0.070 161.630 ;
+    END
+  END wd_in[55]
+  PIN wd_in[56]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 161.840 0.070 161.910 ;
+    END
+  END wd_in[56]
+  PIN wd_in[57]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 162.120 0.070 162.190 ;
+    END
+  END wd_in[57]
+  PIN wd_in[58]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 162.400 0.070 162.470 ;
+    END
+  END wd_in[58]
+  PIN wd_in[59]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 162.680 0.070 162.750 ;
+    END
+  END wd_in[59]
+  PIN wd_in[60]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 162.960 0.070 163.030 ;
+    END
+  END wd_in[60]
+  PIN wd_in[61]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 163.240 0.070 163.310 ;
+    END
+  END wd_in[61]
+  PIN wd_in[62]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 163.520 0.070 163.590 ;
+    END
+  END wd_in[62]
+  PIN wd_in[63]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 163.800 0.070 163.870 ;
+    END
+  END wd_in[63]
+  PIN wd_in[64]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 164.080 0.070 164.150 ;
+    END
+  END wd_in[64]
+  PIN wd_in[65]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 164.360 0.070 164.430 ;
+    END
+  END wd_in[65]
+  PIN wd_in[66]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 164.640 0.070 164.710 ;
+    END
+  END wd_in[66]
+  PIN wd_in[67]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 164.920 0.070 164.990 ;
+    END
+  END wd_in[67]
+  PIN wd_in[68]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 165.200 0.070 165.270 ;
+    END
+  END wd_in[68]
+  PIN wd_in[69]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 165.480 0.070 165.550 ;
+    END
+  END wd_in[69]
+  PIN wd_in[70]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 165.760 0.070 165.830 ;
+    END
+  END wd_in[70]
+  PIN wd_in[71]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 166.040 0.070 166.110 ;
+    END
+  END wd_in[71]
+  PIN wd_in[72]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 166.320 0.070 166.390 ;
+    END
+  END wd_in[72]
+  PIN wd_in[73]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 166.600 0.070 166.670 ;
+    END
+  END wd_in[73]
+  PIN wd_in[74]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 166.880 0.070 166.950 ;
+    END
+  END wd_in[74]
+  PIN wd_in[75]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 167.160 0.070 167.230 ;
+    END
+  END wd_in[75]
+  PIN wd_in[76]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 167.440 0.070 167.510 ;
+    END
+  END wd_in[76]
+  PIN wd_in[77]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 167.720 0.070 167.790 ;
+    END
+  END wd_in[77]
+  PIN wd_in[78]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 168.000 0.070 168.070 ;
+    END
+  END wd_in[78]
+  PIN wd_in[79]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 168.280 0.070 168.350 ;
+    END
+  END wd_in[79]
+  PIN wd_in[80]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 168.560 0.070 168.630 ;
+    END
+  END wd_in[80]
+  PIN wd_in[81]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 168.840 0.070 168.910 ;
+    END
+  END wd_in[81]
+  PIN wd_in[82]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 169.120 0.070 169.190 ;
+    END
+  END wd_in[82]
+  PIN wd_in[83]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 169.400 0.070 169.470 ;
+    END
+  END wd_in[83]
+  PIN wd_in[84]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 169.680 0.070 169.750 ;
+    END
+  END wd_in[84]
+  PIN wd_in[85]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 169.960 0.070 170.030 ;
+    END
+  END wd_in[85]
+  PIN wd_in[86]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 170.240 0.070 170.310 ;
+    END
+  END wd_in[86]
+  PIN wd_in[87]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 170.520 0.070 170.590 ;
+    END
+  END wd_in[87]
+  PIN wd_in[88]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 170.800 0.070 170.870 ;
+    END
+  END wd_in[88]
+  PIN wd_in[89]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 171.080 0.070 171.150 ;
+    END
+  END wd_in[89]
+  PIN wd_in[90]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 171.360 0.070 171.430 ;
+    END
+  END wd_in[90]
+  PIN wd_in[91]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 171.640 0.070 171.710 ;
+    END
+  END wd_in[91]
+  PIN wd_in[92]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 171.920 0.070 171.990 ;
+    END
+  END wd_in[92]
+  PIN wd_in[93]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 172.200 0.070 172.270 ;
+    END
+  END wd_in[93]
+  PIN wd_in[94]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 172.480 0.070 172.550 ;
+    END
+  END wd_in[94]
+  PIN wd_in[95]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 172.760 0.070 172.830 ;
+    END
+  END wd_in[95]
+  PIN wd_in[96]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 173.040 0.070 173.110 ;
+    END
+  END wd_in[96]
+  PIN wd_in[97]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 173.320 0.070 173.390 ;
+    END
+  END wd_in[97]
+  PIN wd_in[98]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 173.600 0.070 173.670 ;
+    END
+  END wd_in[98]
+  PIN wd_in[99]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 173.880 0.070 173.950 ;
+    END
+  END wd_in[99]
+  PIN wd_in[100]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 174.160 0.070 174.230 ;
+    END
+  END wd_in[100]
+  PIN wd_in[101]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 174.440 0.070 174.510 ;
+    END
+  END wd_in[101]
+  PIN wd_in[102]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 174.720 0.070 174.790 ;
+    END
+  END wd_in[102]
+  PIN wd_in[103]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 175.000 0.070 175.070 ;
+    END
+  END wd_in[103]
+  PIN wd_in[104]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 175.280 0.070 175.350 ;
+    END
+  END wd_in[104]
+  PIN wd_in[105]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 175.560 0.070 175.630 ;
+    END
+  END wd_in[105]
+  PIN wd_in[106]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 175.840 0.070 175.910 ;
+    END
+  END wd_in[106]
+  PIN wd_in[107]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 176.120 0.070 176.190 ;
+    END
+  END wd_in[107]
+  PIN wd_in[108]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 176.400 0.070 176.470 ;
+    END
+  END wd_in[108]
+  PIN wd_in[109]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 176.680 0.070 176.750 ;
+    END
+  END wd_in[109]
+  PIN wd_in[110]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 176.960 0.070 177.030 ;
+    END
+  END wd_in[110]
+  PIN wd_in[111]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 177.240 0.070 177.310 ;
+    END
+  END wd_in[111]
+  PIN wd_in[112]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 177.520 0.070 177.590 ;
+    END
+  END wd_in[112]
+  PIN wd_in[113]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 177.800 0.070 177.870 ;
+    END
+  END wd_in[113]
+  PIN wd_in[114]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 178.080 0.070 178.150 ;
+    END
+  END wd_in[114]
+  PIN wd_in[115]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 178.360 0.070 178.430 ;
+    END
+  END wd_in[115]
+  PIN wd_in[116]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 178.640 0.070 178.710 ;
+    END
+  END wd_in[116]
+  PIN wd_in[117]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 178.920 0.070 178.990 ;
+    END
+  END wd_in[117]
+  PIN wd_in[118]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 179.200 0.070 179.270 ;
+    END
+  END wd_in[118]
+  PIN wd_in[119]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 179.480 0.070 179.550 ;
+    END
+  END wd_in[119]
+  PIN wd_in[120]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 179.760 0.070 179.830 ;
+    END
+  END wd_in[120]
+  PIN wd_in[121]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 180.040 0.070 180.110 ;
+    END
+  END wd_in[121]
+  PIN wd_in[122]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 180.320 0.070 180.390 ;
+    END
+  END wd_in[122]
+  PIN wd_in[123]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 180.600 0.070 180.670 ;
+    END
+  END wd_in[123]
+  PIN wd_in[124]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 180.880 0.070 180.950 ;
+    END
+  END wd_in[124]
+  PIN wd_in[125]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 181.160 0.070 181.230 ;
+    END
+  END wd_in[125]
+  PIN wd_in[126]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 181.440 0.070 181.510 ;
+    END
+  END wd_in[126]
+  PIN wd_in[127]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 181.720 0.070 181.790 ;
+    END
+  END wd_in[127]
+  PIN wd_in[128]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 182.000 0.070 182.070 ;
+    END
+  END wd_in[128]
+  PIN wd_in[129]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 182.280 0.070 182.350 ;
+    END
+  END wd_in[129]
+  PIN wd_in[130]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 182.560 0.070 182.630 ;
+    END
+  END wd_in[130]
+  PIN wd_in[131]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 182.840 0.070 182.910 ;
+    END
+  END wd_in[131]
+  PIN wd_in[132]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 183.120 0.070 183.190 ;
+    END
+  END wd_in[132]
+  PIN wd_in[133]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 183.400 0.070 183.470 ;
+    END
+  END wd_in[133]
+  PIN wd_in[134]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 183.680 0.070 183.750 ;
+    END
+  END wd_in[134]
+  PIN wd_in[135]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 183.960 0.070 184.030 ;
+    END
+  END wd_in[135]
+  PIN wd_in[136]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 184.240 0.070 184.310 ;
+    END
+  END wd_in[136]
+  PIN wd_in[137]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 184.520 0.070 184.590 ;
+    END
+  END wd_in[137]
+  PIN wd_in[138]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 184.800 0.070 184.870 ;
+    END
+  END wd_in[138]
+  PIN wd_in[139]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 185.080 0.070 185.150 ;
+    END
+  END wd_in[139]
+  PIN wd_in[140]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 185.360 0.070 185.430 ;
+    END
+  END wd_in[140]
+  PIN wd_in[141]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 185.640 0.070 185.710 ;
+    END
+  END wd_in[141]
+  PIN wd_in[142]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 185.920 0.070 185.990 ;
+    END
+  END wd_in[142]
+  PIN wd_in[143]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 186.200 0.070 186.270 ;
+    END
+  END wd_in[143]
+  PIN wd_in[144]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 186.480 0.070 186.550 ;
+    END
+  END wd_in[144]
+  PIN wd_in[145]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 186.760 0.070 186.830 ;
+    END
+  END wd_in[145]
+  PIN wd_in[146]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 187.040 0.070 187.110 ;
+    END
+  END wd_in[146]
+  PIN wd_in[147]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 187.320 0.070 187.390 ;
+    END
+  END wd_in[147]
+  PIN wd_in[148]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 187.600 0.070 187.670 ;
+    END
+  END wd_in[148]
+  PIN wd_in[149]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 187.880 0.070 187.950 ;
+    END
+  END wd_in[149]
+  PIN wd_in[150]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 188.160 0.070 188.230 ;
+    END
+  END wd_in[150]
+  PIN wd_in[151]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 188.440 0.070 188.510 ;
+    END
+  END wd_in[151]
+  PIN wd_in[152]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 188.720 0.070 188.790 ;
+    END
+  END wd_in[152]
+  PIN wd_in[153]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 189.000 0.070 189.070 ;
+    END
+  END wd_in[153]
+  PIN wd_in[154]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 189.280 0.070 189.350 ;
+    END
+  END wd_in[154]
+  PIN wd_in[155]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 189.560 0.070 189.630 ;
+    END
+  END wd_in[155]
+  PIN wd_in[156]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 189.840 0.070 189.910 ;
+    END
+  END wd_in[156]
+  PIN wd_in[157]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 190.120 0.070 190.190 ;
+    END
+  END wd_in[157]
+  PIN wd_in[158]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 190.400 0.070 190.470 ;
+    END
+  END wd_in[158]
+  PIN wd_in[159]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 190.680 0.070 190.750 ;
+    END
+  END wd_in[159]
+  PIN wd_in[160]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 190.960 0.070 191.030 ;
+    END
+  END wd_in[160]
+  PIN wd_in[161]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 191.240 0.070 191.310 ;
+    END
+  END wd_in[161]
+  PIN wd_in[162]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 191.520 0.070 191.590 ;
+    END
+  END wd_in[162]
+  PIN wd_in[163]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 191.800 0.070 191.870 ;
+    END
+  END wd_in[163]
+  PIN wd_in[164]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 192.080 0.070 192.150 ;
+    END
+  END wd_in[164]
+  PIN wd_in[165]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 192.360 0.070 192.430 ;
+    END
+  END wd_in[165]
+  PIN wd_in[166]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 192.640 0.070 192.710 ;
+    END
+  END wd_in[166]
+  PIN wd_in[167]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 192.920 0.070 192.990 ;
+    END
+  END wd_in[167]
+  PIN wd_in[168]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 193.200 0.070 193.270 ;
+    END
+  END wd_in[168]
+  PIN wd_in[169]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 193.480 0.070 193.550 ;
+    END
+  END wd_in[169]
+  PIN wd_in[170]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 193.760 0.070 193.830 ;
+    END
+  END wd_in[170]
+  PIN wd_in[171]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 194.040 0.070 194.110 ;
+    END
+  END wd_in[171]
+  PIN wd_in[172]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 194.320 0.070 194.390 ;
+    END
+  END wd_in[172]
+  PIN wd_in[173]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 194.600 0.070 194.670 ;
+    END
+  END wd_in[173]
+  PIN wd_in[174]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 194.880 0.070 194.950 ;
+    END
+  END wd_in[174]
+  PIN wd_in[175]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 195.160 0.070 195.230 ;
+    END
+  END wd_in[175]
+  PIN wd_in[176]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 195.440 0.070 195.510 ;
+    END
+  END wd_in[176]
+  PIN wd_in[177]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 195.720 0.070 195.790 ;
+    END
+  END wd_in[177]
+  PIN wd_in[178]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 196.000 0.070 196.070 ;
+    END
+  END wd_in[178]
+  PIN wd_in[179]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 196.280 0.070 196.350 ;
+    END
+  END wd_in[179]
+  PIN wd_in[180]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 196.560 0.070 196.630 ;
+    END
+  END wd_in[180]
+  PIN wd_in[181]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 196.840 0.070 196.910 ;
+    END
+  END wd_in[181]
+  PIN wd_in[182]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 197.120 0.070 197.190 ;
+    END
+  END wd_in[182]
+  PIN wd_in[183]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 197.400 0.070 197.470 ;
+    END
+  END wd_in[183]
+  PIN wd_in[184]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 197.680 0.070 197.750 ;
+    END
+  END wd_in[184]
+  PIN wd_in[185]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 197.960 0.070 198.030 ;
+    END
+  END wd_in[185]
+  PIN wd_in[186]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 198.240 0.070 198.310 ;
+    END
+  END wd_in[186]
+  PIN wd_in[187]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 198.520 0.070 198.590 ;
+    END
+  END wd_in[187]
+  PIN wd_in[188]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 198.800 0.070 198.870 ;
+    END
+  END wd_in[188]
+  PIN wd_in[189]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 199.080 0.070 199.150 ;
+    END
+  END wd_in[189]
+  PIN wd_in[190]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 199.360 0.070 199.430 ;
+    END
+  END wd_in[190]
+  PIN wd_in[191]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 199.640 0.070 199.710 ;
+    END
+  END wd_in[191]
+  PIN wd_in[192]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 199.920 0.070 199.990 ;
+    END
+  END wd_in[192]
+  PIN wd_in[193]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 200.200 0.070 200.270 ;
+    END
+  END wd_in[193]
+  PIN wd_in[194]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 200.480 0.070 200.550 ;
+    END
+  END wd_in[194]
+  PIN wd_in[195]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 200.760 0.070 200.830 ;
+    END
+  END wd_in[195]
+  PIN wd_in[196]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 201.040 0.070 201.110 ;
+    END
+  END wd_in[196]
+  PIN wd_in[197]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 201.320 0.070 201.390 ;
+    END
+  END wd_in[197]
+  PIN wd_in[198]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 201.600 0.070 201.670 ;
+    END
+  END wd_in[198]
+  PIN wd_in[199]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 201.880 0.070 201.950 ;
+    END
+  END wd_in[199]
+  PIN wd_in[200]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 202.160 0.070 202.230 ;
+    END
+  END wd_in[200]
+  PIN wd_in[201]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 202.440 0.070 202.510 ;
+    END
+  END wd_in[201]
+  PIN wd_in[202]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 202.720 0.070 202.790 ;
+    END
+  END wd_in[202]
+  PIN wd_in[203]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 203.000 0.070 203.070 ;
+    END
+  END wd_in[203]
+  PIN wd_in[204]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 203.280 0.070 203.350 ;
+    END
+  END wd_in[204]
+  PIN wd_in[205]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 203.560 0.070 203.630 ;
+    END
+  END wd_in[205]
+  PIN wd_in[206]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 203.840 0.070 203.910 ;
+    END
+  END wd_in[206]
+  PIN wd_in[207]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 204.120 0.070 204.190 ;
+    END
+  END wd_in[207]
+  PIN wd_in[208]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 204.400 0.070 204.470 ;
+    END
+  END wd_in[208]
+  PIN wd_in[209]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 204.680 0.070 204.750 ;
+    END
+  END wd_in[209]
+  PIN wd_in[210]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 204.960 0.070 205.030 ;
+    END
+  END wd_in[210]
+  PIN wd_in[211]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 205.240 0.070 205.310 ;
+    END
+  END wd_in[211]
+  PIN wd_in[212]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 205.520 0.070 205.590 ;
+    END
+  END wd_in[212]
+  PIN wd_in[213]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 205.800 0.070 205.870 ;
+    END
+  END wd_in[213]
+  PIN wd_in[214]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 206.080 0.070 206.150 ;
+    END
+  END wd_in[214]
+  PIN wd_in[215]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 206.360 0.070 206.430 ;
+    END
+  END wd_in[215]
+  PIN wd_in[216]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 206.640 0.070 206.710 ;
+    END
+  END wd_in[216]
+  PIN wd_in[217]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 206.920 0.070 206.990 ;
+    END
+  END wd_in[217]
+  PIN wd_in[218]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 207.200 0.070 207.270 ;
+    END
+  END wd_in[218]
+  PIN wd_in[219]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 207.480 0.070 207.550 ;
+    END
+  END wd_in[219]
+  PIN wd_in[220]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 207.760 0.070 207.830 ;
+    END
+  END wd_in[220]
+  PIN wd_in[221]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 208.040 0.070 208.110 ;
+    END
+  END wd_in[221]
+  PIN wd_in[222]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 208.320 0.070 208.390 ;
+    END
+  END wd_in[222]
+  PIN wd_in[223]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 208.600 0.070 208.670 ;
+    END
+  END wd_in[223]
+  PIN wd_in[224]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 208.880 0.070 208.950 ;
+    END
+  END wd_in[224]
+  PIN wd_in[225]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 209.160 0.070 209.230 ;
+    END
+  END wd_in[225]
+  PIN wd_in[226]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 209.440 0.070 209.510 ;
+    END
+  END wd_in[226]
+  PIN wd_in[227]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 209.720 0.070 209.790 ;
+    END
+  END wd_in[227]
+  PIN wd_in[228]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 210.000 0.070 210.070 ;
+    END
+  END wd_in[228]
+  PIN wd_in[229]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 210.280 0.070 210.350 ;
+    END
+  END wd_in[229]
+  PIN wd_in[230]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 210.560 0.070 210.630 ;
+    END
+  END wd_in[230]
+  PIN wd_in[231]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 210.840 0.070 210.910 ;
+    END
+  END wd_in[231]
+  PIN wd_in[232]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 211.120 0.070 211.190 ;
+    END
+  END wd_in[232]
+  PIN wd_in[233]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 211.400 0.070 211.470 ;
+    END
+  END wd_in[233]
+  PIN wd_in[234]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 211.680 0.070 211.750 ;
+    END
+  END wd_in[234]
+  PIN wd_in[235]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 211.960 0.070 212.030 ;
+    END
+  END wd_in[235]
+  PIN wd_in[236]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 212.240 0.070 212.310 ;
+    END
+  END wd_in[236]
+  PIN wd_in[237]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 212.520 0.070 212.590 ;
+    END
+  END wd_in[237]
+  PIN wd_in[238]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 212.800 0.070 212.870 ;
+    END
+  END wd_in[238]
+  PIN wd_in[239]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 213.080 0.070 213.150 ;
+    END
+  END wd_in[239]
+  PIN wd_in[240]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 213.360 0.070 213.430 ;
+    END
+  END wd_in[240]
+  PIN wd_in[241]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 213.640 0.070 213.710 ;
+    END
+  END wd_in[241]
+  PIN wd_in[242]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 213.920 0.070 213.990 ;
+    END
+  END wd_in[242]
+  PIN wd_in[243]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 214.200 0.070 214.270 ;
+    END
+  END wd_in[243]
+  PIN wd_in[244]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 214.480 0.070 214.550 ;
+    END
+  END wd_in[244]
+  PIN wd_in[245]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 214.760 0.070 214.830 ;
+    END
+  END wd_in[245]
+  PIN wd_in[246]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 215.040 0.070 215.110 ;
+    END
+  END wd_in[246]
+  PIN wd_in[247]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 215.320 0.070 215.390 ;
+    END
+  END wd_in[247]
+  PIN wd_in[248]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 215.600 0.070 215.670 ;
+    END
+  END wd_in[248]
+  PIN wd_in[249]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 215.880 0.070 215.950 ;
+    END
+  END wd_in[249]
+  PIN wd_in[250]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 216.160 0.070 216.230 ;
+    END
+  END wd_in[250]
+  PIN wd_in[251]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 216.440 0.070 216.510 ;
+    END
+  END wd_in[251]
+  PIN wd_in[252]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 216.720 0.070 216.790 ;
+    END
+  END wd_in[252]
+  PIN wd_in[253]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 217.000 0.070 217.070 ;
+    END
+  END wd_in[253]
+  PIN wd_in[254]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 217.280 0.070 217.350 ;
+    END
+  END wd_in[254]
+  PIN wd_in[255]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 217.560 0.070 217.630 ;
+    END
+  END wd_in[255]
+  PIN addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 217.840 0.070 217.910 ;
+    END
+  END addr_in[0]
+  PIN addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 218.120 0.070 218.190 ;
+    END
+  END addr_in[1]
+  PIN addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 218.400 0.070 218.470 ;
+    END
+  END addr_in[2]
+  PIN addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 218.680 0.070 218.750 ;
+    END
+  END addr_in[3]
+  PIN addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 218.960 0.070 219.030 ;
+    END
+  END addr_in[4]
+  PIN addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 219.240 0.070 219.310 ;
+    END
+  END addr_in[5]
+  PIN we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 219.520 0.070 219.590 ;
+    END
+  END we_in
+  PIN ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 219.800 0.070 219.870 ;
+    END
+  END ce_in
+  PIN clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 220.080 0.070 220.150 ;
+    END
+  END clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 2.660 2.800 2.940 221.100 ;
+      RECT 7.140 2.800 7.420 221.100 ;
+      RECT 11.620 2.800 11.900 221.100 ;
+      RECT 16.100 2.800 16.380 221.100 ;
+      RECT 20.580 2.800 20.860 221.100 ;
+      RECT 25.060 2.800 25.340 221.100 ;
+      RECT 29.540 2.800 29.820 221.100 ;
+      RECT 34.020 2.800 34.300 221.100 ;
+      RECT 38.500 2.800 38.780 221.100 ;
+      RECT 42.980 2.800 43.260 221.100 ;
+      RECT 47.460 2.800 47.740 221.100 ;
+      RECT 51.940 2.800 52.220 221.100 ;
+      RECT 56.420 2.800 56.700 221.100 ;
+      RECT 60.900 2.800 61.180 221.100 ;
+      RECT 65.380 2.800 65.660 221.100 ;
+      RECT 69.860 2.800 70.140 221.100 ;
+      RECT 74.340 2.800 74.620 221.100 ;
+      RECT 78.820 2.800 79.100 221.100 ;
+      RECT 83.300 2.800 83.580 221.100 ;
+      RECT 87.780 2.800 88.060 221.100 ;
+      RECT 92.260 2.800 92.540 221.100 ;
+      RECT 96.740 2.800 97.020 221.100 ;
+      RECT 101.220 2.800 101.500 221.100 ;
+      RECT 105.700 2.800 105.980 221.100 ;
+      RECT 110.180 2.800 110.460 221.100 ;
+      RECT 114.660 2.800 114.940 221.100 ;
+      RECT 119.140 2.800 119.420 221.100 ;
+      RECT 123.620 2.800 123.900 221.100 ;
+      RECT 128.100 2.800 128.380 221.100 ;
+      RECT 132.580 2.800 132.860 221.100 ;
+      RECT 137.060 2.800 137.340 221.100 ;
+      RECT 141.540 2.800 141.820 221.100 ;
+      RECT 146.020 2.800 146.300 221.100 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 4.900 2.800 5.180 221.100 ;
+      RECT 9.380 2.800 9.660 221.100 ;
+      RECT 13.860 2.800 14.140 221.100 ;
+      RECT 18.340 2.800 18.620 221.100 ;
+      RECT 22.820 2.800 23.100 221.100 ;
+      RECT 27.300 2.800 27.580 221.100 ;
+      RECT 31.780 2.800 32.060 221.100 ;
+      RECT 36.260 2.800 36.540 221.100 ;
+      RECT 40.740 2.800 41.020 221.100 ;
+      RECT 45.220 2.800 45.500 221.100 ;
+      RECT 49.700 2.800 49.980 221.100 ;
+      RECT 54.180 2.800 54.460 221.100 ;
+      RECT 58.660 2.800 58.940 221.100 ;
+      RECT 63.140 2.800 63.420 221.100 ;
+      RECT 67.620 2.800 67.900 221.100 ;
+      RECT 72.100 2.800 72.380 221.100 ;
+      RECT 76.580 2.800 76.860 221.100 ;
+      RECT 81.060 2.800 81.340 221.100 ;
+      RECT 85.540 2.800 85.820 221.100 ;
+      RECT 90.020 2.800 90.300 221.100 ;
+      RECT 94.500 2.800 94.780 221.100 ;
+      RECT 98.980 2.800 99.260 221.100 ;
+      RECT 103.460 2.800 103.740 221.100 ;
+      RECT 107.940 2.800 108.220 221.100 ;
+      RECT 112.420 2.800 112.700 221.100 ;
+      RECT 116.900 2.800 117.180 221.100 ;
+      RECT 121.380 2.800 121.660 221.100 ;
+      RECT 125.860 2.800 126.140 221.100 ;
+      RECT 130.340 2.800 130.620 221.100 ;
+      RECT 134.820 2.800 135.100 221.100 ;
+      RECT 139.300 2.800 139.580 221.100 ;
+      RECT 143.780 2.800 144.060 221.100 ;
+      RECT 148.260 2.800 148.540 221.100 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 151.810 223.900 ;
+    LAYER metal2 ;
+    RECT 0 0 151.810 223.900 ;
+    LAYER metal3 ;
+    RECT 0.070 0 151.810 223.900 ;
+    RECT 0 0.000 0.070 2.800 ;
+    RECT 0 2.870 0.070 3.080 ;
+    RECT 0 3.150 0.070 3.360 ;
+    RECT 0 3.430 0.070 3.640 ;
+    RECT 0 3.710 0.070 3.920 ;
+    RECT 0 3.990 0.070 4.200 ;
+    RECT 0 4.270 0.070 4.480 ;
+    RECT 0 4.550 0.070 4.760 ;
+    RECT 0 4.830 0.070 5.040 ;
+    RECT 0 5.110 0.070 5.320 ;
+    RECT 0 5.390 0.070 5.600 ;
+    RECT 0 5.670 0.070 5.880 ;
+    RECT 0 5.950 0.070 6.160 ;
+    RECT 0 6.230 0.070 6.440 ;
+    RECT 0 6.510 0.070 6.720 ;
+    RECT 0 6.790 0.070 7.000 ;
+    RECT 0 7.070 0.070 7.280 ;
+    RECT 0 7.350 0.070 7.560 ;
+    RECT 0 7.630 0.070 7.840 ;
+    RECT 0 7.910 0.070 8.120 ;
+    RECT 0 8.190 0.070 8.400 ;
+    RECT 0 8.470 0.070 8.680 ;
+    RECT 0 8.750 0.070 8.960 ;
+    RECT 0 9.030 0.070 9.240 ;
+    RECT 0 9.310 0.070 9.520 ;
+    RECT 0 9.590 0.070 9.800 ;
+    RECT 0 9.870 0.070 10.080 ;
+    RECT 0 10.150 0.070 10.360 ;
+    RECT 0 10.430 0.070 10.640 ;
+    RECT 0 10.710 0.070 10.920 ;
+    RECT 0 10.990 0.070 11.200 ;
+    RECT 0 11.270 0.070 11.480 ;
+    RECT 0 11.550 0.070 11.760 ;
+    RECT 0 11.830 0.070 12.040 ;
+    RECT 0 12.110 0.070 12.320 ;
+    RECT 0 12.390 0.070 12.600 ;
+    RECT 0 12.670 0.070 12.880 ;
+    RECT 0 12.950 0.070 13.160 ;
+    RECT 0 13.230 0.070 13.440 ;
+    RECT 0 13.510 0.070 13.720 ;
+    RECT 0 13.790 0.070 14.000 ;
+    RECT 0 14.070 0.070 14.280 ;
+    RECT 0 14.350 0.070 14.560 ;
+    RECT 0 14.630 0.070 14.840 ;
+    RECT 0 14.910 0.070 15.120 ;
+    RECT 0 15.190 0.070 15.400 ;
+    RECT 0 15.470 0.070 15.680 ;
+    RECT 0 15.750 0.070 15.960 ;
+    RECT 0 16.030 0.070 16.240 ;
+    RECT 0 16.310 0.070 16.520 ;
+    RECT 0 16.590 0.070 16.800 ;
+    RECT 0 16.870 0.070 17.080 ;
+    RECT 0 17.150 0.070 17.360 ;
+    RECT 0 17.430 0.070 17.640 ;
+    RECT 0 17.710 0.070 17.920 ;
+    RECT 0 17.990 0.070 18.200 ;
+    RECT 0 18.270 0.070 18.480 ;
+    RECT 0 18.550 0.070 18.760 ;
+    RECT 0 18.830 0.070 19.040 ;
+    RECT 0 19.110 0.070 19.320 ;
+    RECT 0 19.390 0.070 19.600 ;
+    RECT 0 19.670 0.070 19.880 ;
+    RECT 0 19.950 0.070 20.160 ;
+    RECT 0 20.230 0.070 20.440 ;
+    RECT 0 20.510 0.070 20.720 ;
+    RECT 0 20.790 0.070 21.000 ;
+    RECT 0 21.070 0.070 21.280 ;
+    RECT 0 21.350 0.070 21.560 ;
+    RECT 0 21.630 0.070 21.840 ;
+    RECT 0 21.910 0.070 22.120 ;
+    RECT 0 22.190 0.070 22.400 ;
+    RECT 0 22.470 0.070 22.680 ;
+    RECT 0 22.750 0.070 22.960 ;
+    RECT 0 23.030 0.070 23.240 ;
+    RECT 0 23.310 0.070 23.520 ;
+    RECT 0 23.590 0.070 23.800 ;
+    RECT 0 23.870 0.070 24.080 ;
+    RECT 0 24.150 0.070 24.360 ;
+    RECT 0 24.430 0.070 24.640 ;
+    RECT 0 24.710 0.070 24.920 ;
+    RECT 0 24.990 0.070 25.200 ;
+    RECT 0 25.270 0.070 25.480 ;
+    RECT 0 25.550 0.070 25.760 ;
+    RECT 0 25.830 0.070 26.040 ;
+    RECT 0 26.110 0.070 26.320 ;
+    RECT 0 26.390 0.070 26.600 ;
+    RECT 0 26.670 0.070 26.880 ;
+    RECT 0 26.950 0.070 27.160 ;
+    RECT 0 27.230 0.070 27.440 ;
+    RECT 0 27.510 0.070 27.720 ;
+    RECT 0 27.790 0.070 28.000 ;
+    RECT 0 28.070 0.070 28.280 ;
+    RECT 0 28.350 0.070 28.560 ;
+    RECT 0 28.630 0.070 28.840 ;
+    RECT 0 28.910 0.070 29.120 ;
+    RECT 0 29.190 0.070 29.400 ;
+    RECT 0 29.470 0.070 29.680 ;
+    RECT 0 29.750 0.070 29.960 ;
+    RECT 0 30.030 0.070 30.240 ;
+    RECT 0 30.310 0.070 30.520 ;
+    RECT 0 30.590 0.070 30.800 ;
+    RECT 0 30.870 0.070 31.080 ;
+    RECT 0 31.150 0.070 31.360 ;
+    RECT 0 31.430 0.070 31.640 ;
+    RECT 0 31.710 0.070 31.920 ;
+    RECT 0 31.990 0.070 32.200 ;
+    RECT 0 32.270 0.070 32.480 ;
+    RECT 0 32.550 0.070 32.760 ;
+    RECT 0 32.830 0.070 33.040 ;
+    RECT 0 33.110 0.070 33.320 ;
+    RECT 0 33.390 0.070 33.600 ;
+    RECT 0 33.670 0.070 33.880 ;
+    RECT 0 33.950 0.070 34.160 ;
+    RECT 0 34.230 0.070 34.440 ;
+    RECT 0 34.510 0.070 34.720 ;
+    RECT 0 34.790 0.070 35.000 ;
+    RECT 0 35.070 0.070 35.280 ;
+    RECT 0 35.350 0.070 35.560 ;
+    RECT 0 35.630 0.070 35.840 ;
+    RECT 0 35.910 0.070 36.120 ;
+    RECT 0 36.190 0.070 36.400 ;
+    RECT 0 36.470 0.070 36.680 ;
+    RECT 0 36.750 0.070 36.960 ;
+    RECT 0 37.030 0.070 37.240 ;
+    RECT 0 37.310 0.070 37.520 ;
+    RECT 0 37.590 0.070 37.800 ;
+    RECT 0 37.870 0.070 38.080 ;
+    RECT 0 38.150 0.070 38.360 ;
+    RECT 0 38.430 0.070 38.640 ;
+    RECT 0 38.710 0.070 38.920 ;
+    RECT 0 38.990 0.070 39.200 ;
+    RECT 0 39.270 0.070 39.480 ;
+    RECT 0 39.550 0.070 39.760 ;
+    RECT 0 39.830 0.070 40.040 ;
+    RECT 0 40.110 0.070 40.320 ;
+    RECT 0 40.390 0.070 40.600 ;
+    RECT 0 40.670 0.070 40.880 ;
+    RECT 0 40.950 0.070 41.160 ;
+    RECT 0 41.230 0.070 41.440 ;
+    RECT 0 41.510 0.070 41.720 ;
+    RECT 0 41.790 0.070 42.000 ;
+    RECT 0 42.070 0.070 42.280 ;
+    RECT 0 42.350 0.070 42.560 ;
+    RECT 0 42.630 0.070 42.840 ;
+    RECT 0 42.910 0.070 43.120 ;
+    RECT 0 43.190 0.070 43.400 ;
+    RECT 0 43.470 0.070 43.680 ;
+    RECT 0 43.750 0.070 43.960 ;
+    RECT 0 44.030 0.070 44.240 ;
+    RECT 0 44.310 0.070 44.520 ;
+    RECT 0 44.590 0.070 44.800 ;
+    RECT 0 44.870 0.070 45.080 ;
+    RECT 0 45.150 0.070 45.360 ;
+    RECT 0 45.430 0.070 45.640 ;
+    RECT 0 45.710 0.070 45.920 ;
+    RECT 0 45.990 0.070 46.200 ;
+    RECT 0 46.270 0.070 46.480 ;
+    RECT 0 46.550 0.070 46.760 ;
+    RECT 0 46.830 0.070 47.040 ;
+    RECT 0 47.110 0.070 47.320 ;
+    RECT 0 47.390 0.070 47.600 ;
+    RECT 0 47.670 0.070 47.880 ;
+    RECT 0 47.950 0.070 48.160 ;
+    RECT 0 48.230 0.070 48.440 ;
+    RECT 0 48.510 0.070 48.720 ;
+    RECT 0 48.790 0.070 49.000 ;
+    RECT 0 49.070 0.070 49.280 ;
+    RECT 0 49.350 0.070 49.560 ;
+    RECT 0 49.630 0.070 49.840 ;
+    RECT 0 49.910 0.070 50.120 ;
+    RECT 0 50.190 0.070 50.400 ;
+    RECT 0 50.470 0.070 50.680 ;
+    RECT 0 50.750 0.070 50.960 ;
+    RECT 0 51.030 0.070 51.240 ;
+    RECT 0 51.310 0.070 51.520 ;
+    RECT 0 51.590 0.070 51.800 ;
+    RECT 0 51.870 0.070 52.080 ;
+    RECT 0 52.150 0.070 52.360 ;
+    RECT 0 52.430 0.070 52.640 ;
+    RECT 0 52.710 0.070 52.920 ;
+    RECT 0 52.990 0.070 53.200 ;
+    RECT 0 53.270 0.070 53.480 ;
+    RECT 0 53.550 0.070 53.760 ;
+    RECT 0 53.830 0.070 54.040 ;
+    RECT 0 54.110 0.070 54.320 ;
+    RECT 0 54.390 0.070 54.600 ;
+    RECT 0 54.670 0.070 54.880 ;
+    RECT 0 54.950 0.070 55.160 ;
+    RECT 0 55.230 0.070 55.440 ;
+    RECT 0 55.510 0.070 55.720 ;
+    RECT 0 55.790 0.070 56.000 ;
+    RECT 0 56.070 0.070 56.280 ;
+    RECT 0 56.350 0.070 56.560 ;
+    RECT 0 56.630 0.070 56.840 ;
+    RECT 0 56.910 0.070 57.120 ;
+    RECT 0 57.190 0.070 57.400 ;
+    RECT 0 57.470 0.070 57.680 ;
+    RECT 0 57.750 0.070 57.960 ;
+    RECT 0 58.030 0.070 58.240 ;
+    RECT 0 58.310 0.070 58.520 ;
+    RECT 0 58.590 0.070 58.800 ;
+    RECT 0 58.870 0.070 59.080 ;
+    RECT 0 59.150 0.070 59.360 ;
+    RECT 0 59.430 0.070 59.640 ;
+    RECT 0 59.710 0.070 59.920 ;
+    RECT 0 59.990 0.070 60.200 ;
+    RECT 0 60.270 0.070 60.480 ;
+    RECT 0 60.550 0.070 60.760 ;
+    RECT 0 60.830 0.070 61.040 ;
+    RECT 0 61.110 0.070 61.320 ;
+    RECT 0 61.390 0.070 61.600 ;
+    RECT 0 61.670 0.070 61.880 ;
+    RECT 0 61.950 0.070 62.160 ;
+    RECT 0 62.230 0.070 62.440 ;
+    RECT 0 62.510 0.070 62.720 ;
+    RECT 0 62.790 0.070 63.000 ;
+    RECT 0 63.070 0.070 63.280 ;
+    RECT 0 63.350 0.070 63.560 ;
+    RECT 0 63.630 0.070 63.840 ;
+    RECT 0 63.910 0.070 64.120 ;
+    RECT 0 64.190 0.070 64.400 ;
+    RECT 0 64.470 0.070 64.680 ;
+    RECT 0 64.750 0.070 64.960 ;
+    RECT 0 65.030 0.070 65.240 ;
+    RECT 0 65.310 0.070 65.520 ;
+    RECT 0 65.590 0.070 65.800 ;
+    RECT 0 65.870 0.070 66.080 ;
+    RECT 0 66.150 0.070 66.360 ;
+    RECT 0 66.430 0.070 66.640 ;
+    RECT 0 66.710 0.070 66.920 ;
+    RECT 0 66.990 0.070 67.200 ;
+    RECT 0 67.270 0.070 67.480 ;
+    RECT 0 67.550 0.070 67.760 ;
+    RECT 0 67.830 0.070 68.040 ;
+    RECT 0 68.110 0.070 68.320 ;
+    RECT 0 68.390 0.070 68.600 ;
+    RECT 0 68.670 0.070 68.880 ;
+    RECT 0 68.950 0.070 69.160 ;
+    RECT 0 69.230 0.070 69.440 ;
+    RECT 0 69.510 0.070 69.720 ;
+    RECT 0 69.790 0.070 70.000 ;
+    RECT 0 70.070 0.070 70.280 ;
+    RECT 0 70.350 0.070 70.560 ;
+    RECT 0 70.630 0.070 70.840 ;
+    RECT 0 70.910 0.070 71.120 ;
+    RECT 0 71.190 0.070 71.400 ;
+    RECT 0 71.470 0.070 71.680 ;
+    RECT 0 71.750 0.070 71.960 ;
+    RECT 0 72.030 0.070 72.240 ;
+    RECT 0 72.310 0.070 72.520 ;
+    RECT 0 72.590 0.070 72.800 ;
+    RECT 0 72.870 0.070 73.080 ;
+    RECT 0 73.150 0.070 73.360 ;
+    RECT 0 73.430 0.070 73.640 ;
+    RECT 0 73.710 0.070 73.920 ;
+    RECT 0 73.990 0.070 74.200 ;
+    RECT 0 74.270 0.070 74.480 ;
+    RECT 0 74.550 0.070 74.760 ;
+    RECT 0 74.830 0.070 75.040 ;
+    RECT 0 75.110 0.070 75.320 ;
+    RECT 0 75.390 0.070 75.600 ;
+    RECT 0 75.670 0.070 75.880 ;
+    RECT 0 75.950 0.070 76.160 ;
+    RECT 0 76.230 0.070 76.440 ;
+    RECT 0 76.510 0.070 76.720 ;
+    RECT 0 76.790 0.070 77.000 ;
+    RECT 0 77.070 0.070 77.280 ;
+    RECT 0 77.350 0.070 77.560 ;
+    RECT 0 77.630 0.070 77.840 ;
+    RECT 0 77.910 0.070 78.120 ;
+    RECT 0 78.190 0.070 78.400 ;
+    RECT 0 78.470 0.070 78.680 ;
+    RECT 0 78.750 0.070 78.960 ;
+    RECT 0 79.030 0.070 79.240 ;
+    RECT 0 79.310 0.070 79.520 ;
+    RECT 0 79.590 0.070 79.800 ;
+    RECT 0 79.870 0.070 80.080 ;
+    RECT 0 80.150 0.070 80.360 ;
+    RECT 0 80.430 0.070 80.640 ;
+    RECT 0 80.710 0.070 80.920 ;
+    RECT 0 80.990 0.070 81.200 ;
+    RECT 0 81.270 0.070 81.480 ;
+    RECT 0 81.550 0.070 81.760 ;
+    RECT 0 81.830 0.070 82.040 ;
+    RECT 0 82.110 0.070 82.320 ;
+    RECT 0 82.390 0.070 82.600 ;
+    RECT 0 82.670 0.070 82.880 ;
+    RECT 0 82.950 0.070 83.160 ;
+    RECT 0 83.230 0.070 83.440 ;
+    RECT 0 83.510 0.070 83.720 ;
+    RECT 0 83.790 0.070 84.000 ;
+    RECT 0 84.070 0.070 84.280 ;
+    RECT 0 84.350 0.070 84.560 ;
+    RECT 0 84.630 0.070 84.840 ;
+    RECT 0 84.910 0.070 85.120 ;
+    RECT 0 85.190 0.070 85.400 ;
+    RECT 0 85.470 0.070 85.680 ;
+    RECT 0 85.750 0.070 85.960 ;
+    RECT 0 86.030 0.070 86.240 ;
+    RECT 0 86.310 0.070 86.520 ;
+    RECT 0 86.590 0.070 86.800 ;
+    RECT 0 86.870 0.070 87.080 ;
+    RECT 0 87.150 0.070 87.360 ;
+    RECT 0 87.430 0.070 87.640 ;
+    RECT 0 87.710 0.070 87.920 ;
+    RECT 0 87.990 0.070 88.200 ;
+    RECT 0 88.270 0.070 88.480 ;
+    RECT 0 88.550 0.070 88.760 ;
+    RECT 0 88.830 0.070 89.040 ;
+    RECT 0 89.110 0.070 89.320 ;
+    RECT 0 89.390 0.070 89.600 ;
+    RECT 0 89.670 0.070 89.880 ;
+    RECT 0 89.950 0.070 90.160 ;
+    RECT 0 90.230 0.070 90.440 ;
+    RECT 0 90.510 0.070 90.720 ;
+    RECT 0 90.790 0.070 91.000 ;
+    RECT 0 91.070 0.070 91.280 ;
+    RECT 0 91.350 0.070 91.560 ;
+    RECT 0 91.630 0.070 91.840 ;
+    RECT 0 91.910 0.070 92.120 ;
+    RECT 0 92.190 0.070 92.400 ;
+    RECT 0 92.470 0.070 92.680 ;
+    RECT 0 92.750 0.070 92.960 ;
+    RECT 0 93.030 0.070 93.240 ;
+    RECT 0 93.310 0.070 93.520 ;
+    RECT 0 93.590 0.070 93.800 ;
+    RECT 0 93.870 0.070 94.080 ;
+    RECT 0 94.150 0.070 94.360 ;
+    RECT 0 94.430 0.070 94.640 ;
+    RECT 0 94.710 0.070 94.920 ;
+    RECT 0 94.990 0.070 95.200 ;
+    RECT 0 95.270 0.070 95.480 ;
+    RECT 0 95.550 0.070 95.760 ;
+    RECT 0 95.830 0.070 96.040 ;
+    RECT 0 96.110 0.070 96.320 ;
+    RECT 0 96.390 0.070 96.600 ;
+    RECT 0 96.670 0.070 96.880 ;
+    RECT 0 96.950 0.070 97.160 ;
+    RECT 0 97.230 0.070 97.440 ;
+    RECT 0 97.510 0.070 97.720 ;
+    RECT 0 97.790 0.070 98.000 ;
+    RECT 0 98.070 0.070 98.280 ;
+    RECT 0 98.350 0.070 98.560 ;
+    RECT 0 98.630 0.070 98.840 ;
+    RECT 0 98.910 0.070 99.120 ;
+    RECT 0 99.190 0.070 99.400 ;
+    RECT 0 99.470 0.070 99.680 ;
+    RECT 0 99.750 0.070 99.960 ;
+    RECT 0 100.030 0.070 100.240 ;
+    RECT 0 100.310 0.070 100.520 ;
+    RECT 0 100.590 0.070 100.800 ;
+    RECT 0 100.870 0.070 101.080 ;
+    RECT 0 101.150 0.070 101.360 ;
+    RECT 0 101.430 0.070 101.640 ;
+    RECT 0 101.710 0.070 101.920 ;
+    RECT 0 101.990 0.070 102.200 ;
+    RECT 0 102.270 0.070 102.480 ;
+    RECT 0 102.550 0.070 102.760 ;
+    RECT 0 102.830 0.070 103.040 ;
+    RECT 0 103.110 0.070 103.320 ;
+    RECT 0 103.390 0.070 103.600 ;
+    RECT 0 103.670 0.070 103.880 ;
+    RECT 0 103.950 0.070 104.160 ;
+    RECT 0 104.230 0.070 104.440 ;
+    RECT 0 104.510 0.070 104.720 ;
+    RECT 0 104.790 0.070 105.000 ;
+    RECT 0 105.070 0.070 105.280 ;
+    RECT 0 105.350 0.070 105.560 ;
+    RECT 0 105.630 0.070 105.840 ;
+    RECT 0 105.910 0.070 106.120 ;
+    RECT 0 106.190 0.070 106.400 ;
+    RECT 0 106.470 0.070 106.680 ;
+    RECT 0 106.750 0.070 106.960 ;
+    RECT 0 107.030 0.070 107.240 ;
+    RECT 0 107.310 0.070 107.520 ;
+    RECT 0 107.590 0.070 107.800 ;
+    RECT 0 107.870 0.070 108.080 ;
+    RECT 0 108.150 0.070 108.360 ;
+    RECT 0 108.430 0.070 108.640 ;
+    RECT 0 108.710 0.070 108.920 ;
+    RECT 0 108.990 0.070 109.200 ;
+    RECT 0 109.270 0.070 109.480 ;
+    RECT 0 109.550 0.070 109.760 ;
+    RECT 0 109.830 0.070 110.040 ;
+    RECT 0 110.110 0.070 110.320 ;
+    RECT 0 110.390 0.070 110.600 ;
+    RECT 0 110.670 0.070 110.880 ;
+    RECT 0 110.950 0.070 111.160 ;
+    RECT 0 111.230 0.070 111.440 ;
+    RECT 0 111.510 0.070 111.720 ;
+    RECT 0 111.790 0.070 112.000 ;
+    RECT 0 112.070 0.070 112.280 ;
+    RECT 0 112.350 0.070 112.560 ;
+    RECT 0 112.630 0.070 112.840 ;
+    RECT 0 112.910 0.070 113.120 ;
+    RECT 0 113.190 0.070 113.400 ;
+    RECT 0 113.470 0.070 113.680 ;
+    RECT 0 113.750 0.070 113.960 ;
+    RECT 0 114.030 0.070 114.240 ;
+    RECT 0 114.310 0.070 114.520 ;
+    RECT 0 114.590 0.070 114.800 ;
+    RECT 0 114.870 0.070 115.080 ;
+    RECT 0 115.150 0.070 115.360 ;
+    RECT 0 115.430 0.070 115.640 ;
+    RECT 0 115.710 0.070 115.920 ;
+    RECT 0 115.990 0.070 116.200 ;
+    RECT 0 116.270 0.070 116.480 ;
+    RECT 0 116.550 0.070 116.760 ;
+    RECT 0 116.830 0.070 117.040 ;
+    RECT 0 117.110 0.070 117.320 ;
+    RECT 0 117.390 0.070 117.600 ;
+    RECT 0 117.670 0.070 117.880 ;
+    RECT 0 117.950 0.070 118.160 ;
+    RECT 0 118.230 0.070 118.440 ;
+    RECT 0 118.510 0.070 118.720 ;
+    RECT 0 118.790 0.070 119.000 ;
+    RECT 0 119.070 0.070 119.280 ;
+    RECT 0 119.350 0.070 119.560 ;
+    RECT 0 119.630 0.070 119.840 ;
+    RECT 0 119.910 0.070 120.120 ;
+    RECT 0 120.190 0.070 120.400 ;
+    RECT 0 120.470 0.070 120.680 ;
+    RECT 0 120.750 0.070 120.960 ;
+    RECT 0 121.030 0.070 121.240 ;
+    RECT 0 121.310 0.070 121.520 ;
+    RECT 0 121.590 0.070 121.800 ;
+    RECT 0 121.870 0.070 122.080 ;
+    RECT 0 122.150 0.070 122.360 ;
+    RECT 0 122.430 0.070 122.640 ;
+    RECT 0 122.710 0.070 122.920 ;
+    RECT 0 122.990 0.070 123.200 ;
+    RECT 0 123.270 0.070 123.480 ;
+    RECT 0 123.550 0.070 123.760 ;
+    RECT 0 123.830 0.070 124.040 ;
+    RECT 0 124.110 0.070 124.320 ;
+    RECT 0 124.390 0.070 124.600 ;
+    RECT 0 124.670 0.070 124.880 ;
+    RECT 0 124.950 0.070 125.160 ;
+    RECT 0 125.230 0.070 125.440 ;
+    RECT 0 125.510 0.070 125.720 ;
+    RECT 0 125.790 0.070 126.000 ;
+    RECT 0 126.070 0.070 126.280 ;
+    RECT 0 126.350 0.070 126.560 ;
+    RECT 0 126.630 0.070 126.840 ;
+    RECT 0 126.910 0.070 127.120 ;
+    RECT 0 127.190 0.070 127.400 ;
+    RECT 0 127.470 0.070 127.680 ;
+    RECT 0 127.750 0.070 127.960 ;
+    RECT 0 128.030 0.070 128.240 ;
+    RECT 0 128.310 0.070 128.520 ;
+    RECT 0 128.590 0.070 128.800 ;
+    RECT 0 128.870 0.070 129.080 ;
+    RECT 0 129.150 0.070 129.360 ;
+    RECT 0 129.430 0.070 129.640 ;
+    RECT 0 129.710 0.070 129.920 ;
+    RECT 0 129.990 0.070 130.200 ;
+    RECT 0 130.270 0.070 130.480 ;
+    RECT 0 130.550 0.070 130.760 ;
+    RECT 0 130.830 0.070 131.040 ;
+    RECT 0 131.110 0.070 131.320 ;
+    RECT 0 131.390 0.070 131.600 ;
+    RECT 0 131.670 0.070 131.880 ;
+    RECT 0 131.950 0.070 132.160 ;
+    RECT 0 132.230 0.070 132.440 ;
+    RECT 0 132.510 0.070 132.720 ;
+    RECT 0 132.790 0.070 133.000 ;
+    RECT 0 133.070 0.070 133.280 ;
+    RECT 0 133.350 0.070 133.560 ;
+    RECT 0 133.630 0.070 133.840 ;
+    RECT 0 133.910 0.070 134.120 ;
+    RECT 0 134.190 0.070 134.400 ;
+    RECT 0 134.470 0.070 134.680 ;
+    RECT 0 134.750 0.070 134.960 ;
+    RECT 0 135.030 0.070 135.240 ;
+    RECT 0 135.310 0.070 135.520 ;
+    RECT 0 135.590 0.070 135.800 ;
+    RECT 0 135.870 0.070 136.080 ;
+    RECT 0 136.150 0.070 136.360 ;
+    RECT 0 136.430 0.070 136.640 ;
+    RECT 0 136.710 0.070 136.920 ;
+    RECT 0 136.990 0.070 137.200 ;
+    RECT 0 137.270 0.070 137.480 ;
+    RECT 0 137.550 0.070 137.760 ;
+    RECT 0 137.830 0.070 138.040 ;
+    RECT 0 138.110 0.070 138.320 ;
+    RECT 0 138.390 0.070 138.600 ;
+    RECT 0 138.670 0.070 138.880 ;
+    RECT 0 138.950 0.070 139.160 ;
+    RECT 0 139.230 0.070 139.440 ;
+    RECT 0 139.510 0.070 139.720 ;
+    RECT 0 139.790 0.070 140.000 ;
+    RECT 0 140.070 0.070 140.280 ;
+    RECT 0 140.350 0.070 140.560 ;
+    RECT 0 140.630 0.070 140.840 ;
+    RECT 0 140.910 0.070 141.120 ;
+    RECT 0 141.190 0.070 141.400 ;
+    RECT 0 141.470 0.070 141.680 ;
+    RECT 0 141.750 0.070 141.960 ;
+    RECT 0 142.030 0.070 142.240 ;
+    RECT 0 142.310 0.070 142.520 ;
+    RECT 0 142.590 0.070 142.800 ;
+    RECT 0 142.870 0.070 143.080 ;
+    RECT 0 143.150 0.070 143.360 ;
+    RECT 0 143.430 0.070 143.640 ;
+    RECT 0 143.710 0.070 143.920 ;
+    RECT 0 143.990 0.070 144.200 ;
+    RECT 0 144.270 0.070 144.480 ;
+    RECT 0 144.550 0.070 144.760 ;
+    RECT 0 144.830 0.070 145.040 ;
+    RECT 0 145.110 0.070 145.320 ;
+    RECT 0 145.390 0.070 145.600 ;
+    RECT 0 145.670 0.070 145.880 ;
+    RECT 0 145.950 0.070 146.160 ;
+    RECT 0 146.230 0.070 146.440 ;
+    RECT 0 146.510 0.070 146.720 ;
+    RECT 0 146.790 0.070 147.000 ;
+    RECT 0 147.070 0.070 147.280 ;
+    RECT 0 147.350 0.070 147.560 ;
+    RECT 0 147.630 0.070 147.840 ;
+    RECT 0 147.910 0.070 148.120 ;
+    RECT 0 148.190 0.070 148.400 ;
+    RECT 0 148.470 0.070 148.680 ;
+    RECT 0 148.750 0.070 148.960 ;
+    RECT 0 149.030 0.070 149.240 ;
+    RECT 0 149.310 0.070 149.520 ;
+    RECT 0 149.590 0.070 149.800 ;
+    RECT 0 149.870 0.070 150.080 ;
+    RECT 0 150.150 0.070 150.360 ;
+    RECT 0 150.430 0.070 150.640 ;
+    RECT 0 150.710 0.070 150.920 ;
+    RECT 0 150.990 0.070 151.200 ;
+    RECT 0 151.270 0.070 151.480 ;
+    RECT 0 151.550 0.070 151.760 ;
+    RECT 0 151.830 0.070 152.040 ;
+    RECT 0 152.110 0.070 152.320 ;
+    RECT 0 152.390 0.070 152.600 ;
+    RECT 0 152.670 0.070 152.880 ;
+    RECT 0 152.950 0.070 153.160 ;
+    RECT 0 153.230 0.070 153.440 ;
+    RECT 0 153.510 0.070 153.720 ;
+    RECT 0 153.790 0.070 154.000 ;
+    RECT 0 154.070 0.070 154.280 ;
+    RECT 0 154.350 0.070 154.560 ;
+    RECT 0 154.630 0.070 154.840 ;
+    RECT 0 154.910 0.070 155.120 ;
+    RECT 0 155.190 0.070 155.400 ;
+    RECT 0 155.470 0.070 155.680 ;
+    RECT 0 155.750 0.070 155.960 ;
+    RECT 0 156.030 0.070 156.240 ;
+    RECT 0 156.310 0.070 156.520 ;
+    RECT 0 156.590 0.070 156.800 ;
+    RECT 0 156.870 0.070 157.080 ;
+    RECT 0 157.150 0.070 157.360 ;
+    RECT 0 157.430 0.070 157.640 ;
+    RECT 0 157.710 0.070 157.920 ;
+    RECT 0 157.990 0.070 158.200 ;
+    RECT 0 158.270 0.070 158.480 ;
+    RECT 0 158.550 0.070 158.760 ;
+    RECT 0 158.830 0.070 159.040 ;
+    RECT 0 159.110 0.070 159.320 ;
+    RECT 0 159.390 0.070 159.600 ;
+    RECT 0 159.670 0.070 159.880 ;
+    RECT 0 159.950 0.070 160.160 ;
+    RECT 0 160.230 0.070 160.440 ;
+    RECT 0 160.510 0.070 160.720 ;
+    RECT 0 160.790 0.070 161.000 ;
+    RECT 0 161.070 0.070 161.280 ;
+    RECT 0 161.350 0.070 161.560 ;
+    RECT 0 161.630 0.070 161.840 ;
+    RECT 0 161.910 0.070 162.120 ;
+    RECT 0 162.190 0.070 162.400 ;
+    RECT 0 162.470 0.070 162.680 ;
+    RECT 0 162.750 0.070 162.960 ;
+    RECT 0 163.030 0.070 163.240 ;
+    RECT 0 163.310 0.070 163.520 ;
+    RECT 0 163.590 0.070 163.800 ;
+    RECT 0 163.870 0.070 164.080 ;
+    RECT 0 164.150 0.070 164.360 ;
+    RECT 0 164.430 0.070 164.640 ;
+    RECT 0 164.710 0.070 164.920 ;
+    RECT 0 164.990 0.070 165.200 ;
+    RECT 0 165.270 0.070 165.480 ;
+    RECT 0 165.550 0.070 165.760 ;
+    RECT 0 165.830 0.070 166.040 ;
+    RECT 0 166.110 0.070 166.320 ;
+    RECT 0 166.390 0.070 166.600 ;
+    RECT 0 166.670 0.070 166.880 ;
+    RECT 0 166.950 0.070 167.160 ;
+    RECT 0 167.230 0.070 167.440 ;
+    RECT 0 167.510 0.070 167.720 ;
+    RECT 0 167.790 0.070 168.000 ;
+    RECT 0 168.070 0.070 168.280 ;
+    RECT 0 168.350 0.070 168.560 ;
+    RECT 0 168.630 0.070 168.840 ;
+    RECT 0 168.910 0.070 169.120 ;
+    RECT 0 169.190 0.070 169.400 ;
+    RECT 0 169.470 0.070 169.680 ;
+    RECT 0 169.750 0.070 169.960 ;
+    RECT 0 170.030 0.070 170.240 ;
+    RECT 0 170.310 0.070 170.520 ;
+    RECT 0 170.590 0.070 170.800 ;
+    RECT 0 170.870 0.070 171.080 ;
+    RECT 0 171.150 0.070 171.360 ;
+    RECT 0 171.430 0.070 171.640 ;
+    RECT 0 171.710 0.070 171.920 ;
+    RECT 0 171.990 0.070 172.200 ;
+    RECT 0 172.270 0.070 172.480 ;
+    RECT 0 172.550 0.070 172.760 ;
+    RECT 0 172.830 0.070 173.040 ;
+    RECT 0 173.110 0.070 173.320 ;
+    RECT 0 173.390 0.070 173.600 ;
+    RECT 0 173.670 0.070 173.880 ;
+    RECT 0 173.950 0.070 174.160 ;
+    RECT 0 174.230 0.070 174.440 ;
+    RECT 0 174.510 0.070 174.720 ;
+    RECT 0 174.790 0.070 175.000 ;
+    RECT 0 175.070 0.070 175.280 ;
+    RECT 0 175.350 0.070 175.560 ;
+    RECT 0 175.630 0.070 175.840 ;
+    RECT 0 175.910 0.070 176.120 ;
+    RECT 0 176.190 0.070 176.400 ;
+    RECT 0 176.470 0.070 176.680 ;
+    RECT 0 176.750 0.070 176.960 ;
+    RECT 0 177.030 0.070 177.240 ;
+    RECT 0 177.310 0.070 177.520 ;
+    RECT 0 177.590 0.070 177.800 ;
+    RECT 0 177.870 0.070 178.080 ;
+    RECT 0 178.150 0.070 178.360 ;
+    RECT 0 178.430 0.070 178.640 ;
+    RECT 0 178.710 0.070 178.920 ;
+    RECT 0 178.990 0.070 179.200 ;
+    RECT 0 179.270 0.070 179.480 ;
+    RECT 0 179.550 0.070 179.760 ;
+    RECT 0 179.830 0.070 180.040 ;
+    RECT 0 180.110 0.070 180.320 ;
+    RECT 0 180.390 0.070 180.600 ;
+    RECT 0 180.670 0.070 180.880 ;
+    RECT 0 180.950 0.070 181.160 ;
+    RECT 0 181.230 0.070 181.440 ;
+    RECT 0 181.510 0.070 181.720 ;
+    RECT 0 181.790 0.070 182.000 ;
+    RECT 0 182.070 0.070 182.280 ;
+    RECT 0 182.350 0.070 182.560 ;
+    RECT 0 182.630 0.070 182.840 ;
+    RECT 0 182.910 0.070 183.120 ;
+    RECT 0 183.190 0.070 183.400 ;
+    RECT 0 183.470 0.070 183.680 ;
+    RECT 0 183.750 0.070 183.960 ;
+    RECT 0 184.030 0.070 184.240 ;
+    RECT 0 184.310 0.070 184.520 ;
+    RECT 0 184.590 0.070 184.800 ;
+    RECT 0 184.870 0.070 185.080 ;
+    RECT 0 185.150 0.070 185.360 ;
+    RECT 0 185.430 0.070 185.640 ;
+    RECT 0 185.710 0.070 185.920 ;
+    RECT 0 185.990 0.070 186.200 ;
+    RECT 0 186.270 0.070 186.480 ;
+    RECT 0 186.550 0.070 186.760 ;
+    RECT 0 186.830 0.070 187.040 ;
+    RECT 0 187.110 0.070 187.320 ;
+    RECT 0 187.390 0.070 187.600 ;
+    RECT 0 187.670 0.070 187.880 ;
+    RECT 0 187.950 0.070 188.160 ;
+    RECT 0 188.230 0.070 188.440 ;
+    RECT 0 188.510 0.070 188.720 ;
+    RECT 0 188.790 0.070 189.000 ;
+    RECT 0 189.070 0.070 189.280 ;
+    RECT 0 189.350 0.070 189.560 ;
+    RECT 0 189.630 0.070 189.840 ;
+    RECT 0 189.910 0.070 190.120 ;
+    RECT 0 190.190 0.070 190.400 ;
+    RECT 0 190.470 0.070 190.680 ;
+    RECT 0 190.750 0.070 190.960 ;
+    RECT 0 191.030 0.070 191.240 ;
+    RECT 0 191.310 0.070 191.520 ;
+    RECT 0 191.590 0.070 191.800 ;
+    RECT 0 191.870 0.070 192.080 ;
+    RECT 0 192.150 0.070 192.360 ;
+    RECT 0 192.430 0.070 192.640 ;
+    RECT 0 192.710 0.070 192.920 ;
+    RECT 0 192.990 0.070 193.200 ;
+    RECT 0 193.270 0.070 193.480 ;
+    RECT 0 193.550 0.070 193.760 ;
+    RECT 0 193.830 0.070 194.040 ;
+    RECT 0 194.110 0.070 194.320 ;
+    RECT 0 194.390 0.070 194.600 ;
+    RECT 0 194.670 0.070 194.880 ;
+    RECT 0 194.950 0.070 195.160 ;
+    RECT 0 195.230 0.070 195.440 ;
+    RECT 0 195.510 0.070 195.720 ;
+    RECT 0 195.790 0.070 196.000 ;
+    RECT 0 196.070 0.070 196.280 ;
+    RECT 0 196.350 0.070 196.560 ;
+    RECT 0 196.630 0.070 196.840 ;
+    RECT 0 196.910 0.070 197.120 ;
+    RECT 0 197.190 0.070 197.400 ;
+    RECT 0 197.470 0.070 197.680 ;
+    RECT 0 197.750 0.070 197.960 ;
+    RECT 0 198.030 0.070 198.240 ;
+    RECT 0 198.310 0.070 198.520 ;
+    RECT 0 198.590 0.070 198.800 ;
+    RECT 0 198.870 0.070 199.080 ;
+    RECT 0 199.150 0.070 199.360 ;
+    RECT 0 199.430 0.070 199.640 ;
+    RECT 0 199.710 0.070 199.920 ;
+    RECT 0 199.990 0.070 200.200 ;
+    RECT 0 200.270 0.070 200.480 ;
+    RECT 0 200.550 0.070 200.760 ;
+    RECT 0 200.830 0.070 201.040 ;
+    RECT 0 201.110 0.070 201.320 ;
+    RECT 0 201.390 0.070 201.600 ;
+    RECT 0 201.670 0.070 201.880 ;
+    RECT 0 201.950 0.070 202.160 ;
+    RECT 0 202.230 0.070 202.440 ;
+    RECT 0 202.510 0.070 202.720 ;
+    RECT 0 202.790 0.070 203.000 ;
+    RECT 0 203.070 0.070 203.280 ;
+    RECT 0 203.350 0.070 203.560 ;
+    RECT 0 203.630 0.070 203.840 ;
+    RECT 0 203.910 0.070 204.120 ;
+    RECT 0 204.190 0.070 204.400 ;
+    RECT 0 204.470 0.070 204.680 ;
+    RECT 0 204.750 0.070 204.960 ;
+    RECT 0 205.030 0.070 205.240 ;
+    RECT 0 205.310 0.070 205.520 ;
+    RECT 0 205.590 0.070 205.800 ;
+    RECT 0 205.870 0.070 206.080 ;
+    RECT 0 206.150 0.070 206.360 ;
+    RECT 0 206.430 0.070 206.640 ;
+    RECT 0 206.710 0.070 206.920 ;
+    RECT 0 206.990 0.070 207.200 ;
+    RECT 0 207.270 0.070 207.480 ;
+    RECT 0 207.550 0.070 207.760 ;
+    RECT 0 207.830 0.070 208.040 ;
+    RECT 0 208.110 0.070 208.320 ;
+    RECT 0 208.390 0.070 208.600 ;
+    RECT 0 208.670 0.070 208.880 ;
+    RECT 0 208.950 0.070 209.160 ;
+    RECT 0 209.230 0.070 209.440 ;
+    RECT 0 209.510 0.070 209.720 ;
+    RECT 0 209.790 0.070 210.000 ;
+    RECT 0 210.070 0.070 210.280 ;
+    RECT 0 210.350 0.070 210.560 ;
+    RECT 0 210.630 0.070 210.840 ;
+    RECT 0 210.910 0.070 211.120 ;
+    RECT 0 211.190 0.070 211.400 ;
+    RECT 0 211.470 0.070 211.680 ;
+    RECT 0 211.750 0.070 211.960 ;
+    RECT 0 212.030 0.070 212.240 ;
+    RECT 0 212.310 0.070 212.520 ;
+    RECT 0 212.590 0.070 212.800 ;
+    RECT 0 212.870 0.070 213.080 ;
+    RECT 0 213.150 0.070 213.360 ;
+    RECT 0 213.430 0.070 213.640 ;
+    RECT 0 213.710 0.070 213.920 ;
+    RECT 0 213.990 0.070 214.200 ;
+    RECT 0 214.270 0.070 214.480 ;
+    RECT 0 214.550 0.070 214.760 ;
+    RECT 0 214.830 0.070 215.040 ;
+    RECT 0 215.110 0.070 215.320 ;
+    RECT 0 215.390 0.070 215.600 ;
+    RECT 0 215.670 0.070 215.880 ;
+    RECT 0 215.950 0.070 216.160 ;
+    RECT 0 216.230 0.070 216.440 ;
+    RECT 0 216.510 0.070 216.720 ;
+    RECT 0 216.790 0.070 217.000 ;
+    RECT 0 217.070 0.070 217.280 ;
+    RECT 0 217.350 0.070 217.560 ;
+    RECT 0 217.630 0.070 217.840 ;
+    RECT 0 217.910 0.070 218.120 ;
+    RECT 0 218.190 0.070 218.400 ;
+    RECT 0 218.470 0.070 218.680 ;
+    RECT 0 218.750 0.070 218.960 ;
+    RECT 0 219.030 0.070 219.240 ;
+    RECT 0 219.310 0.070 219.520 ;
+    RECT 0 219.590 0.070 219.800 ;
+    RECT 0 219.870 0.070 220.080 ;
+    RECT 0 220.150 0.070 223.900 ;
+    LAYER metal4 ;
+    RECT 0 0 151.810 2.800 ;
+    RECT 0 221.100 151.810 223.900 ;
+    RECT 0.000 2.800 2.660 221.100 ;
+    RECT 2.940 2.800 4.900 221.100 ;
+    RECT 5.180 2.800 7.140 221.100 ;
+    RECT 7.420 2.800 9.380 221.100 ;
+    RECT 9.660 2.800 11.620 221.100 ;
+    RECT 11.900 2.800 13.860 221.100 ;
+    RECT 14.140 2.800 16.100 221.100 ;
+    RECT 16.380 2.800 18.340 221.100 ;
+    RECT 18.620 2.800 20.580 221.100 ;
+    RECT 20.860 2.800 22.820 221.100 ;
+    RECT 23.100 2.800 25.060 221.100 ;
+    RECT 25.340 2.800 27.300 221.100 ;
+    RECT 27.580 2.800 29.540 221.100 ;
+    RECT 29.820 2.800 31.780 221.100 ;
+    RECT 32.060 2.800 34.020 221.100 ;
+    RECT 34.300 2.800 36.260 221.100 ;
+    RECT 36.540 2.800 38.500 221.100 ;
+    RECT 38.780 2.800 40.740 221.100 ;
+    RECT 41.020 2.800 42.980 221.100 ;
+    RECT 43.260 2.800 45.220 221.100 ;
+    RECT 45.500 2.800 47.460 221.100 ;
+    RECT 47.740 2.800 49.700 221.100 ;
+    RECT 49.980 2.800 51.940 221.100 ;
+    RECT 52.220 2.800 54.180 221.100 ;
+    RECT 54.460 2.800 56.420 221.100 ;
+    RECT 56.700 2.800 58.660 221.100 ;
+    RECT 58.940 2.800 60.900 221.100 ;
+    RECT 61.180 2.800 63.140 221.100 ;
+    RECT 63.420 2.800 65.380 221.100 ;
+    RECT 65.660 2.800 67.620 221.100 ;
+    RECT 67.900 2.800 69.860 221.100 ;
+    RECT 70.140 2.800 72.100 221.100 ;
+    RECT 72.380 2.800 74.340 221.100 ;
+    RECT 74.620 2.800 76.580 221.100 ;
+    RECT 76.860 2.800 78.820 221.100 ;
+    RECT 79.100 2.800 81.060 221.100 ;
+    RECT 81.340 2.800 83.300 221.100 ;
+    RECT 83.580 2.800 85.540 221.100 ;
+    RECT 85.820 2.800 87.780 221.100 ;
+    RECT 88.060 2.800 90.020 221.100 ;
+    RECT 90.300 2.800 92.260 221.100 ;
+    RECT 92.540 2.800 94.500 221.100 ;
+    RECT 94.780 2.800 96.740 221.100 ;
+    RECT 97.020 2.800 98.980 221.100 ;
+    RECT 99.260 2.800 101.220 221.100 ;
+    RECT 101.500 2.800 103.460 221.100 ;
+    RECT 103.740 2.800 105.700 221.100 ;
+    RECT 105.980 2.800 107.940 221.100 ;
+    RECT 108.220 2.800 110.180 221.100 ;
+    RECT 110.460 2.800 112.420 221.100 ;
+    RECT 112.700 2.800 114.660 221.100 ;
+    RECT 114.940 2.800 116.900 221.100 ;
+    RECT 117.180 2.800 119.140 221.100 ;
+    RECT 119.420 2.800 121.380 221.100 ;
+    RECT 121.660 2.800 123.620 221.100 ;
+    RECT 123.900 2.800 125.860 221.100 ;
+    RECT 126.140 2.800 128.100 221.100 ;
+    RECT 128.380 2.800 130.340 221.100 ;
+    RECT 130.620 2.800 132.580 221.100 ;
+    RECT 132.860 2.800 134.820 221.100 ;
+    RECT 135.100 2.800 137.060 221.100 ;
+    RECT 137.340 2.800 139.300 221.100 ;
+    RECT 139.580 2.800 141.540 221.100 ;
+    RECT 141.820 2.800 143.780 221.100 ;
+    RECT 144.060 2.800 146.020 221.100 ;
+    RECT 146.300 2.800 148.260 221.100 ;
+    RECT 148.540 2.800 151.810 221.100 ;
+    LAYER OVERLAP ;
+    RECT 0 0 151.810 223.900 ;
+  END
+END fakeram45_64x256
+
+END LIBRARY

--- a/flow/platforms/nangate45/lef/fakeram45_64x28.lef
+++ b/flow/platforms/nangate45/lef/fakeram45_64x28.lef
@@ -1,0 +1,983 @@
+VERSION 5.7 ;
+BUSBITCHARS "[]" ;
+MACRO fakeram45_64x28
+  FOREIGN fakeram45_64x28 0 0 ;
+  SYMMETRY X Y R90 ;
+  SIZE 20.140 BY 61.600 ;
+  CLASS BLOCK ;
+  PIN w_mask_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 2.800 0.070 2.870 ;
+    END
+  END w_mask_in[0]
+  PIN w_mask_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.360 0.070 3.430 ;
+    END
+  END w_mask_in[1]
+  PIN w_mask_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 3.920 0.070 3.990 ;
+    END
+  END w_mask_in[2]
+  PIN w_mask_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 4.480 0.070 4.550 ;
+    END
+  END w_mask_in[3]
+  PIN w_mask_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.040 0.070 5.110 ;
+    END
+  END w_mask_in[4]
+  PIN w_mask_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 5.600 0.070 5.670 ;
+    END
+  END w_mask_in[5]
+  PIN w_mask_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.160 0.070 6.230 ;
+    END
+  END w_mask_in[6]
+  PIN w_mask_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 6.720 0.070 6.790 ;
+    END
+  END w_mask_in[7]
+  PIN w_mask_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.280 0.070 7.350 ;
+    END
+  END w_mask_in[8]
+  PIN w_mask_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 7.840 0.070 7.910 ;
+    END
+  END w_mask_in[9]
+  PIN w_mask_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.400 0.070 8.470 ;
+    END
+  END w_mask_in[10]
+  PIN w_mask_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 8.960 0.070 9.030 ;
+    END
+  END w_mask_in[11]
+  PIN w_mask_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 9.520 0.070 9.590 ;
+    END
+  END w_mask_in[12]
+  PIN w_mask_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.080 0.070 10.150 ;
+    END
+  END w_mask_in[13]
+  PIN w_mask_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 10.640 0.070 10.710 ;
+    END
+  END w_mask_in[14]
+  PIN w_mask_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.200 0.070 11.270 ;
+    END
+  END w_mask_in[15]
+  PIN w_mask_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 11.760 0.070 11.830 ;
+    END
+  END w_mask_in[16]
+  PIN w_mask_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.320 0.070 12.390 ;
+    END
+  END w_mask_in[17]
+  PIN w_mask_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 12.880 0.070 12.950 ;
+    END
+  END w_mask_in[18]
+  PIN w_mask_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 13.440 0.070 13.510 ;
+    END
+  END w_mask_in[19]
+  PIN w_mask_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.000 0.070 14.070 ;
+    END
+  END w_mask_in[20]
+  PIN w_mask_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 14.560 0.070 14.630 ;
+    END
+  END w_mask_in[21]
+  PIN w_mask_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.120 0.070 15.190 ;
+    END
+  END w_mask_in[22]
+  PIN w_mask_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 15.680 0.070 15.750 ;
+    END
+  END w_mask_in[23]
+  PIN w_mask_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.240 0.070 16.310 ;
+    END
+  END w_mask_in[24]
+  PIN w_mask_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 16.800 0.070 16.870 ;
+    END
+  END w_mask_in[25]
+  PIN w_mask_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.360 0.070 17.430 ;
+    END
+  END w_mask_in[26]
+  PIN w_mask_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 17.920 0.070 17.990 ;
+    END
+  END w_mask_in[27]
+  PIN rd_out[0]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 18.760 0.070 18.830 ;
+    END
+  END rd_out[0]
+  PIN rd_out[1]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.320 0.070 19.390 ;
+    END
+  END rd_out[1]
+  PIN rd_out[2]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 19.880 0.070 19.950 ;
+    END
+  END rd_out[2]
+  PIN rd_out[3]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 20.440 0.070 20.510 ;
+    END
+  END rd_out[3]
+  PIN rd_out[4]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.000 0.070 21.070 ;
+    END
+  END rd_out[4]
+  PIN rd_out[5]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 21.560 0.070 21.630 ;
+    END
+  END rd_out[5]
+  PIN rd_out[6]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.120 0.070 22.190 ;
+    END
+  END rd_out[6]
+  PIN rd_out[7]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 22.680 0.070 22.750 ;
+    END
+  END rd_out[7]
+  PIN rd_out[8]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.240 0.070 23.310 ;
+    END
+  END rd_out[8]
+  PIN rd_out[9]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 23.800 0.070 23.870 ;
+    END
+  END rd_out[9]
+  PIN rd_out[10]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.360 0.070 24.430 ;
+    END
+  END rd_out[10]
+  PIN rd_out[11]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 24.920 0.070 24.990 ;
+    END
+  END rd_out[11]
+  PIN rd_out[12]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 25.480 0.070 25.550 ;
+    END
+  END rd_out[12]
+  PIN rd_out[13]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.040 0.070 26.110 ;
+    END
+  END rd_out[13]
+  PIN rd_out[14]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 26.600 0.070 26.670 ;
+    END
+  END rd_out[14]
+  PIN rd_out[15]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.160 0.070 27.230 ;
+    END
+  END rd_out[15]
+  PIN rd_out[16]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 27.720 0.070 27.790 ;
+    END
+  END rd_out[16]
+  PIN rd_out[17]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.280 0.070 28.350 ;
+    END
+  END rd_out[17]
+  PIN rd_out[18]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 28.840 0.070 28.910 ;
+    END
+  END rd_out[18]
+  PIN rd_out[19]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.400 0.070 29.470 ;
+    END
+  END rd_out[19]
+  PIN rd_out[20]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 29.960 0.070 30.030 ;
+    END
+  END rd_out[20]
+  PIN rd_out[21]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 30.520 0.070 30.590 ;
+    END
+  END rd_out[21]
+  PIN rd_out[22]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.080 0.070 31.150 ;
+    END
+  END rd_out[22]
+  PIN rd_out[23]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 31.640 0.070 31.710 ;
+    END
+  END rd_out[23]
+  PIN rd_out[24]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.200 0.070 32.270 ;
+    END
+  END rd_out[24]
+  PIN rd_out[25]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 32.760 0.070 32.830 ;
+    END
+  END rd_out[25]
+  PIN rd_out[26]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.320 0.070 33.390 ;
+    END
+  END rd_out[26]
+  PIN rd_out[27]
+    DIRECTION OUTPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 33.880 0.070 33.950 ;
+    END
+  END rd_out[27]
+  PIN wd_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 34.720 0.070 34.790 ;
+    END
+  END wd_in[0]
+  PIN wd_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.280 0.070 35.350 ;
+    END
+  END wd_in[1]
+  PIN wd_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 35.840 0.070 35.910 ;
+    END
+  END wd_in[2]
+  PIN wd_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.400 0.070 36.470 ;
+    END
+  END wd_in[3]
+  PIN wd_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 36.960 0.070 37.030 ;
+    END
+  END wd_in[4]
+  PIN wd_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 37.520 0.070 37.590 ;
+    END
+  END wd_in[5]
+  PIN wd_in[6]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.080 0.070 38.150 ;
+    END
+  END wd_in[6]
+  PIN wd_in[7]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 38.640 0.070 38.710 ;
+    END
+  END wd_in[7]
+  PIN wd_in[8]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.200 0.070 39.270 ;
+    END
+  END wd_in[8]
+  PIN wd_in[9]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 39.760 0.070 39.830 ;
+    END
+  END wd_in[9]
+  PIN wd_in[10]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.320 0.070 40.390 ;
+    END
+  END wd_in[10]
+  PIN wd_in[11]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 40.880 0.070 40.950 ;
+    END
+  END wd_in[11]
+  PIN wd_in[12]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 41.440 0.070 41.510 ;
+    END
+  END wd_in[12]
+  PIN wd_in[13]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.000 0.070 42.070 ;
+    END
+  END wd_in[13]
+  PIN wd_in[14]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 42.560 0.070 42.630 ;
+    END
+  END wd_in[14]
+  PIN wd_in[15]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.120 0.070 43.190 ;
+    END
+  END wd_in[15]
+  PIN wd_in[16]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 43.680 0.070 43.750 ;
+    END
+  END wd_in[16]
+  PIN wd_in[17]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.240 0.070 44.310 ;
+    END
+  END wd_in[17]
+  PIN wd_in[18]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 44.800 0.070 44.870 ;
+    END
+  END wd_in[18]
+  PIN wd_in[19]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.360 0.070 45.430 ;
+    END
+  END wd_in[19]
+  PIN wd_in[20]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 45.920 0.070 45.990 ;
+    END
+  END wd_in[20]
+  PIN wd_in[21]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 46.480 0.070 46.550 ;
+    END
+  END wd_in[21]
+  PIN wd_in[22]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.040 0.070 47.110 ;
+    END
+  END wd_in[22]
+  PIN wd_in[23]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 47.600 0.070 47.670 ;
+    END
+  END wd_in[23]
+  PIN wd_in[24]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.160 0.070 48.230 ;
+    END
+  END wd_in[24]
+  PIN wd_in[25]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 48.720 0.070 48.790 ;
+    END
+  END wd_in[25]
+  PIN wd_in[26]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.280 0.070 49.350 ;
+    END
+  END wd_in[26]
+  PIN wd_in[27]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 49.840 0.070 49.910 ;
+    END
+  END wd_in[27]
+  PIN addr_in[0]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 50.680 0.070 50.750 ;
+    END
+  END addr_in[0]
+  PIN addr_in[1]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.240 0.070 51.310 ;
+    END
+  END addr_in[1]
+  PIN addr_in[2]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 51.800 0.070 51.870 ;
+    END
+  END addr_in[2]
+  PIN addr_in[3]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.360 0.070 52.430 ;
+    END
+  END addr_in[3]
+  PIN addr_in[4]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 52.920 0.070 52.990 ;
+    END
+  END addr_in[4]
+  PIN addr_in[5]
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 53.480 0.070 53.550 ;
+    END
+  END addr_in[5]
+  PIN we_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.320 0.070 54.390 ;
+    END
+  END we_in
+  PIN ce_in
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 54.880 0.070 54.950 ;
+    END
+  END ce_in
+  PIN clk
+    DIRECTION INPUT ;
+    USE SIGNAL ;
+    SHAPE ABUTMENT ;
+    PORT
+      LAYER metal3 ;
+      RECT 0.000 55.440 0.070 55.510 ;
+    END
+  END clk
+  PIN VSS
+    DIRECTION INOUT ;
+    USE GROUND ;
+    PORT
+      LAYER metal4 ;
+      RECT 2.660 2.800 2.940 58.800 ;
+      RECT 7.140 2.800 7.420 58.800 ;
+      RECT 11.620 2.800 11.900 58.800 ;
+      RECT 16.100 2.800 16.380 58.800 ;
+    END
+  END VSS
+  PIN VDD
+    DIRECTION INOUT ;
+    USE POWER ;
+    PORT
+      LAYER metal4 ;
+      RECT 4.900 2.800 5.180 58.800 ;
+      RECT 9.380 2.800 9.660 58.800 ;
+      RECT 13.860 2.800 14.140 58.800 ;
+    END
+  END VDD
+  OBS
+    LAYER metal1 ;
+    RECT 0 0 20.140 61.600 ;
+    LAYER metal2 ;
+    RECT 0 0 20.140 61.600 ;
+    LAYER metal3 ;
+    RECT 0.070 0 20.140 61.600 ;
+    RECT 0 0.000 0.070 2.800 ;
+    RECT 0 2.870 0.070 3.360 ;
+    RECT 0 3.430 0.070 3.920 ;
+    RECT 0 3.990 0.070 4.480 ;
+    RECT 0 4.550 0.070 5.040 ;
+    RECT 0 5.110 0.070 5.600 ;
+    RECT 0 5.670 0.070 6.160 ;
+    RECT 0 6.230 0.070 6.720 ;
+    RECT 0 6.790 0.070 7.280 ;
+    RECT 0 7.350 0.070 7.840 ;
+    RECT 0 7.910 0.070 8.400 ;
+    RECT 0 8.470 0.070 8.960 ;
+    RECT 0 9.030 0.070 9.520 ;
+    RECT 0 9.590 0.070 10.080 ;
+    RECT 0 10.150 0.070 10.640 ;
+    RECT 0 10.710 0.070 11.200 ;
+    RECT 0 11.270 0.070 11.760 ;
+    RECT 0 11.830 0.070 12.320 ;
+    RECT 0 12.390 0.070 12.880 ;
+    RECT 0 12.950 0.070 13.440 ;
+    RECT 0 13.510 0.070 14.000 ;
+    RECT 0 14.070 0.070 14.560 ;
+    RECT 0 14.630 0.070 15.120 ;
+    RECT 0 15.190 0.070 15.680 ;
+    RECT 0 15.750 0.070 16.240 ;
+    RECT 0 16.310 0.070 16.800 ;
+    RECT 0 16.870 0.070 17.360 ;
+    RECT 0 17.430 0.070 17.920 ;
+    RECT 0 17.990 0.070 18.760 ;
+    RECT 0 18.830 0.070 19.320 ;
+    RECT 0 19.390 0.070 19.880 ;
+    RECT 0 19.950 0.070 20.440 ;
+    RECT 0 20.510 0.070 21.000 ;
+    RECT 0 21.070 0.070 21.560 ;
+    RECT 0 21.630 0.070 22.120 ;
+    RECT 0 22.190 0.070 22.680 ;
+    RECT 0 22.750 0.070 23.240 ;
+    RECT 0 23.310 0.070 23.800 ;
+    RECT 0 23.870 0.070 24.360 ;
+    RECT 0 24.430 0.070 24.920 ;
+    RECT 0 24.990 0.070 25.480 ;
+    RECT 0 25.550 0.070 26.040 ;
+    RECT 0 26.110 0.070 26.600 ;
+    RECT 0 26.670 0.070 27.160 ;
+    RECT 0 27.230 0.070 27.720 ;
+    RECT 0 27.790 0.070 28.280 ;
+    RECT 0 28.350 0.070 28.840 ;
+    RECT 0 28.910 0.070 29.400 ;
+    RECT 0 29.470 0.070 29.960 ;
+    RECT 0 30.030 0.070 30.520 ;
+    RECT 0 30.590 0.070 31.080 ;
+    RECT 0 31.150 0.070 31.640 ;
+    RECT 0 31.710 0.070 32.200 ;
+    RECT 0 32.270 0.070 32.760 ;
+    RECT 0 32.830 0.070 33.320 ;
+    RECT 0 33.390 0.070 33.880 ;
+    RECT 0 33.950 0.070 34.720 ;
+    RECT 0 34.790 0.070 35.280 ;
+    RECT 0 35.350 0.070 35.840 ;
+    RECT 0 35.910 0.070 36.400 ;
+    RECT 0 36.470 0.070 36.960 ;
+    RECT 0 37.030 0.070 37.520 ;
+    RECT 0 37.590 0.070 38.080 ;
+    RECT 0 38.150 0.070 38.640 ;
+    RECT 0 38.710 0.070 39.200 ;
+    RECT 0 39.270 0.070 39.760 ;
+    RECT 0 39.830 0.070 40.320 ;
+    RECT 0 40.390 0.070 40.880 ;
+    RECT 0 40.950 0.070 41.440 ;
+    RECT 0 41.510 0.070 42.000 ;
+    RECT 0 42.070 0.070 42.560 ;
+    RECT 0 42.630 0.070 43.120 ;
+    RECT 0 43.190 0.070 43.680 ;
+    RECT 0 43.750 0.070 44.240 ;
+    RECT 0 44.310 0.070 44.800 ;
+    RECT 0 44.870 0.070 45.360 ;
+    RECT 0 45.430 0.070 45.920 ;
+    RECT 0 45.990 0.070 46.480 ;
+    RECT 0 46.550 0.070 47.040 ;
+    RECT 0 47.110 0.070 47.600 ;
+    RECT 0 47.670 0.070 48.160 ;
+    RECT 0 48.230 0.070 48.720 ;
+    RECT 0 48.790 0.070 49.280 ;
+    RECT 0 49.350 0.070 49.840 ;
+    RECT 0 49.910 0.070 50.680 ;
+    RECT 0 50.750 0.070 51.240 ;
+    RECT 0 51.310 0.070 51.800 ;
+    RECT 0 51.870 0.070 52.360 ;
+    RECT 0 52.430 0.070 52.920 ;
+    RECT 0 52.990 0.070 53.480 ;
+    RECT 0 53.550 0.070 54.320 ;
+    RECT 0 54.390 0.070 54.880 ;
+    RECT 0 54.950 0.070 55.440 ;
+    RECT 0 55.510 0.070 61.600 ;
+    LAYER metal4 ;
+    RECT 0 0 20.140 2.800 ;
+    RECT 0 58.800 20.140 61.600 ;
+    RECT 0.000 2.800 2.660 58.800 ;
+    RECT 2.940 2.800 4.900 58.800 ;
+    RECT 5.180 2.800 7.140 58.800 ;
+    RECT 7.420 2.800 9.380 58.800 ;
+    RECT 9.660 2.800 11.620 58.800 ;
+    RECT 11.900 2.800 13.860 58.800 ;
+    RECT 14.140 2.800 16.100 58.800 ;
+    RECT 16.380 2.800 20.140 58.800 ;
+    LAYER OVERLAP ;
+    RECT 0 0 20.140 61.600 ;
+  END
+END fakeram45_64x28
+
+END LIBRARY

--- a/flow/platforms/nangate45/lib/fakeram45_128x64.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_128x64.lib
@@ -28,7 +28,6 @@ library(fakeram45_128x64) {
     default_inout_pin_cap : 0.0;
     default_input_pin_cap : 0.0;
     default_output_pin_cap : 0.0;
-    default_input_pin_cap : 0.0;
     default_max_transition : 0.227;
 
     default_operating_conditions : tt_1.0_25.0;

--- a/flow/platforms/nangate45/lib/fakeram45_128x64.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_128x64.lib
@@ -1,0 +1,314 @@
+library(fakeram45_128x64) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-08-14 04:03:28Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1nw";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,ff);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram45_128x64_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram45_128x64_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 64;
+        bit_from : 63;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram45_128x64_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 7;
+        bit_from : 6;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram45_128x64) {
+    area : 5479.600;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 7;
+        word_width : 64;
+    }
+    pin(clk)   {
+        direction : input;
+        capacitance : 25.000;
+        clock : true;
+        min_period           : 0.201 ;
+        internal_power(){
+            rise_power(scalar) {
+                values ("2761.520")
+            }
+            fall_power(scalar) {
+                values ("2761.520")
+            }
+        }
+    }
+
+    bus(rd_out)   {
+        bus_type : fakeram45_128x64_DATA;
+        direction : output;
+        max_capacitance : 500.000;
+        memory_read() {
+            address : addr_in;
+        }
+        timing() {
+            related_pin : "clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(scalar) {
+                values ("0.233");
+            }
+            cell_fall(scalar) {
+                values ("0.233");
+            }
+            rise_transition(fakeram45_128x64_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram45_128x64_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(we_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+    }
+    pin(ce_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+    }
+    bus(addr_in)   {
+        bus_type : fakeram45_128x64_ADDRESS;
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+    }
+    bus(wd_in)   {
+        bus_type : fakeram45_128x64_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+    }
+    bus(w_mask_in)   {
+        bus_type : fakeram45_128x64_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("27.615");
+            }
+            fall_power(scalar) {
+                values ("27.615");
+            }
+        }
+    }
+    cell_leakage_power : 303495.000;
+}
+
+}

--- a/flow/platforms/nangate45/lib/fakeram45_64x25.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x25.lib
@@ -28,7 +28,6 @@ library(fakeram45_64x25) {
     default_inout_pin_cap : 0.0;
     default_input_pin_cap : 0.0;
     default_output_pin_cap : 0.0;
-    default_input_pin_cap : 0.0;
     default_max_transition : 0.227;
 
     default_operating_conditions : tt_1.0_25.0;

--- a/flow/platforms/nangate45/lib/fakeram45_64x25.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x25.lib
@@ -1,0 +1,314 @@
+library(fakeram45_64x25) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-08-14 04:03:28Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1nw";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,ff);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram45_64x25_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram45_64x25_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 25;
+        bit_from : 24;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram45_64x25_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 6;
+        bit_from : 5;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram45_64x25) {
+    area : 1240.624;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 6;
+        word_width : 25;
+    }
+    pin(clk)   {
+        direction : input;
+        capacitance : 25.000;
+        clock : true;
+        min_period           : 0.164 ;
+        internal_power(){
+            rise_power(scalar) {
+                values ("795.762")
+            }
+            fall_power(scalar) {
+                values ("795.762")
+            }
+        }
+    }
+
+    bus(rd_out)   {
+        bus_type : fakeram45_64x25_DATA;
+        direction : output;
+        max_capacitance : 500.000;
+        memory_read() {
+            address : addr_in;
+        }
+        timing() {
+            related_pin : "clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(scalar) {
+                values ("0.207");
+            }
+            cell_fall(scalar) {
+                values ("0.207");
+            }
+            rise_transition(fakeram45_64x25_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram45_64x25_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(we_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    pin(ce_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(addr_in)   {
+        bus_type : fakeram45_64x25_ADDRESS;
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(wd_in)   {
+        bus_type : fakeram45_64x25_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(w_mask_in)   {
+        bus_type : fakeram45_64x25_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    cell_leakage_power : 81627.200;
+}
+
+}

--- a/flow/platforms/nangate45/lib/fakeram45_64x256.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x256.lib
@@ -28,7 +28,6 @@ library(fakeram45_64x256) {
     default_inout_pin_cap : 0.0;
     default_input_pin_cap : 0.0;
     default_output_pin_cap : 0.0;
-    default_input_pin_cap : 0.0;
     default_max_transition : 0.227;
 
     default_operating_conditions : tt_1.0_25.0;

--- a/flow/platforms/nangate45/lib/fakeram45_64x256.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x256.lib
@@ -1,0 +1,314 @@
+library(fakeram45_64x256) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-08-14 04:03:29Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1nw";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,ff);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram45_64x256_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram45_64x256_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 256;
+        bit_from : 255;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram45_64x256_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 6;
+        bit_from : 5;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram45_64x256) {
+    area : 33990.259;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 6;
+        word_width : 256;
+    }
+    pin(clk)   {
+        direction : input;
+        capacitance : 25.000;
+        clock : true;
+        min_period           : 0.249 ;
+        internal_power(){
+            rise_power(scalar) {
+                values ("13566.900")
+            }
+            fall_power(scalar) {
+                values ("13566.900")
+            }
+        }
+    }
+
+    bus(rd_out)   {
+        bus_type : fakeram45_64x256_DATA;
+        direction : output;
+        max_capacitance : 500.000;
+        memory_read() {
+            address : addr_in;
+        }
+        timing() {
+            related_pin : "clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(scalar) {
+                values ("0.253");
+            }
+            cell_fall(scalar) {
+                values ("0.253");
+            }
+            rise_transition(fakeram45_64x256_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram45_64x256_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(we_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+    }
+    pin(ce_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+    }
+    bus(addr_in)   {
+        bus_type : fakeram45_64x256_ADDRESS;
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+    }
+    bus(wd_in)   {
+        bus_type : fakeram45_64x256_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+    }
+    bus(w_mask_in)   {
+        bus_type : fakeram45_64x256_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("135.669");
+            }
+            fall_power(scalar) {
+                values ("135.669");
+            }
+        }
+    }
+    cell_leakage_power : 692663.000;
+}
+
+}

--- a/flow/platforms/nangate45/lib/fakeram45_64x28.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x28.lib
@@ -28,7 +28,6 @@ library(fakeram45_64x28) {
     default_inout_pin_cap : 0.0;
     default_input_pin_cap : 0.0;
     default_output_pin_cap : 0.0;
-    default_input_pin_cap : 0.0;
     default_max_transition : 0.227;
 
     default_operating_conditions : tt_1.0_25.0;

--- a/flow/platforms/nangate45/lib/fakeram45_64x28.lib
+++ b/flow/platforms/nangate45/lib/fakeram45_64x28.lib
@@ -1,0 +1,314 @@
+library(fakeram45_64x28) {
+    technology (cmos);
+    delay_model : table_lookup;
+    revision : 1.0;
+    date : "2026-08-14 04:03:28Z";
+    comment : "SRAM";
+    time_unit : "1ns";
+    voltage_unit : "1V";
+    current_unit : "1uA";
+    leakage_power_unit : "1nw";
+    nom_process : 1;
+    nom_temperature : 25.000;
+    nom_voltage : 1.1;
+    capacitive_load_unit (1,ff);
+
+    pulling_resistance_unit : "1kohm";
+
+    operating_conditions(tt_1.0_25.0) {
+        process : 1;
+        temperature : 25.000;
+        voltage : 1.1;
+        tree_type : balanced_tree;
+    }
+
+    /* default attributes */
+    default_cell_leakage_power : 0;
+    default_fanout_load : 1;
+    default_inout_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_output_pin_cap : 0.0;
+    default_input_pin_cap : 0.0;
+    default_max_transition : 0.227;
+
+    default_operating_conditions : tt_1.0_25.0;
+    default_leakage_power_density : 0.0;
+
+    /* additional header data */
+    slew_derate_from_library : 1.000;
+    slew_lower_threshold_pct_fall : 20.000;
+    slew_upper_threshold_pct_fall : 80.000;
+    slew_lower_threshold_pct_rise : 20.000;
+    slew_upper_threshold_pct_rise : 80.000;
+    input_threshold_pct_fall : 50.000;
+    input_threshold_pct_rise : 50.000;
+    output_threshold_pct_fall : 50.000;
+    output_threshold_pct_rise : 50.000;
+
+
+    lu_table_template(fakeram45_64x28_mem_out_slew_template) {
+        variable_1 : total_output_net_capacitance;
+            index_1 ("1000, 1001");
+    }
+    library_features(report_delay_calculation);
+    type (fakeram45_64x28_DATA) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 28;
+        bit_from : 27;
+        bit_to : 0 ;
+        downto : true ;
+    }
+    type (fakeram45_64x28_ADDRESS) {
+        base_type : array ;
+        data_type : bit ;
+        bit_width : 6;
+        bit_from : 5;
+        bit_to : 0 ;
+        downto : true ;
+    }
+cell(fakeram45_64x28) {
+    area : 1240.624;
+    interface_timing : true;
+    memory() {
+        type : ram;
+        address_width : 6;
+        word_width : 28;
+    }
+    pin(clk)   {
+        direction : input;
+        capacitance : 25.000;
+        clock : true;
+        min_period           : 0.164 ;
+        internal_power(){
+            rise_power(scalar) {
+                values ("795.762")
+            }
+            fall_power(scalar) {
+                values ("795.762")
+            }
+        }
+    }
+
+    bus(rd_out)   {
+        bus_type : fakeram45_64x28_DATA;
+        direction : output;
+        max_capacitance : 500.000;
+        memory_read() {
+            address : addr_in;
+        }
+        timing() {
+            related_pin : "clk" ;
+            timing_type : rising_edge;
+            timing_sense : non_unate;
+            cell_rise(scalar) {
+                values ("0.207");
+            }
+            cell_fall(scalar) {
+                values ("0.207");
+            }
+            rise_transition(fakeram45_64x28_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+            fall_transition(fakeram45_64x28_mem_out_slew_template) {
+                index_1 ("5.000, 500.000");
+                values ("0.009, 0.227")
+            }
+        }
+    }
+    pin(we_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    pin(ce_in){
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(addr_in)   {
+        bus_type : fakeram45_64x28_ADDRESS;
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin : clk;
+            timing_type : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin : clk;
+            timing_type : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(wd_in)   {
+        bus_type : fakeram45_64x28_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    bus(w_mask_in)   {
+        bus_type : fakeram45_64x28_DATA;
+        memory_write() {
+            address : addr_in;
+            clocked_on : "clk";
+        }
+        direction : input;
+        capacitance : 5.000;
+        timing() {
+            related_pin     : clk;
+            timing_type     : setup_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        timing() {
+            related_pin     : clk;
+            timing_type     : hold_rising ;
+            rise_constraint(scalar) {
+                values ("0.050");
+            }
+            fall_constraint(scalar) {
+                values ("0.050");
+            }
+        }
+        internal_power(){
+            when : "(! (we_in) )";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+        internal_power(){
+            when : "(we_in)";
+            rise_power(scalar) {
+                values ("7.958");
+            }
+            fall_power(scalar) {
+                values ("7.958");
+            }
+        }
+    }
+    cell_leakage_power : 81627.200;
+}
+
+}


### PR DESCRIPTION
## Summary

- add a CVA6 flow configuration for Nangate45, following the existing ASAP7 CVA6 flow structure
- add minimal Verilog adapters that map the CVA6 FakeRAM modules to Nangate45 FakeRAM macros
- add and register the four generated Nangate45 LEF/Liberty memory views required by CVA6
- add metadata rules for continuous QoR validation

## Motivation

ORFS already includes CVA6 support for ASAP7. This change makes the same open-source CPU available on Nangate45 while preserving the existing CVA6 source, canonicalization, and constraint structure. The platform-specific plumbing is limited to configuration, memory adapters, and the required FakeRAM views.

## Validation

- completed the full RTL-to-GDS flow on an AMD Ryzen Threadripper PRO 7955WX (`amd128`)
- placed all 8 memory macros
- global routing completed without congestion
- detailed routing completed with 0 DRC violations
- antenna checking reported 0 violations
- final timing reported 0 setup TNS and 0 hold TNS
- power-grid analysis connected VDD/VSS and reported 0.01% worst IR drop
- metadata validation passed all 27 rules with 0 warnings
- `git diff --check` passes

The run used current ORFS scripts with the locally cached ORFS tool image. Local formal equivalence could not be exercised because the cached `kepler-formal` binary exited with `SIGILL`; no source configuration disables LEC, so upstream CI can run the normal formal check with its current image.
