### PR TITLE
ci: test setup.sh local installation path

### DIFF
--- a/.github/workflows/github-actions-cron-test-installer.yml
+++ b/.github/workflows/github-actions-cron-test-installer.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'etc/DependencyInstaller.sh'
       - 'etc/DockerHelper.sh'
+      - 'setup.sh'
       - '.github/workflows/github-actions-cron-test-installer.yml'
       - 'build_openroad.sh'
       - 'env.sh'
@@ -14,6 +15,7 @@ on:
     paths:
       - 'etc/DependencyInstaller.sh'
       - 'etc/DockerHelper.sh'
+      - 'setup.sh'
       - '.github/workflows/github-actions-cron-test-installer.yml'
       - 'build_openroad.sh'
       - 'env.sh'
@@ -53,3 +55,22 @@ jobs:
         run: |
           cmd="source ./env.sh ; yosys -help ; openroad -help ; make -C flow ;"
           docker run openroad/flow-${{ matrix.os }}-builder /bin/bash -c "${cmd}"
+
+  testSetup:
+    name: Test setup.sh local installation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 1
+          submodules: recursive
+      - name: Run setup.sh
+        run: sudo ./setup.sh
+      - name: Build OpenROAD locally
+        run: ./build_openroad.sh --local
+      - name: Verify local installation
+        run: |
+          source ./env.sh
+          yosys -help
+          openroad -help


### PR DESCRIPTION
## What does this PR do?

Adds CI coverage for the host-local installation path through `setup.sh`.

The existing installer workflow exercises `DependencyInstaller.sh` through Docker, but it does not execute the user-facing `setup.sh` path directly. This can allow regressions in setup-specific behavior to go unnoticed.

This PR adds an Ubuntu 22.04 job that:
- checks out ORFS with submodules
- runs `sudo ./setup.sh`
- builds OpenROAD with `./build_openroad.sh --local`
- sources `env.sh` and verifies the resulting `yosys` and `openroad` installations

It also makes changes to the workflow itself trigger the installer workflow and explicitly includes `setup.sh` in the path filters.

This addresses the intent of upstream issue #4453 without changing the production flow or installer implementation.