### PR TITLE
Export scripts/variables.yaml as a source label

### DIFF
--- a/flow/BUILD
+++ b/flow/BUILD
@@ -24,7 +24,14 @@ exports_files(
 # instead of vendoring its own (drifting) copy at the bazel-orfs repo
 # root. See bazel-orfs `private/rules.bzl`.
 exports_files(
-    ["scripts/synth.tcl"],
+    [
+        "scripts/synth.tcl",
+        # Expose variables.yaml as an addressable source label so a
+        # downstream target can data-dep the variable catalogue at this
+        # commit. It is reachable today only inside the private makefile
+        # filegroups' data, not as a source target.
+        "scripts/variables.yaml",
+    ],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
`flow/BUILD`'s `exports_files` already publishes `scripts/synth.tcl` so bazel-orfs can point a rule attribute at `@orfs//flow:scripts/synth.tcl` rather than vendor a drifting copy.

`scripts/variables.yaml` — the variable catalogue carrying each variable's description and stage scoping — has the same need but no label: it is reachable only inside the private makefile filegroups' `data`, so a downstream Bazel target cannot `data`-dep the catalogue at a given commit.

This adds it to the same `exports_files`. Source-visibility only; no flow behaviour changes.
