### PR TITLE
setup.sh: make submodule checks independent of working directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,13 +19,13 @@ tmpfile=$(mktemp)
 # any error messages from this command will stand out
 # more clearly when run as a separate command rather than
 # being piped
-git submodule status --recursive > "$tmpfile"
+git -C "$DIR" submodule status --recursive > "$tmpfile"
 
 if grep -q "^-" "$tmpfile"; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    git submodule update --init --recursive
+    git -C "$DIR" submodule update --init --recursive
   else
-    sudo -u $SUDO_USER git submodule update --init --recursive
+    sudo -u $SUDO_USER git -C "$DIR" submodule update --init --recursive
   fi
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,

--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ if grep -q "^-" "$tmpfile"; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
     git -C "$DIR" submodule update --init --recursive
   else
-    sudo -u $SUDO_USER git -C "$DIR" submodule update --init --recursive
+    sudo -u "${SUDO_USER:-root}" git -C "$DIR" submodule update --init --recursive
   fi
 elif grep -q "^+" "$tmpfile"; then
   # Make it easy for users who are not hacking ORFS to do the right thing,
@@ -51,5 +51,5 @@ fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
   "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 else
-  sudo -u $SUDO_USER "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
+  sudo -u "${SUDO_USER:-root}" "$DIR/etc/DependencyInstaller.sh" -common -prefix="$DIR/dependencies"
 fi


### PR DESCRIPTION
## What does this PR do?

`setup.sh` says it can be invoked from any working directory, but the initial `git submodule status` and `git submodule update` commands run against the caller's current directory rather than the ORFS checkout.

This can make setup fail when the script is launched from outside the repository.

This PR uses the already-resolved `DIR` path with `git -C` for both submodule operations, keeping the setup behavior independent of the caller's working directory.

## Validation

The change is intentionally limited to the submodule commands. I would appreciate CI/maintainer validation on the supported Linux and macOS setup paths, particularly when invoking `setup.sh` from a directory outside the ORFS checkout.

## Related behavior

The script already resolves its own location into `DIR` and uses that path for the dependency installer, so this keeps the submodule handling consistent with the rest of the script.