### PR TITLE
gui: patch ICU

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -79,6 +79,25 @@ git_override(
     remote = "https://github.com/The-OpenROAD-Project/qt_bazel_prebuilts",
 )
 
+# icu is transitive (qt-bazel -> icu). The BCR overlay patches
+# u_getDataDirectory() to locate icudt*.dat via
+# rules_cc::cc::runfiles::Runfiles::Rlocation(), but Runfiles::Create()
+# returns nullptr whenever no runfiles tree is reachable and the overlay
+# dereferences it unconditionally. A binary that a bazel/install.sh-style
+# step copies out of bazel-bin loses its .runfiles directory, so the first
+# locale-aware compare (QCollator, std::locale, ...) anywhere in the process
+# segfaults -- e.g. QFileDialog listing a directory, or a sortable Qt list/
+# table. Mirrors tools/OpenROAD's fixed-version override (single_version_
+# override is root-honored only); drop when tools/OpenROAD drops its copy.
+single_version_override(
+    module_name = "icu",
+    patch_strip = 1,
+    patches = [
+        "//patches/icu:0001-putil-null-check-bazel-runfiles-before-dereference.patch",
+    ],
+    version = "76.1.bcr.3",
+)
+
 # Exception to the dev-only rule above: flow/BUILD has
 # load("@bazel-orfs//:openroad.bzl", "orfs_pdk"), so @bazel-orfs must stay
 # visible from @orfs even at non-root consumption; a dev-only bazel_dep

--- a/patches/icu/0001-putil-null-check-bazel-runfiles-before-dereference.patch
+++ b/patches/icu/0001-putil-null-check-bazel-runfiles-before-dereference.patch
@@ -1,0 +1,24 @@
+--- a/icu4c/source/common/putil.cpp
++++ b/icu4c/source/common/putil.cpp
+@@ -1494,9 +1494,19 @@
+ #endif
+
+ #if defined(BAZEL_CURRENT_REPOSITORY) && defined(ICU_DATA_DIR_BAZEL)
++    // Runfiles::Create() returns nullptr when no runfiles tree is reachable,
++    // which is the case for a binary copied out of bazel-bin by an install
++    // step (its .runfiles directory is gone and $RUNFILES_DIR/
++    // $RUNFILES_MANIFEST_FILE are unset). The unconditional dereference below
++    // then segfaults the first time any locale-aware compare (QCollator,
++    // std::locale, ...) reaches this function. Fall through to the ""
++    // default instead.
+     std::unique_ptr<Runfiles> runfiles(Runfiles::Create("", BAZEL_CURRENT_REPOSITORY));
+-    std::string dat_path = runfiles->Rlocation(ICU_DATA_DIR_BAZEL);
+-    path = dat_path.c_str();
++    std::string dat_path = runfiles ? runfiles->Rlocation(ICU_DATA_DIR_BAZEL)
++                                     : std::string();
++    if (!dat_path.empty()) {
++        path = dat_path.c_str();
++    }
+ #endif
+
+     if(path==nullptr) {

--- a/patches/icu/BUILD.bazel
+++ b/patches/icu/BUILD.bazel
@@ -1,0 +1,7 @@
+"""icu fixes carried as single_version_override patches.
+
+Mirrored from tools/OpenROAD/bazel/icu-patches (overrides are
+root-honored only). Drop when tools/OpenROAD drops its copy.
+"""
+
+exports_files(glob(["*.patch"]))


### PR DESCRIPTION
## Summary

Fix done using Claude.
This PR implements the same fix as https://github.com/The-OpenROAD-Project-private/OpenROAD/pull/3700, but when compiling with ORFS.

`QFileDialog`'s built-in file listing (`QFileSystemModel`) sorts entries with a locale-aware compare, which constructs a `QCollator` and loads ICU locale data. The Bazel Central Registry's `icu` module patches `u_getDataDirectory()` to locate that data via `rules_cc::cc::runfiles::Runfiles::Rlocation()`, but `Runfiles::Create()` returns `nullptr` whenever no runfiles tree is reachable, and the overlay dereferences it unconditionally. A binary produced by `bazel/install.sh` has its `.runfiles` directory stripped after unpacking, so the very first locale-aware compare anywhere in the process — e.g. `QFileDialog::getOpenFileName` populating its file list — segfaults.

This is the same defect class fixed in #11203 for `HelpWidget::sortItems()`; that PR's own "Scope" section flagged the file-dialog path as still open: *"a file dialog's `QFileSystemModel`... would still reach the same unchecked pointer."*

Rather than patch each call site that happens to trigger a collated sort, this adds a `single_version_override` on the `icu` module (pulled in transitively via `qt-bazel`) that null-checks `Runfiles::Create()`'s result before calling `->Rlocation()` on it, falling through to ICU's existing `""` default instead of crashing. This closes the bug for every locale-aware sort in the GUI (file dialogs, sortable timing tables, etc.), not just `HelpWidget`.

Every `icu` version currently in the BCR carries the same unchecked dereference (`76.1.bcr.4`, `78.2.bcr.2`, ...), so bumping the version is not a workaround; only patching `putil.cpp` fixes it. The real fix belongs upstream in the BCR's `icu` module — this override should be dropped once that lands.

## Type of Change
- Bug fix

## Impact

No behavior change for anyone whose binary still has a reachable runfiles tree (e.g. running via `bazel run` / `bazel-bin` directly) — `Runfiles::Rlocation()` still resolves and `path` is still set exactly as before. For an *installed* binary (no runfiles tree), ICU's data directory now silently falls back to `""` instead of segfaulting; ICU already handles that case gracefully elsewhere in `dataDirectoryInitFn()`. Fixes the crash reported in #11217 (opening the "Open DB" file dialog) and the equivalent one in [OpenROAD-flow-scripts#4454](https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/issues/4454) (DRC Viewer's "Load" file chooser).

## Verification
- [x] I have verified that the local build succeeds (`./etc/Build.sh`).
- [x] I have run the relevant tests and they pass.
- [x] My code follows the repository's formatting guidelines.
- [ ] I have included tests to prevent regressions.
- [x] **I have signed my commits (DCO).**

Verified directly at the Bazel module level rather than a full `./etc/Build.sh` run:
- `bazelisk mod graph` resolves `icu@76.1.bcr.3` with the override applied.
- `bazelisk fetch` on the real `@icu` external repo, then inspected the materialized source on disk — the null-check is present after the BCR's own overlay patches are applied on top of it.
- `bazelisk build @@icu+//icu4c/source/common:platform` (the target compiling the patched `putil.cpp`) builds cleanly.
- Confirmed by counter-test: moving the same override into `qt_bazel_prebuilts`'s own `MODULE.bazel` (a non-root module here) causes Bazel to silently ignore it and refetch the unpatched, vulnerable source — confirming the override must live in whichever module is root (`openroad` here, and `orfs` for the ORFS-side build), not in `qt-bazel` itself.

No regression test added: this is a Bazel dependency-patch fix with no C++ code path in this repo to exercise, and there's no existing harness for asserting installed-binary runfiles-absent behavior (same reasoning as #11203).

## Related Issues
Fixes #4454 
Related: [OpenROAD#11217](https://github.com/The-OpenROAD-Project/OpenROAD/issues/11217)
