### PR TITLE
fix: pin googleapis-common-protos to repair the dev image build

### DIFF
--- a/etc/DockerTag.sh
+++ b/etc/DockerTag.sh
@@ -8,6 +8,7 @@ if [[ "$@" == "-dev" ]]; then
         "./docker/Dockerfile.dev"
         "./Dockerfile"
         "./etc/DependencyInstaller.sh"
+        "./etc/requirements-common_lock.txt"
         "./tools/OpenROAD/etc/DependencyInstaller.sh"
     )
     cat "${file_list[@]}" | sha256sum | awk '{print substr($1, 1, 6)}'

--- a/etc/requirements-common_lock.txt
+++ b/etc/requirements-common_lock.txt
@@ -308,6 +308,15 @@ google-cloud-pubsub==2.39.1 \
     --hash=sha256:b40347cff2df3c4b33747bfdf8a8d74942754c5a6752592acd51a20fec316b56 \
     --hash=sha256:dacead1fa0aca7b2015f1acc88d279cd4b12852087908f426fbecf71985940e8
     # via -r etc/requirements-common.in
+# Hand-added: pip-compile emits only the [grpc] variant below, but
+# google-api-core also requires the plain package. pip resolves that as a
+# separate requirement, and without a pin here it fetches the newest release
+# from the index and then fails the --require-hashes check. Keep both entries
+# at the same version when regenerating this file.
+googleapis-common-protos==1.75.0 \
+    --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
+    --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
+    # via google-api-core
 googleapis-common-protos[grpc]==1.75.0 \
     --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
     --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed


### PR DESCRIPTION
The dev image build fails in `pip install` with "In --require-hashes mode, all
requirements must have their versions pinned with ==". `pip-compile` wrote only
the `googleapis-common-protos[grpc]` entry into
`etc/requirements-common_lock.txt`, but `google-api-core` needs the package
without the extra. pip counts that as a separate requirement and takes the
newest release from the index. That release has no hash in the lock, so the
check fails. The failure is not constant. It occurs only when the newest release
differs from the pinned version. This change adds the plain pin, with the same
two hashes as the `[grpc]` entry.

`etc/DockerTag.sh` did not hash the lock file into the dev image tag. A change
to the pinned pip dependencies thus kept the old tag. `dockerMakeImage` then
pulled the old image and skipped the build, so pip never ran against the new
lock. The fault became visible one day later, when an unrelated commit changed
the tag and forced a rebuild. This change adds the lock file to the tag inputs.