### PR TITLE
update public metrics

### DIFF
--- a/flow/designs/ihp-sg13g2/ibex/rules-base.json
+++ b/flow/designs/ihp-sg13g2/ibex/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -5.01,
+        "value": -2.75,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1000843,
+        "value": 1000508,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -3.26,
+        "value": -6.45,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/nangate45/cva6/constraint.sdc
+++ b/flow/designs/nangate45/cva6/constraint.sdc
@@ -8,29 +8,4 @@ set input_delay 0.46
 set output_delay 0.11
 create_clock [get_ports $clk_port] -name $clk_name -period $clk_period
 
-# #set_dont_touch to keep sram as black boxes
-# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams[*].i_tag_sram
-# set_dont_touch i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks[*].i_data_sram
-# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].data_sram
-# set_dont_touch i_cache_subsystem/i_cva6_icache/gen_sram[*].tag_sram
-# #constraint the timing to and from the sram black boxes
-# set_input_delay -clock main_clk -max $input_delay \
-#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-# set_input_delay -clock main_clk -max $input_delay \
-#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-# set_input_delay -clock main_clk -max $input_delay \
-#   i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-# set_input_delay -clock main_clk -max $input_delay \
-#   i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/rdata_o[*]
-
-# set_output_delay $output_delay -max -clock main_clk \
-#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_tag_srams_*__i_tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-# set_output_delay $output_delay -max -clock main_clk \
-#   i_cache_subsystem/i_wt_dcache/i_wt_dcache_mem/gen_data_banks_*__i_data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-# set_output_delay $output_delay -max -clock main_clk \
-#   i_cache_subsystem/i_cva6_icache/gen_sram_*__data_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-# set_output_delay $output_delay -max -clock main_clk \
-#   i_cache_subsystem/i_cva6_icache/gen_sram_*__tag_sram/gen_cut_*__gen_mem_i_tc_sram_wrapper/addr_i[*]
-
-
 set_max_fanout 10 [current_design]

--- a/flow/designs/sky130hd/microwatt/rules-base.json
+++ b/flow/designs/sky130hd/microwatt/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "2bfce367a7b9e450c60e37954e2129f0b0d0018c",
+        "value": "ac96d25af26f4c444d6d33c37bcbe873ae3330f7",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "9ad86d2c1fc49d89f16f179403a07403d067c7b4",
+        "value": "ef0ae6eee3a802961bdd11bae631bb23692b1abe",
         "compare": "==",
         "level": "warning"
     },
@@ -54,7 +54,7 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 2711,
+        "value": 2520,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -256.0,
+        "value": -248.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -86,15 +86,15 @@
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 1290,
+        "value": 1333,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.14,
+        "value": -2.12,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -215.0,
+        "value": -209.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 5512180,
+        "value": 5511421,
         "compare": "<="
     }
 }


### PR DESCRIPTION
designs/ihp-sg13g2/ibex/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |      -5.01 |      -2.75 | Tighten  |
| detailedroute__route__wirelength              |    1000843 |    1000508 | Tighten  |
| finish__timing__setup__tns                    |      -3.26 |      -6.45 | Failing  |

designs/sky130hd/microwatt/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 2bfce367a7b9e450c60e37954e2129f0b0d0018c | ac96d25af26f4c444d6d33c37bcbe873ae3330f7 | Failing  |
| synth__netlist__hash                          | 9ad86d2c1fc49d89f16f179403a07403d067c7b4 | ef0ae6eee3a802961bdd11bae631bb23692b1abe | Failing  |
| globalroute__antenna_diodes_count             |       2711 |       2520 | Tighten  |
| globalroute__timing__setup__tns               |     -256.0 |     -248.0 | Tighten  |
| detailedroute__antenna_diodes_count           |       1290 |       1333 | Failing  |
| finish__timing__setup__ws                     |      -2.14 |      -2.12 | Tighten  |
| finish__timing__setup__tns                    |     -215.0 |     -209.0 | Tighten  |
| finish__design__instance__area                |    5512180 |    5511421 | Tighten  |