### PR TITLE
update failing metrics

### DIFF
--- a/flow/designs/asap7/aes-block/rules-base.json
+++ b/flow/designs/asap7/aes-block/rules-base.json
@@ -1,6 +1,6 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "583be2e7c135e29c3f1278b5b89263ff2a1f0891",
+        "value": "ebaa691cab308fe6bb4b8b1d587926ac20ea4f68",
         "compare": "==",
         "level": "warning"
     },
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1890.0,
+        "value": -3080.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -206.0,
+        "value": -331.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -418.0,
+        "value": -694.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/asap7/aes/rules-base.json
+++ b/flow/designs/asap7/aes/rules-base.json
@@ -62,7 +62,7 @@
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -339.0,
+        "value": -467.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 57763,
+        "value": 57175,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -94,7 +94,7 @@
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -87.7,
+        "value": -191.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/gf12/ariane/rules-base.json
+++ b/flow/designs/gf12/ariane/rules-base.json
@@ -42,7 +42,7 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -50800.0,
+        "value": -236000.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {

--- a/flow/designs/gf12/tinyRocket/rules-base.json
+++ b/flow/designs/gf12/tinyRocket/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "f7457cffb9b503f94149db1125f2dbc6327bbdbd",
+        "value": "17c595f38b1323a017b98f896031666c88db25f7",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "9891ca2e5eee886e3ab0c24c2a3e7817e8826b1c",
+        "value": "fe809a7c44fbc967701c1faa1fd11ca9ecd2a361",
         "compare": "==",
         "level": "warning"
     },
@@ -18,7 +18,7 @@
         "compare": "=="
     },
     "placeopt__design__instance__area": {
-        "value": 14746,
+        "value": 14729,
         "compare": "<="
     },
     "placeopt__design__instance__count__stdcell": {
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -150.0,
+        "value": -149.0,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -64400.0,
+        "value": -83300.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -163.0,
+        "value": -150.0,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -72800.0,
+        "value": -74900.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -134.0,
+        "value": -126.0,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -42800.0,
+        "value": -40300.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 15322,
+        "value": 15300,
         "compare": "<="
     }
 }

--- a/flow/designs/gf180/aes-hybrid/rules-base.json
+++ b/flow/designs/gf180/aes-hybrid/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -1.12,
+        "value": -1.02,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -132.0,
+        "value": -170.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -1.1,
+        "value": -1.06,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -144.0,
+        "value": -186.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -74,7 +74,7 @@
         "compare": ">="
     },
     "detailedroute__route__wirelength": {
-        "value": 1477431,
+        "value": 1436375,
         "compare": "<="
     },
     "detailedroute__route__drc_errors": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.1,
+        "value": -1.06,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -144.0,
+        "value": -176.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
@@ -106,7 +106,7 @@
         "compare": ">="
     },
     "finish__design__instance__area": {
-        "value": 720794,
+        "value": 716226,
         "compare": "<="
     }
 }

--- a/flow/designs/gf180/ibex/rules-base.json
+++ b/flow/designs/gf180/ibex/rules-base.json
@@ -1,11 +1,11 @@
 {
     "synth__canonical_netlist__hash": {
-        "value": "155b07a6f0eab98942fd61d43ae3c03367efccf4",
+        "value": "8a0bf3f54eefa1056787ab96dbbf7ed3e981399a",
         "compare": "==",
         "level": "warning"
     },
     "synth__netlist__hash": {
-        "value": "d8285312f036a992dbe6e0c0616a375cf7853e4d",
+        "value": "8189996a5444e85e4f8c27d736f4b4450f86ee1e",
         "compare": "==",
         "level": "warning"
     },
@@ -42,15 +42,15 @@
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -1450.0,
+        "value": -1280.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
-        "value": -1.3,
+        "value": -1.29,
         "compare": ">="
     },
     "cts__timing__hold__tns": {
-        "value": -2.5,
+        "value": -2.49,
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -1.99,
+        "value": -1.92,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -1480.0,
+        "value": -1790.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,19 +90,19 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -1.97,
+        "value": -1.89,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -1450.0,
+        "value": -1460.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {
-        "value": -1.27,
+        "value": -1.26,
         "compare": ">="
     },
     "finish__timing__hold__tns": {
-        "value": -2.47,
+        "value": -2.46,
         "compare": ">="
     },
     "finish__design__instance__area": {

--- a/flow/designs/nangate45/aes/rules-base.json
+++ b/flow/designs/nangate45/aes/rules-base.json
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.0692,
+        "value": -0.0659,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -0.785,
+        "value": -0.963,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {

--- a/flow/designs/sky130hd/chameleon/rules-base.json
+++ b/flow/designs/sky130hd/chameleon/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -2.96,
+        "value": -3.38,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -172.0,
+        "value": -276.0,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -54,15 +54,15 @@
         "compare": ">="
     },
     "globalroute__antenna_diodes_count": {
-        "value": 181,
+        "value": 196,
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -2.82,
+        "value": -3.21,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -151.0,
+        "value": -180.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -82,19 +82,19 @@
         "compare": "<="
     },
     "detailedroute__antenna__violating__nets": {
-        "value": 1,
+        "value": 0,
         "compare": "<="
     },
     "detailedroute__antenna_diodes_count": {
-        "value": 162,
+        "value": 150,
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -2.41,
+        "value": -2.88,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -146.0,
+        "value": -165.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {

--- a/flow/designs/sky130hs/ibex/rules-base.json
+++ b/flow/designs/sky130hs/ibex/rules-base.json
@@ -38,11 +38,11 @@
         "compare": "<="
     },
     "cts__timing__setup__ws": {
-        "value": -0.35,
+        "value": -0.825,
         "compare": ">="
     },
     "cts__timing__setup__tns": {
-        "value": -57.7,
+        "value": -98.8,
         "compare": ">="
     },
     "cts__timing__hold__ws": {
@@ -58,11 +58,11 @@
         "compare": "<="
     },
     "globalroute__timing__setup__ws": {
-        "value": -0.89,
+        "value": -1.48,
         "compare": ">="
     },
     "globalroute__timing__setup__tns": {
-        "value": -604.0,
+        "value": -994.0,
         "compare": ">="
     },
     "globalroute__timing__hold__ws": {
@@ -90,11 +90,11 @@
         "compare": "<="
     },
     "finish__timing__setup__ws": {
-        "value": -0.861,
+        "value": -1.28,
         "compare": ">="
     },
     "finish__timing__setup__tns": {
-        "value": -291.0,
+        "value": -761.0,
         "compare": ">="
     },
     "finish__timing__hold__ws": {


### PR DESCRIPTION
### asap7/aes
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__tns               |     -339.0 |     -467.0 | Failing  |
| detailedroute__route__wirelength              |      57763 |      57175 | Tighten  |
| finish__timing__setup__tns                    |      -87.7 |     -191.0 | Failing  |

### asap7/aes-block
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |    -1890.0 |    -3080.0 | Failing  |
| globalroute__timing__setup__tns               |     -206.0 |     -331.0 | Failing  |
| finish__timing__setup__tns                    |     -418.0 |     -694.0 | Failing  |

### gf180/aes-hybrid
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -1.12 |      -1.02 | Tighten  |
| cts__timing__setup__tns                       |     -132.0 |     -170.0 | Failing  |
| globalroute__timing__setup__ws                |       -1.1 |      -1.06 | Tighten  |
| globalroute__timing__setup__tns               |     -144.0 |     -186.0 | Failing  |
| detailedroute__route__wirelength              |    1477431 |    1436375 | Tighten  |
| finish__timing__setup__ws                     |       -1.1 |      -1.06 | Tighten  |
| finish__timing__setup__tns                    |     -144.0 |     -176.0 | Failing  |
| finish__design__instance__area                |     720794 |     716226 | Tighten  |

### gf180/ibex
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |    -1450.0 |    -1280.0 | Tighten  |
| cts__timing__hold__ws                         |       -1.3 |      -1.29 | Tighten  |
| cts__timing__hold__tns                        |       -2.5 |      -2.49 | Tighten  |
| globalroute__timing__setup__ws                |      -1.99 |      -1.92 | Tighten  |
| globalroute__timing__setup__tns               |    -1480.0 |    -1790.0 | Failing  |
| finish__timing__setup__ws                     |      -1.97 |      -1.89 | Tighten  |
| finish__timing__setup__tns                    |    -1450.0 |    -1460.0 | Failing  |
| finish__timing__hold__ws                      |      -1.27 |      -1.26 | Tighten  |
| finish__timing__hold__tns                     |      -2.47 |      -2.46 | Tighten  |

### nangate45/aes
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| globalroute__timing__setup__ws                |    -0.0692 |    -0.0659 | Tighten  |
| globalroute__timing__setup__tns               |     -0.785 |     -0.963 | Failing  |

### sky130hs/ibex
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -0.35 |     -0.825 | Failing  |
| cts__timing__setup__tns                       |      -57.7 |      -98.8 | Failing  |
| globalroute__timing__setup__ws                |      -0.89 |      -1.48 | Failing  |
| globalroute__timing__setup__tns               |     -604.0 |     -994.0 | Failing  |
| finish__timing__setup__ws                     |     -0.861 |      -1.28 | Failing  |
| finish__timing__setup__tns                    |     -291.0 |     -761.0 | Failing  |

### gf12/ariane
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__tns                       |   -50800.0 |  -236000.0 | Failing  |

### gf12/tinyRocket
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| placeopt__design__instance__area              |      14746 |      14729 | Tighten  |
| cts__timing__setup__ws                        |     -150.0 |     -149.0 | Tighten  |
| cts__timing__setup__tns                       |   -64400.0 |   -83300.0 | Failing  |
| globalroute__timing__setup__ws                |     -163.0 |     -150.0 | Tighten  |
| globalroute__timing__setup__tns               |   -72800.0 |   -74900.0 | Failing  |
| finish__timing__setup__ws                     |     -134.0 |     -126.0 | Tighten  |
| finish__timing__setup__tns                    |   -42800.0 |   -40300.0 | Tighten  |
| finish__design__instance__area                |      15322 |      15300 | Tighten  |

### sky130hd/chameleon
| Metric                                        | Old        | New        | Type     |
| ------                                        | ---        | ---        | ----     |
| cts__timing__setup__ws                        |      -2.96 |      -3.38 | Failing  |
| cts__timing__setup__tns                       |     -172.0 |     -276.0 | Failing  |
| globalroute__antenna_diodes_count             |        181 |        196 | Failing  |
| globalroute__timing__setup__ws                |      -2.82 |      -3.21 | Failing  |
| globalroute__timing__setup__tns               |     -151.0 |     -180.0 | Failing  |
| detailedroute__antenna__violating__nets       |          1 |          0 | Tighten  |
| detailedroute__antenna_diodes_count           |        162 |        150 | Tighten  |
| finish__timing__setup__ws                     |      -2.41 |      -2.88 | Failing  |
| finish__timing__setup__tns                    |     -146.0 |     -165.0 | Failing  |