### PR TITLE
fix(deps): drop the hand-added googleapis-protos pin

### DIFF
--- a/etc/requirements-common_lock.txt
+++ b/etc/requirements-common_lock.txt
@@ -308,15 +308,6 @@ google-cloud-pubsub==2.39.1 \
     --hash=sha256:b40347cff2df3c4b33747bfdf8a8d74942754c5a6752592acd51a20fec316b56 \
     --hash=sha256:dacead1fa0aca7b2015f1acc88d279cd4b12852087908f426fbecf71985940e8
     # via -r etc/requirements-common.in
-# Hand-added: pip-compile emits only the [grpc] variant below, but
-# google-api-core also requires the plain package. pip resolves that as a
-# separate requirement, and without a pin here it fetches the newest release
-# from the index and then fails the --require-hashes check. Keep both entries
-# at the same version when regenerating this file.
-googleapis-common-protos==1.75.0 \
-    --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
-    --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
-    # via google-api-core
 googleapis-common-protos[grpc]==1.75.0 \
     --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
     --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed


### PR DESCRIPTION
pip 25.2 matches googleapis-common-protos[grpc]==1.75.0 against the plain request from google-api-core, so the extra pin is not necessary. This reverts the hand edit from #4498 and restores the pip-compile output.

Tested on ubuntu:22.04. The root and the non-root --user path both install googleapis-common-protos-1.75.0, not the newest release.