### PR TITLE
Update urllib3 to 2.7.0 due to CVE-2026-44431 and CVE-2026-44432

### DIFF
--- a/tools/AutoTuner/requirements.txt
+++ b/tools/AutoTuner/requirements.txt
@@ -8,6 +8,6 @@ colorama==0.4.6
 tensorboard>=2.17.0
 protobuf>=5.26.1
 SQLAlchemy==1.4.17
-urllib3>=1.26.17
+urllib3>=2.7.0
 matplotlib==3.10.0
 pyyaml==6.0.1


### PR DESCRIPTION
Replaces #4260. A 2.6.0 floor still permits CVE-2026-44432, which was introduced in 2.6.0. Version 2.7.0 is the first release that corrects both CVE-2026-44431 and CVE-2026-44432.