### PR TITLE
update gf12/ca53 metrics

### DIFF
--- a/flow/designs/gf12/ca53/rules-base.json
+++ b/flow/designs/gf12/ca53/rules-base.json
@@ -9,12 +9,16 @@
         "compare": "==",
         "level": "warning"
     },
+    "synth__design__instance__area__stdcell": {
+        "value": 174000.0,
+        "compare": "<="
+    },
     "constraints__clocks__count": {
         "value": 1,
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 375030,
+        "value": 368285,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -34,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -100.0,
+        "value": -248.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -400.0,
+        "value": -2080.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -50,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 528,
+        "value": 516,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -74,7 +78,7 @@
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
@@ -82,7 +86,7 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 528,
+        "value": 516,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
@@ -98,11 +102,11 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -4350.0,
+        "value": -1600.0,
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 408918,
+        "value": 403433,
         "compare": "<="
     }
 }


### PR DESCRIPTION
designs/gf12/ca53/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |     375030 |     368285 | Tighten  |
| cts__timing__setup__ws                        |     -100.0 |     -248.0 | Failing  |
| cts__timing__setup__tns                       |     -400.0 |    -2080.0 | Failing  |
| globalroute__antenna_diodes_count             |        528 |        516 | Tighten  |
| detailedroute__route__drc_errors              |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |        528 |        516 | Tighten  |
| finish__timing__hold__tns                     |    -4350.0 |    -1600.0 | Tighten  |
| finish__design__instance__area                |     408918 |     403433 | Tighten  |