### PR TITLE
build: update rules_python dependency version to 2.0.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 
 # --- Regular dependencies (propagated to downstream consumers) ---
 
-bazel_dep(name = "rules_python", version = "1.8.5")
+bazel_dep(name = "rules_python", version = "2.0.0")
 bazel_dep(name = "rules_shell", version = "0.6.1")
 
 # --- Dev dependencies (only honoured when @orfs is the root module) ---


### PR DESCRIPTION
fewer warnings, matches tools/OpenROAD