### PR TITLE
update private metrics

### DIFF
--- a/flow/designs/gf12/ariane/rules-base.json
+++ b/flow/designs/gf12/ariane/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -222.0,
+        "value": -213.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -9180.0,
+        "value": -50800.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -211.0,
+        "value": -210.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -2230.0,
+        "value": -719.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -714.0,
+        "value": -711.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/bp_single/rules-base.json
+++ b/flow/designs/gf12/bp_single/rules-base.json
@@ -22,7 +22,7 @@
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
-        "value": 523318,
+        "value": 523297,
         "compare": "<="
     },
     "detailedplace__design__violations": {
@@ -30,11 +30,11 @@
         "compare": "=="
     },
     "cts__design__instance__count__setup_buffer": {
-        "value": 45506,
+        "value": 45504,
         "compare": "<="
     },
     "cts__design__instance__count__hold_buffer": {
-        "value": 45506,
+        "value": 45504,
         "compare": "<="
     },
     "cts__timing__setup__ws": {
@@ -46,7 +46,7 @@
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -197.0,
+        "value": -468.0,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
@@ -66,7 +66,7 @@
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -174.0,
+        "value": -459.0,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 5525536,
+        "value": 5475411,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,15 +90,15 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -207.0,
+        "value": -187.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1130.0,
+        "value": -877.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -114.0,
+        "value": -242.0,
         "compare": ">="
     },
     "finish__timing__hold__tns": {


### PR DESCRIPTION
designs/gf12/ariane/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |     -222.0 |     -213.0 | Tighten  |
| cts__timing__setup__tns                       |    -9180.0 |   -50800.0 | Failing  |
| globalroute__timing__setup__ws                |     -211.0 |     -210.0 | Tighten  |
| globalroute__timing__setup__tns               |    -2230.0 |     -719.0 | Tighten  |
| finish__timing__setup__tns                    |     -714.0 |     -711.0 | Tighten  |

designs/gf12/bp_single/rules-base.json updates:
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__count__stdcell    |     523318 |     523297 | Tighten  |
| cts__design__instance__count__setup_buffer    |      45506 |      45504 | Tighten  |
| cts__design__instance__count__hold_buffer     |      45506 |      45504 | Tighten  |
| cts__timing__hold__ws                         |     -197.0 |     -468.0 | Failing  |
| globalroute__timing__hold__ws                 |     -174.0 |     -459.0 | Failing  |
| detailedroute__route__wirelength              |    5525536 |    5475411 | Tighten  |
| finish__timing__setup__ws                     |     -207.0 |     -187.0 | Tighten  |
| finish__timing__setup__tns                    |    -1130.0 |     -877.0 | Tighten  |
| finish__timing__hold__ws                      |     -114.0 |     -242.0 | Failing  |
