### PR TITLE
Removed REMOVE_LIBS_FOR_LEC workaround

### DIFF
--- a/docs/user/FlowVariables.md
+++ b/docs/user/FlowVariables.md
@@ -250,7 +250,6 @@ configuration file.
 | <a name="RECOVER_POWER"></a>RECOVER_POWER| Specifies how many percent of paths with positive slacks can be slowed for power savings [0-100].| 0|
 | <a name="REMOVE_ABC_BUFFERS"></a>REMOVE_ABC_BUFFERS (deprecated)| Remove abc buffers from the netlist. If timing repair in floorplanning is taking too long, use a SETUP/HOLD_SLACK_MARGIN to terminate timing repair early instead of using REMOVE_ABC_BUFFERS or set SKIP_LAST_GASP=1.| 0|
 | <a name="REMOVE_CELLS_FOR_LEC"></a>REMOVE_CELLS_FOR_LEC| String patterns directly passed to write_verilog -remove_cells <> for lec checks.| |
-| <a name="REMOVE_LIBS_FOR_LEC"></a>REMOVE_LIBS_FOR_LEC| List of Liberty files to exclude from LEC. This is required for cases where a Verilog black box needs to be used instead of a Liberty file.| |
 | <a name="REPAIR_PDN_VIA_LAYER"></a>REPAIR_PDN_VIA_LAYER| Remove power grid vias which generate DRC violations after detailed routing.| |
 | <a name="REPORT_CLOCK_SKEW"></a>REPORT_CLOCK_SKEW| Report clock skew as part of reporting metrics, starting at CTS, before which there is no clock skew. This metric can be quite time-consuming, so it can be useful to disable.| 1|
 | <a name="ROUTING_LAYER_ADJUSTMENT"></a>ROUTING_LAYER_ADJUSTMENT| Adjusts routing layer capacities to manage congestion and improve detailed routing. High values ease detailed routing but risk excessive detours and long global routing times, while low values reduce global routing failure but can complicate detailed routing. The global routing running time normally reduces dramatically (entirely design specific, but going from hours to minutes has been observed) when the value is low (such as 0.10). Sometimes, global routing will succeed with lower values and fail with higher values. Exploring results with different values can help shed light on the problem. Start with a too low value, such as 0.10, and bisect to value that works by doing multiple global routing runs. As a last resort, `make global_route_issue` and using the tools/OpenROAD/etc/whittle.py can be useful to debug global routing errors. If there is something specific that is impossible to route, such as a clock line over a macro, global routing will terminate with DRC errors routes that could have been routed were it not for the specific impossible routes. whittle.py should weed out the possible routes and leave a minimal failing case that pinpoints the problem.| 0.5|
@@ -525,7 +524,6 @@ configuration file.
 - [MATCH_CELL_FOOTPRINT](#MATCH_CELL_FOOTPRINT)
 - [POST_CTS_TCL](#POST_CTS_TCL)
 - [PRE_CTS_TCL](#PRE_CTS_TCL)
-- [REMOVE_LIBS_FOR_LEC](#REMOVE_LIBS_FOR_LEC)
 - [REPORT_CLOCK_SKEW](#REPORT_CLOCK_SKEW)
 - [SETUP_MOVE_SEQUENCE](#SETUP_MOVE_SEQUENCE)
 - [SETUP_SLACK_MARGIN](#SETUP_SLACK_MARGIN)

--- a/flow/designs/gf12/bp_dual/config.mk
+++ b/flow/designs/gf12/bp_dual/config.mk
@@ -69,10 +69,3 @@ export MACRO_PLACE_HALO = 5 5
 
 export OPT_POST_GRT_WNS = 0
 
-# Have to use Verilog stubs for LEC for some of the RF's, since they have
-# a pin that has a condition that references multiple clocks. These two settings
-# use the Verilog stubs and remove the Liberty files from the kepler-formal
-# configuration file
-export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
-export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
-			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/bp_quad/config.mk
+++ b/flow/designs/gf12/bp_quad/config.mk
@@ -71,10 +71,3 @@ export MACRO_PLACE_HALO = 21 21
 
 export OPT_POST_GRT_WNS = 0
 
-# Have to use Verilog stubs for LEC for some of the RF's, since they have
-# a pin that has a condition that references multiple clocks. These two settings
-# use the Verilog stubs and remove the Liberty files from the kepler-formal
-# configuration file
-export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
-export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
-			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/bp_single/config.mk
+++ b/flow/designs/gf12/bp_single/config.mk
@@ -73,10 +73,3 @@ export SWAP_ARITH_OPERATORS = 1
 export OPENROAD_HIERARCHICAL = 1
 export OPT_POST_GRT_WNS = 0
 
-# Have to use Verilog stubs for LEC for some of the RF's, since they have
-# a pin that has a condition that references multiple clocks. These two settings
-# use the Verilog stubs and remove the Liberty files from the kepler-formal
-# configuration file
-export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_1r1w_d32_w64_m1.v
-export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
-			       $(OBJECTS_DIR)/gf12_1r1w_d32_w64_m1_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/designs/gf12/coyote/config.mk
+++ b/flow/designs/gf12/coyote/config.mk
@@ -40,13 +40,3 @@ endif
 export SWAP_ARITH_OPERATORS = 1
 export OPENROAD_HIERARCHICAL = 1
 
-# Have to use Verilog stubs for LEC for some of the RF's, since they have
-# a pin that has a condition that references multiple clocks. These two settings
-# use the Verilog stubs and remove the Liberty files from the kepler-formal
-# configuration file
-export LEC_AUX_VERILOG_FILES = $(PLATFORM_DIR)/verilog/gf12_2rf_lg6_w44_bit.v \
-			       $(PLATFORM_DIR)/verilog/gf12_2rf_lg8_w64_bit.v
-export REMOVE_LIBS_FOR_LEC   = $(PLATFORM_DIR)/lib/gf12_2rf_lg6_w44_bit_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
-	                       $(PLATFORM_DIR)/lib/gf12_2rf_lg8_w64_bit_ffpg_sigcmin_0p88v_0p88v_m40c.lib \
-			       $(OBJECTS_DIR)/gf12_2rf_lg6_w44_bit_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib \
-			       $(OBJECTS_DIR)/gf12_2rf_lg8_w64_bit_ffpg_sigcmin_0p88v_0p88v_m40c_mod.lib

--- a/flow/scripts/variables.json
+++ b/flow/scripts/variables.json
@@ -955,12 +955,6 @@
     "description": "String patterns directly passed to write_verilog -remove_cells <> for lec checks.\n",
     "type": "string"
   },
-  "REMOVE_LIBS_FOR_LEC": {
-    "description": "List of Liberty files to exclude from LEC. This is required for cases where a Verilog black box needs to be used instead of a Liberty file.\n",
-    "stages": [
-      "cts"
-    ]
-  },
   "REPAIR_PDN_VIA_LAYER": {
     "description": "Remove power grid vias which generate DRC violations after detailed routing.\n"
   },

--- a/flow/scripts/variables.yaml
+++ b/flow/scripts/variables.yaml
@@ -1621,12 +1621,6 @@ LEC_AUX_VERILOG_FILES:
     running the formal equivalence check.
   stages:
     - cts
-REMOVE_LIBS_FOR_LEC:
-  description: >
-    List of Liberty files to exclude from LEC. This is required for cases where
-    a Verilog black box needs to be used instead of a Liberty file.
-  stages:
-    - cts
 REMOVE_CELLS_FOR_LEC:
   description: >
     String patterns directly passed to write_verilog -remove_cells <> for


### PR DESCRIPTION
With the kepler-formal Liberty fixes, the REMOVE_LIBS_FOR_LEC override is no longer needed. Removed from gf12 configs.