### PR TITLE
ci: cap PR builds to tests under 3 hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 @Library('utils@main') _
 
 node {
-    pipelineORFS()
+    pipelineORFS(maxTimeout: 180)
 }


### PR DESCRIPTION
Set maxTimeout to 180 minutes in the Jenkinsfile. This drops any per-design test with a longer timeout from PR and trunk builds. Nightly builds still run every test, with no cap.

This change is scoped to this repo's own Jenkinsfile, not the shared pipelineORFS library in jenkins-ci. At 180 minutes, it only affects one design on the public pipeline (coralnpu, asap7). A shared-library default would have also capped 8 private gf12/rapidus2hp designs, one with a 29.5-hour test.