### PR TITLE
designs: mempool_group/rtl BUILD uses files() so its sources export individually

### DIFF
--- a/flow/designs/src/mempool_group/rtl/BUILD
+++ b/flow/designs/src/mempool_group/rtl/BUILD
@@ -1,11 +1,18 @@
-filegroup(
-    name = "include",
-    srcs = glob(["*.v", "*.sv", "*.svh"], allow_empty = True) + [
+load("//flow/designs:design.bzl", "files")
+
+# files() rather than a bare filegroup: the globbed sources are then also
+# exported as individual labels, which the config.mk parser in bazel-orfs
+# needs -- nangate45/mempool_group's VERILOG_FILES names files in this
+# directory one by one, and a bare filegroup makes them private to it.
+# The extra sources are the headers from sibling packages that the
+# include group has always carried.
+files(
+    "include",
+    extra_srcs = [
         "//flow/designs/src/mempool_group/rtl/axi:assign.svh",
         "//flow/designs/src/mempool_group/rtl/axi:typedef.svh",
         "//flow/designs/src/mempool_group/rtl/common_cells:assertions.svh",
         "//flow/designs/src/mempool_group/rtl/common_cells:registers.svh",
         "//flow/designs/src/mempool_group/rtl/mempool:mempool.svh",
     ],
-    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
`nangate45/mempool_group`'s `VERILOG_FILES` names the files under `src/mempool_group/rtl` one by one. bazel-orfs's config.mk parser turns each into a per-file label, and a bare `filegroup` over a glob makes those files private to the package, so the design fails analysis under bazel with a visibility error on every one of them:

```
target '//flow/designs/src/mempool_group/rtl:mempool_pkg.sv' is not visible from
target '//flow/designs/nangate45/mempool_group:mempool_group_synth'
```

`files("include", extra_srcs = ...)` is the same filegroup, the same glob plus the same five sibling-package headers, and also exports each source as its own label. No change to what the `include` group contains. Every other `src/` package already uses `files()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)