### PR TITLE
Fix quarterly tag drift between fork and upstream

### DIFF
--- a/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
+++ b/.github/workflows/github-actions-cron-sync-fork-from-upstream.yml
@@ -41,4 +41,10 @@ jobs:
         # You can also manually trigger a workflow dispatch with the force
         # value equal to 'true'.
         force: ${{ github.event.inputs.force || (secrets.UPSTREAM_SYNC == 'always overwrite master branch') }}
+        # Quarterly release tags are only created upstream (see
+        # github-actions-quarterly-tag.yml); mirror the exact tag object
+        # here instead of letting this repo mint its own, which is what
+        # caused tag drift (same commit, two different annotated tag
+        # objects, breaking plain `git fetch` between the two remotes).
+        syncTags: true
         deployKey: ${{ secrets.DEPLOY_KEY }}

--- a/.github/workflows/github-actions-quarterly-tag.yml
+++ b/.github/workflows/github-actions-quarterly-tag.yml
@@ -14,6 +14,7 @@ jobs:
   create-tag:
     name: Create quarterly tag
     runs-on: ubuntu-latest
+    if: github.repository == 'The-OpenROAD-Project/OpenROAD-flow-scripts'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
The quarterly tag workflow ran on both the fork and upstream. Each side made its own annotated tag object for the same commit. The two tag objects did not match, so a plain `git fetch` between the fork and upstream failed on the tag.

Now the tag workflow runs only on the upstream repo. The fork sync workflow copies the exact tag object from upstream instead.