### PR TITLE
update metrics for private designs

### DIFF
--- a/flow/designs/gf12/ariane/rules-base.json
+++ b/flow/designs/gf12/ariane/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "7343906f7e9dcd5f60cafbafb23b983b059f4a9d",
+        "value": "77f1fdb64f18708bc3220e348db41e9cc4f527b5",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "dfaf98db80a73f2e5390da9cccf157018b028098",
+        "value": "69f0884c178a3ff96476f6d0cc96c626744d26c9",
         "compare": "==",
         "level": "warning"
     },
@@ -18,11 +18,11 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 211858,
+        "value": 208888,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 220675,
+        "value": 216134,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,19 +30,19 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 19189,
+        "value": 18794,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 19189,
+        "value": 18794,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -225.0,
+        "value": -222.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -112000.0,
+        "value": -9180.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -721.0,
+        "value": -2230.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,7 +90,7 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -208.0,
+        "value": -206.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 214224,
+        "value": 211208,
         "compare": "<="
     }
 }

--- a/flow/designs/gf12/ca53/rules-base.json
+++ b/flow/designs/gf12/ca53/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -883.0,
+        "value": -820.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -8300.0,
+        "value": -3310.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -392.0,
+        "value": -227.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1330.0,
+        "value": -768.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -102,7 +102,7 @@
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -2390.0,
+        "value": -3070.0,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
designs/gf12/ca53/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -883.0 |     -820.0 | Tighten  |
| cts__timing__setup__tns                       |    -8300.0 |    -3310.0 | Tighten  |
| globalroute__timing__setup__ws                |     -392.0 |     -227.0 | Tighten  |
| globalroute__timing__setup__tns               |    -1330.0 |     -768.0 | Tighten  |
| finish__timing__hold__tns                     |    -2390.0 |    -3070.0 | Failing  |

designs/gf12/ariane/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |     211858 |     208888 | Tighten  |
| placeopt__design__instance__count__stdcell    |     220675 |     216134 | Tighten  |
| cts__design__instance__count__setup_buffer    |      19189 |      18794 | Tighten  |
| cts__design__instance__count__hold_buffer     |      19189 |      18794 | Tighten  |
| cts__timing__setup__ws                        |     -225.0 |     -222.0 | Tighten  |
| cts__timing__setup__tns                       |  -112000.0 |    -9180.0 | Tighten  |
| globalroute__timing__setup__tns               |     -721.0 |    -2230.0 | Failing  |
| finish__timing__setup__ws                     |     -208.0 |     -206.0 | Tighten  |
| finish__design__instance__area                |     214224 |     211208 | Tighten  |