### PR TITLE
synth: load the slang plugin when read_slang is not built in

### DIFF
--- a/flow/scripts/synth_preamble.tcl
+++ b/flow/scripts/synth_preamble.tcl
@@ -76,7 +76,14 @@ proc read_design_sources { } {
   }
 
   if { [env_var_equals SYNTH_HDL_FRONTEND slang] } {
-    # read_slang is built into Yosys (>=0.67); no plugin load needed.
+    # read_slang is built into Yosys >= 0.67, which vendors the frontend
+    # under frontends/slang. Older Yosys needs the same code loaded as an
+    # out-of-tree plugin; `plugin -i` finds it on YOSYS_PLUGIN_PATH. The
+    # guard makes this a no-op on a Yosys that has the frontend built in,
+    # so a build system is free to supply either one.
+    if { [info commands read_slang] eq "" } {
+      plugin -i slang
+    }
     set slang_args [list \
       -D SYNTHESIS --keep-hierarchy --compat=vcs --ignore-assertions --top $::env(DESIGN_NAME) \
       {*}$vIdirsArgs {*}[env_var_or_empty VERILOG_DEFINES]]


### PR DESCRIPTION
`b18e110c1` ("drop bundled yosys-slang, use Yosys 0.67 built-in read_slang") removed the explicit plugin load from `synth_preamble.tcl`, on the strength of Yosys 0.67 vendoring the slang frontend under `frontends/slang`. That is correct for 0.67+ — I confirmed `frontends/slang` is absent in v0.65/v0.66 and present in v0.67/v0.68.

It leaves Yosys 0.66 and older with no way to use `SYNTH_HDL_FRONTEND=slang`:

```
ERROR: No such command: read_slang (type 'help' for a command overview)
```

even when the same code is available as the out-of-tree plugin (`povik/sv-elab`, formerly `yosys-slang`) and is already on `YOSYS_PLUGIN_PATH` — because nothing loads it any more.

This is not hypothetical: the Bazel Central Registry `yosys` module is still on **0.64**. Yosys ships no Bazel files upstream, so that module is a hand-written overlay and nobody has carried it past 0.64. Every ORFS consumer building through BCR yosys is on 0.64 and cannot use the slang frontend today.

## The change

```tcl
if { [info commands read_slang] eq "" } {
  plugin -i slang
}
```

`plugin -i slang` resolves through `YOSYS_PLUGIN_PATH`. The guard makes it a strict no-op on a Yosys that has the frontend built in, so ORFS works against either without the caller having to declare which it has — and 0.67+ behaviour is unchanged.

## Testing

Exercised through bazel-orfs, whose `//slang:test` and `//slang:blackbox_synth` targets are regression coverage for exactly this path (slang frontend, and `SYNTH_BLACKBOXES` + `--empty-blackboxes` through it). Both had been failing since `b18e110c1`; both build green with this patch against BCR yosys 0.64.