### PR TITLE
use the new function for setting extraction rules

### DIFF
--- a/flow/scripts/final_outputs.tcl
+++ b/flow/scripts/final_outputs.tcl
@@ -13,7 +13,8 @@ if {
 } {
   # RCX section
   define_process_corner -ext_model_index 0 X
-  extract_parasitics -ext_model_file $::env(RCX_RULES)
+  set_extraction_rules_file $::env(RCX_RULES)
+  extract_parasitics
 
   # Write Spef
   write_spef $::env(RESULTS_DIR)/6_final.spef


### PR DESCRIPTION
So that we don't have the warning popping anymore.

```
[WARNING RCX-0514] The ext_model_file option is deprecated. Use set_extraction_rules_file command instead.