### PR TITLE
Reduced asap7 cva6 clock period

### DIFF
--- a/flow/designs/asap7/cva6/constraint.sdc
+++ b/flow/designs/asap7/cva6/constraint.sdc
@@ -3,7 +3,7 @@
 set clk_name main_clk
 set clk_port clk_i
 set clk_ports_list [list $clk_port]
-set clk_period 1000
+set clk_period 850
 set input_delay 0.46
 set output_delay 0.11
 create_clock [get_ports $clk_port] -name $clk_name -period $clk_period

--- a/flow/designs/asap7/cva6/rules-base.json
+++ b/flow/designs/asap7/cva6/rules-base.json
@@ -1,16 +1,16 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "8546daa9fab20173e2a1873f0268f52214d41e78",
+        "value": "b5569a76b853effb01c401361d6f003c183d955a",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "1f542e5a81cd52225b1d7480385ff67bb3c00b40",
+        "value": "355d32a1b861216172287b13fcd958bfae501043",
         "compare": "==",
         "level": "warning"
     },
     "synth__design__instance__area__stdcell": {
-        "value": 14100.0,
+        "value": 14000.0,
         "compare": "<="
     },
     "constraints__clocks__count": {
@@ -38,19 +38,19 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -50.0,
+        "value": -58.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -200.0,
+        "value": -3990.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -50.0,
+        "value": -42.5,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -200.0,
+        "value": -170.0,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -58,19 +58,19 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -50.0,
+        "value": -110.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -200.0,
+        "value": -9920.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
-        "value": -50.0,
+        "value": -42.5,
         "compare": ">="
     },
     "globalroute__timing__hold__tns": {
-        "value": -200.0,
+        "value": -170.0,
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
@@ -90,19 +90,19 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -50.0,
+        "value": -101.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -200.0,
+        "value": -7140.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -50.0,
+        "value": -42.5,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -200.0,
+        "value": -170.0,
         "compare": ">="
     },
     "finish__design__instance__area": {


### PR DESCRIPTION
finish setup WNS now negative (reduced clock period from 1000 to 850)

| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| synth__canonical_netlist__hash                | 8546daa9fab20173e2a1873f0268f52214d41e78 | b5569a76b853effb01c401361d6f003c183d955a | Failing  |
| synth__netlist__hash                          | 1f542e5a81cd52225b1d7480385ff67bb3c00b40 | 355d32a1b861216172287b13fcd958bfae501043 | Failing  |
| synth__design__instance__area__stdcell        |    14100.0 |    14000.0 | Tighten  |
| cts__timing__setup__tns                       |     -200.0 |    -2940.0 | Failing  |
| cts__timing__hold__ws                         |      -50.0 |      -42.5 | Tighten  |
| cts__timing__hold__tns                        |     -200.0 |     -170.0 | Tighten  |
| globalroute__timing__setup__ws                |      -50.0 |     -110.0 | Failing  |
| globalroute__timing__setup__tns               |     -200.0 |    -9920.0 | Failing  |
| globalroute__timing__hold__ws                 |      -50.0 |      -42.5 | Tighten  |
| globalroute__timing__hold__tns                |     -200.0 |     -170.0 | Tighten  |
| finish__timing__setup__ws                     |      -50.0 |     -101.0 | Failing  |
| finish__timing__setup__tns                    |     -200.0 |    -7140.0 | Failing  |
| finish__timing__hold__ws                      |      -50.0 |      -42.5 | Tighten  |
| finish__timing__hold__tns                     |     -200.0 |     -170.0 | Tighten  |
