### PR TITLE
fix(deps): raise pip before the hashed lock install

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -9,6 +9,7 @@ WORKDIR /tmp/installer/etc
 
 COPY DependencyInstaller.sh .
 COPY requirements-common_lock.txt .
+COPY requirements-pip_lock.txt .
 
 COPY InstallerOpenROAD.sh \
        /tmp/installer/tools/OpenROAD/etc/DependencyInstaller.sh

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -14,10 +14,6 @@ cd "${_script_dir}/../"
 
 # package versions
 klayoutVersion=0.30.7
-# pip 23.3 is the first release that matches an extras-bearing pin such as
-# googleapis-common-protos[grpc]==X against a plain request for the same
-# package. Older pip fails --require-hashes on requirements-common_lock.txt.
-pipVersion=25.2
 if [[ "$OSTYPE" == "darwin"* ]]; then
     numThreads=$(sysctl -n hw.logicalcpu)
 else
@@ -43,26 +39,31 @@ _installPipCommon() {
         source /opt/rh/rh-python38/enable
         set -u
     fi
-    local lockfile
+    local lockfile piplock
     lockfile="${_script_dir}/requirements-common_lock.txt"
+    piplock="${_script_dir}/requirements-pip_lock.txt"
     if [[ "$OSTYPE" == "darwin"* ]]; then
         if [[ "$EUID" -eq 0 ]]; then
             echo "Error: Do NOT run with sudo."
             exit 1
         fi
         if [[ -n "${VIRTUAL_ENV:-}" ]]; then
-            pip3 install --no-cache-dir -r "$lockfile"
+            python3 -m pip install --no-cache-dir -r "$lockfile"
         else
             echo "Error: Activate a virtual environment on macOS."
             exit 1
         fi
     else
+        # pip before 23.3 fails --require-hashes on requirements-common_lock.txt:
+        # it does not match an extras-bearing pin such as
+        # googleapis-common-protos[grpc]==X against a plain request for the same
+        # package. Raise pip first, from its own hashed lock.
         if [[ $(id -u) == 0 ]]; then
-            pip3 install --no-cache-dir --upgrade "pip==${pipVersion}"
-            pip3 install --no-cache-dir -r "$lockfile"
+            python3 -m pip install --no-cache-dir --upgrade --require-hashes -r "$piplock"
+            python3 -m pip install --no-cache-dir -r "$lockfile"
         else
-            pip3 install --no-cache-dir --user --upgrade "pip==${pipVersion}"
-            pip3 install --no-cache-dir --user -r "$lockfile"
+            python3 -m pip install --no-cache-dir --user --upgrade --require-hashes -r "$piplock"
+            python3 -m pip install --no-cache-dir --user -r "$lockfile"
         fi
     fi
 }

--- a/etc/DependencyInstaller.sh
+++ b/etc/DependencyInstaller.sh
@@ -14,6 +14,10 @@ cd "${_script_dir}/../"
 
 # package versions
 klayoutVersion=0.30.7
+# pip 23.3 is the first release that matches an extras-bearing pin such as
+# googleapis-common-protos[grpc]==X against a plain request for the same
+# package. Older pip fails --require-hashes on requirements-common_lock.txt.
+pipVersion=25.2
 if [[ "$OSTYPE" == "darwin"* ]]; then
     numThreads=$(sysctl -n hw.logicalcpu)
 else
@@ -54,8 +58,10 @@ _installPipCommon() {
         fi
     else
         if [[ $(id -u) == 0 ]]; then
+            pip3 install --no-cache-dir --upgrade "pip==${pipVersion}"
             pip3 install --no-cache-dir -r "$lockfile"
         else
+            pip3 install --no-cache-dir --user --upgrade "pip==${pipVersion}"
             pip3 install --no-cache-dir --user -r "$lockfile"
         fi
     fi

--- a/etc/DockerTag.sh
+++ b/etc/DockerTag.sh
@@ -9,6 +9,7 @@ if [[ "$@" == "-dev" ]]; then
         "./Dockerfile"
         "./etc/DependencyInstaller.sh"
         "./etc/requirements-common_lock.txt"
+        "./etc/requirements-pip_lock.txt"
         "./tools/OpenROAD/etc/DependencyInstaller.sh"
     )
     cat "${file_list[@]}" | sha256sum | awk '{print substr($1, 1, 6)}'

--- a/etc/requirements-pip_lock.txt
+++ b/etc/requirements-pip_lock.txt
@@ -1,0 +1,9 @@
+#
+# pip bootstrap for etc/DependencyInstaller.sh. Kept out of
+# requirements-common_lock.txt because it must install with the old pip.
+# To update: pick a version, then take both hashes from
+# https://pypi.org/pypi/pip/<version>/json
+#
+pip==25.2 \
+    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
+    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717


### PR DESCRIPTION
pip before 23.3 does not match a pin with extras, such as `googleapis-common-protos[grpc]==X`, against a plain request for the same package. It then takes the plain package from the index and fails the `--require-hashes` check. Ubuntu 22.04 gives pip 22.0.2, so the dev image failed.

Pinning pip to 25.2 before the lock install lets `pip-compile` output install as generated, and removes the need for the hand-added pin in `requirements-common_lock.txt`.

Tested on `ubuntu:22.04` against a lock with the hand-added pin removed: root and non-root `--user` paths both install cleanly, and `pubsub`, `pandas`, `numpy`, `yamlfix` import.

This is a follow-up on https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts/pull/4498
  