### PR TITLE
flow: collect the global placement HPWL metric

### DIFF
--- a/flow/util/genRuleFile.py
+++ b/flow/util/genRuleFile.py
@@ -102,6 +102,12 @@ def gen_rule_file(
             "compare": "==",
         },
         # place
+        "globalplace__route__wirelength__estimated": {
+            "mode": "padding",
+            "padding": 15,
+            "round_value": True,
+            "compare": "<=",
+        },
         "placeopt__design__instance__area": {
             "mode": "padding",
             "padding": 15,


### PR DESCRIPTION
Register `globalplace__route__wirelength__estimated` in `genRuleFile.py`, with the same padding and comparison as the neighbouring `placeopt__*` rules.

gpl already reports the metric ([#11201](https://github.com/The-OpenROAD-Project/OpenROAD/pull/11201), merged), and `genMetrics.py` already collects it, so this is the only change needed.


