### PR TITLE
ci: add explicit permissions blocks to 11 workflows

### DIFF
--- a/.github/workflows/black.yaml
+++ b/.github/workflows/black.yaml
@@ -1,6 +1,10 @@
 name: Lint Python
 
 on: [push, pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-cron-test-installer.yml
+++ b/.github/workflows/github-actions-cron-test-installer.yml
@@ -21,6 +21,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   testInstaller:
     strategy:

--- a/.github/workflows/github-actions-cron-update-OR.yml
+++ b/.github/workflows/github-actions-cron-update-OR.yml
@@ -5,6 +5,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   update:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-cron-update-yosys.yml
+++ b/.github/workflows/github-actions-cron-update-yosys.yml
@@ -6,6 +6,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-cron-util-test.yml
+++ b/.github/workflows/github-actions-cron-util-test.yml
@@ -13,6 +13,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   testUtilScripts:
     strategy:

--- a/.github/workflows/github-actions-lint-tcl.yml
+++ b/.github/workflows/github-actions-lint-tcl.yml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+permissions:
+  contents: read
+
 jobs:
   Tclint:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-manual-update-rules.yml
+++ b/.github/workflows/github-actions-manual-update-rules.yml
@@ -7,6 +7,9 @@ on:
         required: true
         default: 'normal'
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-on-push.yml
+++ b/.github/workflows/github-actions-on-push.yml
@@ -6,6 +6,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scan:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-publish-docker-images.yml
+++ b/.github/workflows/github-actions-publish-docker-images.yml
@@ -25,6 +25,10 @@ on:
       - tools/codespace/scripts/**
       - tools/codespace/Dockerfile-lxqt
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   buildCodespaceImage:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-update-rules.yml
+++ b/.github/workflows/github-actions-update-rules.yml
@@ -4,6 +4,10 @@ on:
     types:
       - set-new-golden
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}

--- a/.github/workflows/github-actions-yaml-test.yml
+++ b/.github/workflows/github-actions-yaml-test.yml
@@ -3,6 +3,9 @@ name: ORFS variables.yaml tester and linter
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   docs-test-job:
     name: 'Tests for variables.yaml'


### PR DESCRIPTION
## Summary
- CodeQL's dry-run scan (#1818) found 13 `missing-workflow-permissions` findings: none of 11 workflows declares a `permissions:` block, so each runs with the repo/org default `GITHUB_TOKEN` scope, wider than any of them need.
- Add an explicit, minimally scoped `permissions:` block to each of the 11 workflows, matched to what its own steps do (checkout-only vs. pushing commits, opening PRs, publishing GHCR images). No workflow's runtime behavior changes.
- Split into two commits: read-only workflows (`contents: read` only) and write-capable workflows (scoped to their push/PR/publish needs).

## Test plan
- [x] `actionlint` passes on all 11 edited files (checked locally, clean apart from 2 pre-existing `set-output` deprecation warnings unrelated to this change).
- [x] Re-run CodeQL's dry-run workflow (from #1818) on this branch and confirm the 13 `missing-workflow-permissions` findings clear.
- [x] Confirm each workflow's own steps still succeed on its next real trigger (cron/dispatch/push), since none can be exercised end-to-end before merge.